### PR TITLE
process types registry

### DIFF
--- a/process_bigraph/__init__.py
+++ b/process_bigraph/__init__.py
@@ -1,10 +1,13 @@
 import pprint
-from bigraph_schema.registry import deep_merge, default
+from bigraph_schema.registry import deep_merge, default, Registry
 from process_bigraph.processes import register_processes
 from process_bigraph.composite import Process, Step, Composite, ProcessTypes, interval_time_precision
 
 
 pretty = pprint.PrettyPrinter(indent=2)
+
+
+process_types_registry = Registry()
 
 
 def pp(x):
@@ -42,6 +45,8 @@ def register_types(core):
 
     core = register_processes(
         core)
+
+    process_types_registry.register('core', core)
 
     return core
 

--- a/process_bigraph/__init__.py
+++ b/process_bigraph/__init__.py
@@ -1,13 +1,11 @@
 import pprint
-from bigraph_schema.registry import deep_merge, default, Registry
 from process_bigraph.processes import register_processes
 from process_bigraph.composite import Process, Step, Composite, ProcessTypes, interval_time_precision
+from process_bigraph.process_types import process_types_registry
 
 
 pretty = pprint.PrettyPrinter(indent=2)
 
-
-process_types_registry = Registry()
 
 
 def pp(x):
@@ -43,11 +41,12 @@ def register_types(core):
         'rates': 'map[float]',
         'species': 'map[float]'})
 
-    core = register_processes(
-        core)
-
-    process_types_registry.register('core', core)
+    core = register_processes(core)
 
     return core
 
 
+# Make the core process types
+process_types_core = ProcessTypes()
+process_types_core = register_types(process_types_core)
+process_types_registry.register('core', process_types_core)

--- a/process_bigraph/composite.py
+++ b/process_bigraph/composite.py
@@ -97,7 +97,7 @@ def serialize_process(schema, value, core):
     return process
 
 
-def deserialize_process(schema, encoded, core):
+def deserialize_process(schema, encoded, core_type='core', core=None):
     """Deserialize a process from a serialized state.
 
     This function is used by the type system to deserialize a process.
@@ -148,9 +148,8 @@ def deserialize_process(schema, encoded, core):
 
     if not 'instance' in deserialized:
         # assign the process a core and initialize
-        instantiate.core = core
-        process = instantiate(
-            config)
+        # TODO -- how do we assign core to process...?
+        process = instantiate(config, core_type=core_type)
 
         deserialized['instance'] = process
 
@@ -189,8 +188,7 @@ def deserialize_step(schema, encoded, core):
         deserialized.get('config', {}))
 
     if not 'instance' in deserialized:
-        instantiate.core = core  # TODO -- check this works
-        process = instantiate(config)
+        process = instantiate(config, core_type=core_type)
         deserialized['instance'] = process
 
     deserialized['config'] = config
@@ -350,11 +348,8 @@ class Step(Edge):
     config_schema = {}
 
 
-    def __init__(self, config=None, core=None):
-        if core is None:
-            raise Exception('must provide a core')
-
-        self.core = core
+    def __init__(self, config=None, core_type='core'):
+        self.core = process_types_registry.access(core_type)
 
         if config is None:
             config = {}
@@ -397,11 +392,8 @@ class Process(Edge):
     """
     config_schema = {}
 
-    def __init__(self, config=None, core=None):
-        if core is None:
-            raise Exception('must provide a core')
-
-        self.core = core
+    def __init__(self, config=None, core_type='core'):
+        self.core = process_types_registry.access(core_type)
 
         if config is None:
             config = {}

--- a/process_bigraph/composite.py
+++ b/process_bigraph/composite.py
@@ -153,7 +153,8 @@ def deserialize_process(schema, encoded, core_type='core', core=None):
     if not 'instance' in deserialized:
         # assign the process a core and initialize
         # TODO -- how do we assign core to process...?
-        process = instantiate(config, core_type=core_type)
+        instantiate.core = core
+        process = instantiate(config)
 
         deserialized['instance'] = process
 
@@ -192,7 +193,8 @@ def deserialize_step(schema, encoded, core):
         deserialized.get('config', {}))
 
     if not 'instance' in deserialized:
-        process = instantiate(config, core_type=core_type)
+        instantiate.core = core
+        process = instantiate(config)
         deserialized['instance'] = process
 
     deserialized['config'] = config

--- a/process_bigraph/composite.py
+++ b/process_bigraph/composite.py
@@ -352,10 +352,11 @@ class Step(Edge):
     """
     # TODO: support trigger every time as well as dependency trigger
     config_schema = {}
-    core = process_types_registry.access('core')
+    core = None
 
     def __init__(self, config=None, core_type='core'):
-        self.core = process_types_registry.access(core_type)
+        if not self.core:
+            self.core = process_types_registry.access(core_type)
 
         if config is None:
             config = {}
@@ -397,10 +398,11 @@ class Process(Edge):
               also contain the following special keys (TODO):
     """
     config_schema = {}
-    core = process_types_registry.access('core')
+    core = None
 
     def __init__(self, config=None, core_type='core'):
-        self.core = process_types_registry.access(core_type)
+        if not self.core:
+            self.core = process_types_registry.access(core_type)
 
         if config is None:
             config = {}

--- a/process_bigraph/composite.py
+++ b/process_bigraph/composite.py
@@ -12,6 +12,7 @@ from typing import Dict
 
 from bigraph_schema import Edge, TypeSystem, get_path, set_path, deep_merge, is_schema_key, strip_schema_keys, Registry, hierarchy_depth, visit_method
 
+from process_bigraph import process_types_registry
 from process_bigraph.protocols import local_lookup, local_lookup_module
 
 
@@ -758,7 +759,8 @@ class Composite(Process):
         return composite
 
 
-    def __init__(self, config=None, core=None):
+    def __init__(self, config=None, core_type='core'):
+        core = process_types_registry.access(core_type)
         super().__init__(config, core)
 
         # insert global_time into schema if not present

--- a/process_bigraph/composite.py
+++ b/process_bigraph/composite.py
@@ -12,7 +12,7 @@ from typing import Dict
 
 from bigraph_schema import Edge, TypeSystem, get_path, set_path, deep_merge, is_schema_key, strip_schema_keys, Registry, hierarchy_depth, visit_method
 
-from process_bigraph import process_types_registry
+from process_bigraph.process_types import process_types_registry
 from process_bigraph.protocols import local_lookup, local_lookup_module
 
 
@@ -147,9 +147,10 @@ def deserialize_process(schema, encoded, core):
                 'interval'))
 
     if not 'instance' in deserialized:
+        # assign the process a core and initialize
+        instantiate.core = core
         process = instantiate(
-            config,
-            core=core)
+            config)
 
         deserialized['instance'] = process
 
@@ -188,7 +189,8 @@ def deserialize_step(schema, encoded, core):
         deserialized.get('config', {}))
 
     if not 'instance' in deserialized:
-        process = instantiate(config, core=core)
+        instantiate.core = core  # TODO -- check this works
+        process = instantiate(config)
         deserialized['instance'] = process
 
     deserialized['config'] = config
@@ -748,13 +750,12 @@ class Composite(Process):
 
 
     @classmethod
-    def load(cls, path, core=None):
+    def load(cls, path, core_type='core'):
         with open(path) as data:
             document = json.load(data)
 
             composite = cls(
-                document,
-                core=core)
+                document, core_type=core_type)
 
         return composite
 

--- a/process_bigraph/experiments/growth_division.py
+++ b/process_bigraph/experiments/growth_division.py
@@ -7,8 +7,8 @@ class Grow(Process):
         'rate': 'float'}
 
 
-    def __init__(self, config, core=None):
-        super().__init__(config, core)
+    def __init__(self, config):
+        super().__init__(config)
 
 
     def inputs(self):
@@ -41,8 +41,8 @@ class Divide(Step):
             '_default': 2}}
 
 
-    def __init__(self, config, core=None):
-        super().__init__(config, core)
+    def __init__(self, config):
+        super().__init__(config)
 
 
     def inputs(self):

--- a/process_bigraph/experiments/minimal_gillespie.py
+++ b/process_bigraph/experiments/minimal_gillespie.py
@@ -87,8 +87,8 @@ class GillespieEvent(Process):
             '_default': '1e-1'}}
 
 
-    def __init__(self, config=None, core=None):
-        super().__init__(config, core)
+    def __init__(self, config=None):
+        super().__init__(config)
 
         self.stoichiometry = np.array([[0, 1], [0, -1]])
 

--- a/process_bigraph/process_types.py
+++ b/process_bigraph/process_types.py
@@ -5,6 +5,10 @@ This module contains the process methods for the process bigraph schema.
 import copy
 
 from bigraph_schema import Edge, deep_merge, visit_method
+from bigraph_schema.registry import Registry
+
+
+process_types_registry = Registry()
 
 
 def apply_process(schema, current, update, core):

--- a/process_bigraph/processes/__init__.py
+++ b/process_bigraph/processes/__init__.py
@@ -1,6 +1,5 @@
 from process_bigraph.processes.parameter_scan import ToySystem, ODE, RunProcess, ParameterScan
 from process_bigraph.experiments.growth_division import Grow, Divide
-from process_bigraph.experiments.minimal_gillespie import GillespieInterval, GillespieEvent
 
 
 def register_processes(core):
@@ -11,8 +10,5 @@ def register_processes(core):
 
     core.register_process('grow', Grow)
     core.register_process('divide', Divide)
-
-    core.register_process('GillespieInterval', GillespieInterval)
-    core.register_process('GillespieEvent', GillespieEvent)
 
     return core

--- a/process_bigraph/tests.py
+++ b/process_bigraph/tests.py
@@ -43,7 +43,7 @@ class IncreaseProcess(Process):
 
 
 def test_default_config(core):
-    process = IncreaseProcess(core=core)
+    process = IncreaseProcess()
 
     assert process.config['rate'] == 0.1
 
@@ -58,7 +58,7 @@ def test_merge_collections(core):
 
 
 def test_process(core):
-    process = IncreaseProcess({'rate': 0.2}, core=core)
+    process = IncreaseProcess({'rate': 0.2})
     interface = process.interface()
     state = core.fill(interface['inputs'])
     state = core.fill(interface['outputs'])
@@ -100,7 +100,7 @@ def test_composite(core):
                 'interval': 1.0,
                 'inputs': {'level': ['value']},
                 'outputs': {'level': ['value']}},
-            'value': '11.11'}}, core=core)
+            'value': '11.11'}})
 
     initial_state = {'exchange': 3.33}
 
@@ -124,7 +124,7 @@ def test_infer(core):
                 'config': {'rate': '0.3'},
                 'inputs': {'level': ['value']},
                 'outputs': {'level': ['value']}},
-            'value': '11.11'}}, core=core)
+            'value': '11.11'}})
 
     assert composite.composition['value']['_type'] == 'float'
     assert composite.state['value'] == 4.4
@@ -188,7 +188,7 @@ def test_step_initialization(core):
                     'a': ['B'],
                     'b': ['C']},
                 'outputs': {
-                    'c': ['D']}}}}, core=core)
+                    'c': ['D']}}}})
 
     composite.run(0.0)
     assert composite.state['D'] == (13 + 21) * 21
@@ -252,8 +252,7 @@ def test_dependencies(core):
                 'c': ['i']}}}
 
     composite = Composite(
-        {'state': operation},
-        core=core)
+        {'state': operation})
 
     composite.run(0.0)
 
@@ -418,9 +417,7 @@ def test_emitter(core):
                 'mRNA': ['mRNA'],
                 'interval': ['event', 'interval']}}}
 
-    gillespie = Composite(
-        composite_schema,
-        core=core)
+    gillespie = Composite(composite_schema)
 
     updates = gillespie.update({
         'DNA': {
@@ -466,8 +463,7 @@ def test_run_process(core):
         'bridge': {
             'outputs': {
                 'results': ['A_results']}},
-        'state': state},
-        core=core)
+        'state': state})
 
     results = process.update({}, 0.0)
 
@@ -503,8 +499,7 @@ def test_nested_wires(core):
         'bridge': {
             'outputs': {
                 'results': ['A_results']}},
-        'state': state},
-        core=core)
+        'state': state})
 
     results = process.update({}, 0.0)
 
@@ -544,8 +539,7 @@ def test_parameter_scan(core):
         'bridge': {
             'outputs': {
                 'results': ['results']}},
-        'state': state},
-        core=core)
+        'state': state})
             
     # TODO: make a method so we can run it directly, provide some way to get the result out
     # result = scan.update({})
@@ -576,8 +570,7 @@ def test_grow_divide(core):
         'state': environment,
         'bridge': {
             'inputs': {
-                'environment': ['environment']}}},
-        core=core)
+                'environment': ['environment']}}})
 
     updates = composite.update({
         'environment': {
@@ -700,9 +693,7 @@ def test_gillespie_composite(core):
             # 'mRNA': {
             #     'C': '21.0'}}}
 
-    gillespie = Composite(
-        composite_schema,
-        core=core)
+    gillespie = Composite(composite_schema)
 
     updates = gillespie.update({
         'DNA': {


### PR DESCRIPTION
This is another possible fix to the cores everywhere. I made a `process_type_registry` which includes a ProcessType called `'core'`, which is the default core that Composites and Processes can use. People can add to this core if they want to, or make new cores and then just pass a string into Composite to look up the appropriate core. 

I think there may need to be something smarter with how Processes are assigned cores, without having our users needing to thread cores through everywhere -- I don't want Processes to have to do the whole core=core through the super. Can Composite ensure each Process is given the correct core by setting it rather than having to weave it in through the init?