### PR TITLE
Added experiments module to setup.py 'packages'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/
 .DS_Store
 .empty
 build/
+.venv/
 
 process_bigraph.egg-info/
 out/

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     packages=[
         'process_bigraph',
         'process_bigraph.processes',
+        'process_bigraph.experiments'
     ],
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
Ran into a quick issue. When installing spatio-flux onto my computer, I found that the process-bigraph dependency was throwing errors because the process_bigraph.experiments module wasn't found. This is because it isn't added to the 'packages' list in process-bigraph's setup.py. Assuming this module should be included in the package (it currently errors without it), I figured adding it and sending a pull request would be easy enough. If this module shouldn't be included, its imports would need to be removed from other files