### PR TITLE
fix: updated process repo name for import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import re
 from setuptools import setup, find_packages
 
 
-VERSION = '0.0.9'
+VERSION = '0.0.10'
 
 
 with open("README.md", "r") as readme:

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ setup(
         "pytest>=6.2.5",
         "pymongo",
         "orjson",
-        "biosimulator-processes",
         "matplotlib"
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         "pytest>=6.2.5",
         "pymongo",
         "orjson",
-        "core-processes",
+        "biosimulator-processes",
         "matplotlib"
     ]
 )


### PR DESCRIPTION
_What does this PR do?_: 
- Updates core processes dependency name for installation in `setup.py` to reflect `biosimulator-processes` rather than `core-processes`.

This is an unblocking update as `core-processes` was one of the primary dependencies of `process-bigraph`. The issue here is that `core-processes` no longer exists.