### PR TITLE
fix initial_edge_state to reflect the change to inputs/outputs ports

### DIFF
--- a/process_bigraph/tests.py
+++ b/process_bigraph/tests.py
@@ -27,6 +27,12 @@ class IncreaseProcess(Process):
                 'level': 'float'}}
 
 
+    def initial_state(self):
+        return {
+            'inputs': {
+                'level': 11.0}}
+
+
     def update(self, state, interval):
         return {
             'level': state['level'] * self.config['rate']}

--- a/process_bigraph/type_system.py
+++ b/process_bigraph/type_system.py
@@ -286,13 +286,16 @@ class ProcessTypes(TypeSystem):
 
     def initialize_edge_state(self, schema, path, edge):
         initial_state = edge['instance'].initial_state()
-        ports = get_path(schema, path + ('_ports',))
+        input_ports = get_path(schema, path + ('_inputs',))
+        output_ports = get_path(schema, path + ('_outputs',))
+        ports = {'inputs': input_ports, 'outputs': output_ports}
 
-        return self.project_edge(
+        projected_state = self.project_edge(
             ports,
             edge,
             path[:-1],
             initial_state)
+        return projected_state
 
     def dehydrate(self, schema):
         return {}

--- a/process_bigraph/type_system.py
+++ b/process_bigraph/type_system.py
@@ -4,7 +4,7 @@ Process Types
 =============
 """
 
-from bigraph_schema import Edge, TypeSystem, get_path, establish_path, set_path
+from bigraph_schema import Edge, TypeSystem, get_path, establish_path, set_path, deep_merge
 from process_bigraph.registry import protocol_registry
 
 
@@ -290,12 +290,24 @@ class ProcessTypes(TypeSystem):
         output_ports = get_path(schema, path + ('_outputs',))
         ports = {'inputs': input_ports, 'outputs': output_ports}
 
-        projected_state = self.project_edge(
+        input_state = self.project_edge(
             ports,
             edge,
             path[:-1],
-            initial_state)
-        return projected_state
+            initial_state,
+            ports_key='input')
+
+        output_state = self.project_edge(
+            ports,
+            edge,
+            path[:-1],
+            initial_state,
+            ports_key='output')
+
+        state = deep_merge(input_state, output_state)
+
+        return state
+
 
     def dehydrate(self, schema):
         return {}


### PR DESCRIPTION
We need the initial state to project according to the new schema with inputs/outputs instead of bidirectional wires.