### PR TITLE
Cache view/project for step_paths, not just process_paths

### DIFF
--- a/process_bigraph/composite.py
+++ b/process_bigraph/composite.py
@@ -1082,7 +1082,7 @@ class Composite(Process):
         """
         self._compiled_links = {}
 
-        for path in self.process_paths:
+        for path in list(self.process_paths) + list(self.step_paths):
             compiled = self.core.precompile_link(
                 self.schema, self.state, path)
             if compiled is not None:


### PR DESCRIPTION
## Summary
- `_build_view_project_cache()` only precompiled links for `process_paths`, missing `step_paths` entirely
- In step-heavy composites (e.g. v2ecoli: 55 steps, 1 process), nearly all `invoke()` calls went through the slow uncached `core.view()` path
- Including `step_paths` in the cache loop gives a **14% speedup** on a 60s v2ecoli simulation (9.42s → 8.11s)

## Test plan
- [x] Benchmarked before/after on v2ecoli (60s simulation)
- [x] All v2ecoli tests pass with correlation 1.0000 vs v1

🤖 Generated with [Claude Code](https://claude.com/claude-code)