### PR TITLE
core is a singleton

### DIFF
--- a/process_bigraph/__init__.py
+++ b/process_bigraph/__init__.py
@@ -3,8 +3,10 @@ from bigraph_schema.registry import deep_merge, default
 from process_bigraph.processes import register_processes
 from process_bigraph.composite import Process, Step, Composite, ProcessTypes, interval_time_precision
 
-
 pretty = pprint.PrettyPrinter(indent=2)
+
+# make the singleton instance of the ProcessTypes class
+core = ProcessTypes()
 
 
 def pp(x):

--- a/process_bigraph/composite.py
+++ b/process_bigraph/composite.py
@@ -251,18 +251,27 @@ class ProcessTypes(TypeSystem):
     It maintains a registry of process types and provides methods to register
     new process types, protocols, and emitters.
     """
+    _instance = None  # Class-level private variable for the singleton instance
+
+    def __new__(cls, *args, **kwargs):
+        if cls._instance is None:
+            cls._instance = super(ProcessTypes, cls).__new__(cls)
+            # Initialize the instance
+            cls._instance._is_initialized = False
+        return cls._instance
 
     def __init__(self):
-        super().__init__()
-        self.process_registry = Registry()
-        self.protocol_registry = Registry()
+        if not self._is_initialized:  # Prevent re-initialization
+            super().__init__()
+            self.process_registry = Registry()
+            self.protocol_registry = Registry()
 
-        self.register_types(PROCESS_TYPES)
-        self.register_protocols(BASE_PROTOCOLS)
-        self.register_processes(BASE_EMITTERS)
+            self.register_types(PROCESS_TYPES)
+            self.register_protocols(BASE_PROTOCOLS)
+            self.register_processes(BASE_EMITTERS)
 
-        self.register_process('composite', Composite)
-
+            self.register_process('composite', Composite)
+            self._is_initialized = True
 
     def register_protocols(self, protocols):
         """Register protocols with the core"""

--- a/process_bigraph/tests.py
+++ b/process_bigraph/tests.py
@@ -731,6 +731,13 @@ def test_stochastic_deterministic_composite(core):
     pass
 
 
+def test_singleton_core():
+    from process_bigraph import core
+    from process_bigraph import ProcessTypes
+    core2 = ProcessTypes()  # This should point to the singleton instance
+    assert core is core2, "ProcessTypes is not behaving like a singleton."
+
+
 if __name__ == '__main__':
     core = ProcessTypes()
     core = register_types(core)


### PR DESCRIPTION
This introduces a global singleton instance `core` within the process_bigraph module. The core is implemented as a singleton of the ProcessTypes class, ensuring that only one instance of ProcessTypes exists. The `ProcessTypes` class was modified to follow the Singleton design pattern using the `__new__` method to ensure only one instance is created