### PR TITLE
SQLiteEmitter, bundle save/load, and composite refinements

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ rendered to HTML and published automatically on GitHub Pages.
 
 More tutorials are added continuously and appear automatically in the index.
 
+### Topic Guides
+
+- **Emitters — Recording Simulation Results**
+  *Built-in emitters (RAM, console, JSON, SQLite), how to wire them, retrieve results, store runs long-term, and write your own.*
+  [doc/emitters.md](doc/emitters.md)
+
 ---
 
 ## 🧪 Reference Implementation: spatio-flux

--- a/doc/emitters.md
+++ b/doc/emitters.md
@@ -1,0 +1,368 @@
+# Emitters — Recording Simulation Results
+
+**Emitters** are how a process-bigraph simulation records what happens over time. They are a small, specialized kind of **Step** that observes state each tick and writes it somewhere — memory, the console, a JSON file, or a SQLite database — without ever modifying the state they observe.
+
+This guide walks through:
+
+- [How emitters work](#how-emitters-work)
+- [The built-in emitters](#the-built-in-emitters)
+- [Configuring an emitter inline in a composite](#configuring-an-emitter-inline-in-a-composite)
+- [Adding an emitter to an existing composite](#adding-an-emitter-to-an-existing-composite)
+- [Retrieving results after a run](#retrieving-results-after-a-run)
+- [Filtering what gets recorded](#filtering-what-gets-recorded)
+- [Long-term storage with SQLiteEmitter](#long-term-storage-with-sqliteemitter)
+- [Writing a custom emitter](#writing-a-custom-emitter)
+
+All examples are self-contained — paste them into a script or a notebook and they run.
+
+---
+
+## How emitters work
+
+An emitter is a `Step` subclass. Like any Step, it:
+
+- declares **input ports** (what parts of state it reads),
+- has a `config_schema` describing its configuration,
+- is scheduled by the `Composite` and invoked each tick with the wired state.
+
+What makes it an *emitter* rather than an ordinary Step is what it does on each invocation:
+
+- it writes the observed state to some external sink (RAM list, stdout, a file, a database),
+- it declares **no outputs**, so it never feeds state back into the simulation,
+- it exposes a `query(paths=None)` method so you can read the recorded history afterwards.
+
+The base class lives at `process_bigraph.emitter.Emitter`. Every built-in emitter extends it, and you can extend it yourself — see [Writing a custom emitter](#writing-a-custom-emitter).
+
+A minimal emitter step spec looks like this:
+
+```python
+{
+    '_type': 'step',
+    'address': 'local:RAMEmitter',
+    'config': {
+        'emit': {'time': 'node', 'x': 'node'},  # schema for observed ports
+    },
+    'inputs': {
+        'time': ['global_time'],   # wire: read from composite.state['global_time']
+        'x':    ['Env', 'x'],      # wire: read from composite.state['Env']['x']
+    },
+}
+```
+
+You rarely write that spec by hand — the helpers below build it for you.
+
+---
+
+## The built-in emitters
+
+| Emitter | Address | Stores to | Good for |
+|---|---|---|---|
+| `ConsoleEmitter` | `local:ConsoleEmitter` | stdout | Quick debugging while you iterate |
+| `RAMEmitter` | `local:RAMEmitter` | in-memory list | Short runs, analysis inside the same process |
+| `JSONEmitter` | `local:JSONEmitter` | one JSON file per run | Small-to-medium runs you want to keep around |
+| `SQLiteEmitter` | `local:SQLiteEmitter` | one SQLite `.db` file, rows keyed by `simulation_id` | Long runs, cross-run analytics, long-term storage |
+
+All of them share the same `query(paths=None)` API, so downstream plotting and analysis code doesn't need to care which one produced the history.
+
+---
+
+## Configuring an emitter inline in a composite
+
+The most common pattern: define the emitter alongside your processes when you build the composite. The `emitter_from_wires` helper builds the spec from a dict of wires.
+
+```python
+from process_bigraph import Composite, allocate_core
+from process_bigraph.emitter import emitter_from_wires
+
+core = allocate_core()
+
+composite = Composite({
+    'state': {
+        'Env': {'x': 0.0, 'target': 10.0},
+
+        'mover': {
+            '_type': 'process',
+            'address': 'local:!my_module.MoveToward',
+            'config': {'rate': 2.0},
+            'interval': 1.0,
+            'inputs':  {'x': ['Env', 'x'], 'target': ['Env', 'target']},
+            'outputs': {'x': ['Env', 'x']},
+        },
+
+        # Record global_time and x every tick into a RAM emitter.
+        'emitter': emitter_from_wires({
+            'time': ['global_time'],
+            'x':    ['Env', 'x'],
+        }),
+    },
+}, core=core)
+
+composite.run(10.0)
+history = composite.state['emitter']['instance'].query()
+
+for row in history[:3]:
+    print(row)
+```
+
+Output:
+
+```
+{'time': 0.0, 'x': 0.0}
+{'time': 1.0, 'x': 2.0}
+{'time': 2.0, 'x': 4.0}
+```
+
+`emitter_from_wires(wires, address='local:RAMEmitter')` builds a `step` spec with inputs set to `wires` and an `emit` schema derived from their keys. To use a different backend, pass `address='local:ConsoleEmitter'`, `'local:JSONEmitter'`, or `'local:SQLiteEmitter'`.
+
+---
+
+## Adding an emitter to an existing composite
+
+If you already have a `Composite` and want to attach an emitter — for example, because the composite was built by someone else, or you want to observe every wired-in variable without listing them by hand — use `add_emitter_to_composite`:
+
+```python
+from process_bigraph.emitter import add_emitter_to_composite, gather_emitter_results
+
+# 'all' observes every non-process, non-step port in state.
+composite = add_emitter_to_composite(composite, core, emitter_mode='all')
+
+composite.run(10.0)
+
+# gather_emitter_results returns {path: history} for every emitter in the composite.
+results = gather_emitter_results(composite)
+print(next(iter(results.values()))[0])
+```
+
+`emitter_mode` accepts:
+
+- `'all'` — observe all valid input ports in state (the default).
+- `'none'` — observe only `global_time`.
+- `{'paths': [['Env', 'x'], 'target']}` — explicit list of paths.
+
+You can also pass `address='local:SQLiteEmitter'` (or any other emitter address) to change the backend.
+
+---
+
+## Retrieving results after a run
+
+Every emitter exposes the same `query()` API, so downstream code stays backend-agnostic.
+
+```python
+emitter = composite.state['emitter']['instance']
+
+# Full history: list of dicts, one per tick.
+history = emitter.query()
+
+# Path-filtered: return only specific wires from each tick.
+times_only = emitter.query([['time']])
+x_and_target = emitter.query([['x'], ['Env', 'target']])
+```
+
+For a composite with multiple emitters, `gather_emitter_results(composite, queries=None)` calls `query()` on all of them and returns a `{path: history}` dict. Optionally pass `queries={('emitter',): [['Env', 'x']]}` to drive each emitter's query independently.
+
+---
+
+## Filtering what gets recorded
+
+There are two places to filter:
+
+1. **At emit time**, via the wires you pass to `emitter_from_wires` — the emitter only ever sees what you wire in, so unwired state is never copied.
+2. **At query time**, via `emitter.query(paths)` — the emitter kept the full observed tree in storage, but returns only the paths you ask for.
+
+For long runs, prefer filtering at emit time (less memory, smaller files, smaller db rows).
+
+```python
+# Only record x and the global clock, nothing else.
+emitter_from_wires({
+    'time': ['global_time'],
+    'x':    ['Env', 'x'],
+})
+```
+
+---
+
+## Long-term storage with `SQLiteEmitter`
+
+`RAMEmitter` throws everything away when the Python process ends. `JSONEmitter` rewrites the whole history file on every tick, which is fine for small runs but expensive for long ones. `SQLiteEmitter` appends one row per tick into a single `.db` file, indexed by a `simulation_id` — ideal for long runs and for analysis sessions that happen weeks after the simulation.
+
+### Writing history
+
+```python
+from process_bigraph.emitter import (
+    emitter_from_wires,
+    save_simulation_metadata,
+)
+
+sim_id = 'run-2026-04-14-001'
+
+composite = Composite({
+    'state': {
+        # ... processes and state ...
+        'emitter': {
+            '_type': 'step',
+            'address': 'local:SQLiteEmitter',
+            'config': {
+                'emit':          {'time': 'node', 'x': 'node'},
+                'file_path':     './out',            # directory
+                'db_file':       'history.db',       # file name inside file_path
+                'simulation_id': sim_id,             # defaults to a new UUID
+                'name':          'mover_demo',       # optional human-readable label
+            },
+            'inputs': {'time': ['global_time'], 'x': ['Env', 'x']},
+        },
+    },
+}, core=core)
+
+# Record the config that produced this run, alongside the history.
+save_simulation_metadata(
+    './out/history.db', sim_id,
+    composite_config=composite.state,   # serialize this however you like
+    metadata={'notes': 'quick smoke test'},
+    name='mover_demo',
+)
+
+composite.run(100.0)
+```
+
+Multiple runs can share one `.db` file — rows are partitioned by `simulation_id`, so `history.db` becomes a persistent archive of every experiment you've run.
+
+### Reading history back, without any `Composite`
+
+The retrieval helpers take only a db path, so you can analyze runs long after the simulation process has exited — no need to reconstruct the `Composite` or import the original processes.
+
+```python
+from process_bigraph.emitter import (
+    list_simulations,
+    load_history,
+    load_simulation_metadata,
+)
+
+db_path = './out/history.db'
+
+# What's in this db?
+for sim in list_simulations(db_path):
+    print(sim['simulation_id'], sim['name'], sim['step_count'])
+# -> run-2026-04-14-001 mover_demo 101
+
+# Full history of a specific run (same shape as emitter.query()).
+history = load_history(db_path, 'run-2026-04-14-001')
+
+# Or a path-filtered slice.
+only_x = load_history(db_path, 'run-2026-04-14-001', paths=[['x']])
+
+# Metadata: when it ran, what config produced it, any notes attached.
+meta = load_simulation_metadata(db_path, 'run-2026-04-14-001')
+print(meta['started_at'], meta['name'])
+print(meta['composite_config'])
+print(meta['metadata'])
+```
+
+Because it's a plain SQLite file, you can also open it directly and run SQL:
+
+```python
+import sqlite3, json
+conn = sqlite3.connect('./out/history.db')
+
+# All simulations, newest first.
+for row in conn.execute(
+    'SELECT simulation_id, name, started_at FROM simulations ORDER BY started_at DESC'
+):
+    print(row)
+
+# Mean x by simulation.
+for sim_id, avg_x in conn.execute('''
+    SELECT simulation_id, AVG(json_extract(state, '$.x'))
+    FROM history GROUP BY simulation_id
+'''):
+    print(sim_id, avg_x)
+```
+
+The schema:
+
+```sql
+CREATE TABLE history (
+    simulation_id TEXT NOT NULL,
+    step INTEGER NOT NULL,
+    global_time REAL,
+    state TEXT NOT NULL,             -- JSON
+    PRIMARY KEY (simulation_id, step)
+);
+CREATE INDEX idx_history_sim_time ON history(simulation_id, global_time);
+
+CREATE TABLE simulations (
+    simulation_id TEXT PRIMARY KEY,
+    name TEXT,
+    started_at TEXT NOT NULL,        -- ISO 8601 UTC
+    composite_config TEXT,           -- JSON
+    metadata TEXT                    -- JSON
+);
+```
+
+---
+
+## Writing a custom emitter
+
+An emitter is just a `Step` subclass with an `inputs()` method that returns what to observe and an `update(state)` method that records it. Here's a compact example that streams observations to a CSV file:
+
+```python
+import csv
+from typing import Dict
+from process_bigraph.emitter import Emitter
+
+
+class CSVEmitter(Emitter):
+    '''Append each tick to a CSV file.'''
+
+    config_schema = {
+        **Emitter.config_schema,
+        'file_path':  {'_type': 'string', '_default': 'history.csv'},
+        'fieldnames': {'_type': 'list[string]', '_default': None},
+    }
+
+    def __init__(self, config, core):
+        super().__init__(config, core)
+        self.file_path = config.get('file_path', 'history.csv')
+        self.fieldnames = config.get('fieldnames') or list(self.inputs().keys())
+        self._fh = open(self.file_path, 'a', newline='')
+        self._writer = csv.DictWriter(self._fh, fieldnames=self.fieldnames)
+        if self._fh.tell() == 0:
+            self._writer.writeheader()
+
+    def update(self, state) -> Dict:
+        self._writer.writerow({k: state.get(k) for k in self.fieldnames})
+        self._fh.flush()
+        return {}
+
+    def query(self, query=None):
+        import csv
+        with open(self.file_path) as f:
+            return list(csv.DictReader(f))
+
+    def __del__(self):
+        try:
+            self._fh.close()
+        except Exception:
+            pass
+```
+
+To register it so it's reachable at an address like `local:CSVEmitter`:
+
+```python
+core.register_link('CSVEmitter', CSVEmitter)
+```
+
+Then use it exactly like any other emitter — `emitter_from_wires({...}, address='local:CSVEmitter')`, `add_emitter_to_composite(..., address='local:CSVEmitter')`, or drop its spec directly into a composite.
+
+The contract to satisfy:
+
+- Accept an `emit` key in `config_schema` (inherit from `Emitter.config_schema`) — this is the schema of observed state.
+- Implement `update(state)` to persist observations. Returning `{}` keeps it read-only.
+- Implement `query(paths=None)` to return the same shape your users expect (a list of per-tick dicts) so it plugs into existing plotting/analysis code.
+- If you need to handle live process/edge objects that get wired into state, reuse `process_bigraph.emitter.tree_copy` — it's what `RAMEmitter` and `SQLiteEmitter` use to strip `Edge` instances before persistence.
+
+---
+
+## See also
+
+- `process_bigraph/emitter.py` — the source of all built-in emitters and helpers.
+- [Tutorial 1 — Process-Bigraph Basics](https://vivarium-collective.github.io/process-bigraph/notebooks/tutorial_1.html) — section 7 introduces emitters in context.

--- a/doc/emitters.md
+++ b/doc/emitters.md
@@ -247,6 +247,21 @@ Pass `subsample: N` in the emitter config to keep only every Nth tick:
 
 The stored `step` column still reflects the true composite tick number, so time series you build from the history preserve the simulation's real cadence even though the intermediate ticks were not persisted. `subsample` defaults to `1` (record every tick).
 
+### Batching writes for throughput
+
+SQLite commits one transaction per INSERT by default, which means a per-row fsync; for high-frequency runs most of the wall-clock ends up in that fsync. `batch_size: N` buffers up to N recorded rows in memory and flushes them as one transaction:
+
+```python
+'config': {
+    'emit':          {'time': 'node', 'x': 'node'},
+    'simulation_id': sim_id,
+    'subsample':     10,
+    'batch_size':    100,    # flush in transactions of up to 100 rows
+}
+```
+
+The emitter guarantees a flush on `close()` and before every `query()`, so readers and clean shutdown always see a consistent picture. A hard crash before flush loses buffered rows only — the on-disk invariants are unaffected. `batch_size` composes with `subsample`: together they cut write volume (subsample) and amortize fsync (batch_size). Default is `1`.
+
 ### Reading history back, without any `Composite`
 
 The retrieval helpers take only a db path, so you can analyze runs long after the simulation process has exited — no need to reconstruct the `Composite` or import the original processes.

--- a/doc/emitters.md
+++ b/doc/emitters.md
@@ -226,6 +226,27 @@ composite.run(100.0)
 
 Multiple runs can share one `.db` file — rows are partitioned by `simulation_id`, so `history.db` becomes a persistent archive of every experiment you've run.
 
+### Thinning high-frequency runs with `subsample`
+
+If your composite fires the emitter on a very short interval (e.g. `interval=0.1` over hours of sim time), you can easily end up writing tens of thousands of rows per run. Most of those rows are redundant for analysis and plotting — and each one costs a JSON-encode plus a SQLite INSERT.
+
+Pass `subsample: N` in the emitter config to keep only every Nth tick:
+
+```python
+'emitter': {
+    '_type': 'step',
+    'address': 'local:SQLiteEmitter',
+    'config': {
+        'emit':          {'time': 'node', 'x': 'node'},
+        'simulation_id': sim_id,
+        'subsample':     10,     # record every 10th tick (first tick always kept)
+    },
+    'inputs': {'time': ['global_time'], 'x': ['Env', 'x']},
+}
+```
+
+The stored `step` column still reflects the true composite tick number, so time series you build from the history preserve the simulation's real cadence even though the intermediate ticks were not persisted. `subsample` defaults to `1` (record every tick).
+
 ### Reading history back, without any `Composite`
 
 The retrieval helpers take only a db path, so you can analyze runs long after the simulation process has exited — no need to reconstruct the `Composite` or import the original processes.

--- a/process_bigraph/emitter.py
+++ b/process_bigraph/emitter.py
@@ -251,7 +251,16 @@ def _json_default(value):
         return int(value)
     if isinstance(value, (np.floating,)):
         return float(value)
-    raise TypeError(f'Object of type {type(value).__name__} is not JSON serializable')
+    # bigraph-schema Node dataclasses (String, Float, Integer, ...) can end
+    # up wired into emitted state; fall back to their repr so history stays
+    # serializable without dragging in the schema machinery.
+    try:
+        import dataclasses
+        if dataclasses.is_dataclass(value):
+            return dataclasses.asdict(value)
+    except Exception:
+        pass
+    return repr(value)
 
 
 def _init_history_db(conn):
@@ -452,7 +461,10 @@ class SQLiteEmitter(Emitter):
 
     def update(self, state) -> Dict:
         global_time = state.get('global_time') if isinstance(state, dict) else None
-        payload = json.dumps(state, default=_json_default)
+        # Strip live Edge/process instances the same way RAMEmitter does;
+        # otherwise wires that pull in process objects break JSON serialization.
+        clean = tree_copy(state)
+        payload = json.dumps(clean, default=_json_default)
         self._conn.execute(
             'INSERT OR REPLACE INTO history '
             '(simulation_id, step, global_time, state) VALUES (?, ?, ?, ?)',

--- a/process_bigraph/emitter.py
+++ b/process_bigraph/emitter.py
@@ -11,18 +11,19 @@ Emitters are steps that observe a composite simulation's state and emit data to 
 - Implement concrete emitters (RAM, console, JSON, SQLite)
 '''
 
-import os
-import json
 import copy
-import uuid
-import sqlite3
+import dataclasses
 import datetime
-# import pytest
-import numpy as np
+import json
+import os
+import sqlite3
+import uuid
 from typing import Dict, List, Optional
 
-from bigraph_schema import get_path, set_path, is_schema_key, Edge
-from process_bigraph.composite import Composite, Step, find_instance_paths
+import numpy as np
+
+from bigraph_schema import Edge, get_path, is_schema_key, set_path
+from process_bigraph.composite import Step, find_instance_paths
 
 
 # ==========================
@@ -137,16 +138,24 @@ class Emitter(Step):
     def inputs(self) -> Dict:
         return self.config['emit']
 
-    def query(self, query=None):
-        '''
-        Query the history of the emitter.
-        :param query: a list of paths to query from the history. If None, the entire history is returned.
-        :return: results of the query in a list
+    def query(self, paths=None, query=None):
+        '''Return recorded history.
+
+        :param paths: a list of paths to project from each recorded state.
+            If None, the entire history is returned.
+        :param query: deprecated alias for ``paths``.
         '''
         return {}
 
     def update(self, state) -> Dict:
         return {}
+
+
+def _resolve_query_paths(paths, query):
+    '''Accept either the new ``paths`` kwarg or the legacy ``query`` kwarg.'''
+    if paths is None and query is not None:
+        return query
+    return paths
 
 
 # ========================
@@ -180,13 +189,14 @@ class RAMEmitter(Emitter):
         self.history.append(tree_copy(state))
         return {}
 
-    def query(self, query=None, schema=None):
+    def query(self, paths=None, schema=None, query=None):
+        paths = _resolve_query_paths(paths, query)
         schema = schema or self.inputs()
-        if isinstance(query, list):
+        if isinstance(paths, list):
             results = []
             for t in self.history:
                 result = {}
-                for path in query:
+                for path in paths:
                     _, value = self.core.traverse(schema, t, path)
                     result = set_path(result, path, value)
                 results.append(result)
@@ -223,7 +233,8 @@ class JSONEmitter(Emitter):
             json.dump(data, f, indent=4)
         return {}
 
-    def query(self, query=None):
+    def query(self, paths=None, query=None):
+        paths = _resolve_query_paths(paths, query)
         if not os.path.exists(self.filepath):
             return []
         with open(self.filepath, 'r') as f:
@@ -232,11 +243,11 @@ class JSONEmitter(Emitter):
             except json.JSONDecodeError:
                 return []
 
-        if isinstance(query, list):
+        if isinstance(paths, list):
             results = []
             for t in data:
                 result = {}
-                for path in query:
+                for path in paths:
                     element = get_path(t, path)
                     result = set_path(result, path, element)
                 results.append(result)
@@ -254,12 +265,8 @@ def _json_default(value):
     # bigraph-schema Node dataclasses (String, Float, Integer, ...) can end
     # up wired into emitted state; fall back to their repr so history stays
     # serializable without dragging in the schema machinery.
-    try:
-        import dataclasses
-        if dataclasses.is_dataclass(value):
-            return dataclasses.asdict(value)
-    except Exception:
-        pass
+    if dataclasses.is_dataclass(value):
+        return dataclasses.asdict(value)
     return repr(value)
 
 
@@ -322,7 +329,7 @@ def save_simulation_metadata(db_path, simulation_id, composite_config=None,
             (
                 simulation_id,
                 name,
-                datetime.datetime.utcnow().isoformat(timespec='seconds') + 'Z',
+                datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
                 json.dumps(composite_config, default=_json_default) if composite_config is not None else None,
                 json.dumps(metadata, default=_json_default) if metadata is not None else None,
             ),
@@ -449,7 +456,7 @@ def mark_simulation_finished(db_path, simulation_id, elapsed_seconds=None):
     conn = sqlite3.connect(db_path, isolation_level=None)
     try:
         _init_history_db(conn)
-        completed_at = datetime.datetime.utcnow().isoformat(timespec='seconds') + 'Z'
+        completed_at = datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
         conn.execute(
             'UPDATE simulations SET completed_at = ?, elapsed_seconds = ? '
             'WHERE simulation_id = ?',
@@ -496,41 +503,44 @@ class SQLiteEmitter(Emitter):
         self._step = 0
 
     def update(self, state) -> Dict:
+        if self._conn is None:
+            raise RuntimeError('SQLiteEmitter has been closed')
         global_time = state.get('global_time') if isinstance(state, dict) else None
         # Strip live Edge/process instances the same way RAMEmitter does;
         # otherwise wires that pull in process objects break JSON serialization.
         clean = tree_copy(state)
         payload = json.dumps(clean, default=_json_default)
+        # Plain INSERT (not OR REPLACE): `step` is a per-run monotonic
+        # counter, so a PK conflict here would indicate a real bug — fail
+        # loudly rather than silently overwriting a row.
         self._conn.execute(
-            'INSERT OR REPLACE INTO history '
+            'INSERT INTO history '
             '(simulation_id, step, global_time, state) VALUES (?, ?, ?, ?)',
             (self.simulation_id, self._step, global_time, payload),
         )
         self._step += 1
         return {}
 
-    def query(self, query=None):
-        cursor = self._conn.execute(
-            'SELECT state FROM history WHERE simulation_id = ? ORDER BY step',
-            (self.simulation_id,),
-        )
-        history = [json.loads(row[0]) for row in cursor.fetchall()]
+    def query(self, paths=None, query=None):
+        paths = _resolve_query_paths(paths, query)
+        # Route through the standalone helper so the in-process and post-hoc
+        # retrieval paths go through the same code.
+        return load_history(self.db_path, self.simulation_id, paths=paths)
 
-        if isinstance(query, list):
-            results = []
-            for t in history:
-                result = {}
-                for path in query:
-                    element = get_path(t, path)
-                    result = set_path(result, path, element)
-                results.append(result)
-            return results
-        return history
+    def close(self):
+        '''Close the underlying SQLite connection explicitly.
+
+        Call this when you are done with the emitter — for example, at the
+        end of a script — so WAL data is flushed deterministically. After
+        calling ``close`` the emitter can no longer record new rows.
+        '''
+        if self._conn is not None:
+            self._conn.close()
+            self._conn = None
 
     def __del__(self):
         try:
-            if getattr(self, '_conn', None) is not None:
-                self._conn.close()
+            self.close()
         except Exception:
             pass
 

--- a/process_bigraph/emitter.py
+++ b/process_bigraph/emitter.py
@@ -477,6 +477,14 @@ class SQLiteEmitter(Emitter):
     To record the composite config or other metadata alongside the history
     rows, call :func:`save_simulation_metadata` after constructing the
     Composite — the emitter itself only writes the per-step history rows.
+
+    ``subsample`` records only every Nth composite tick (default 1 = every
+    tick). The ``step`` column still stores the true composite tick number,
+    so time-series produced from the history reflect the real cadence even
+    though intermediate ticks were not persisted. Use this when a Composite
+    fires the emitter very often (small intervals, long runs) and you don't
+    need every tick in the archive — it's the cheapest way to shrink the
+    write volume without losing the simulation's time axis.
     '''
     config_schema = {
         **Emitter.config_schema,
@@ -484,6 +492,7 @@ class SQLiteEmitter(Emitter):
         'db_file': {'_type': 'string', '_default': 'history.db'},
         'simulation_id': {'_type': 'string', '_default': None},
         'name': {'_type': 'string', '_default': None},
+        'subsample': {'_type': 'integer', '_default': 1},
     }
 
     def __init__(self, config, core):
@@ -492,6 +501,13 @@ class SQLiteEmitter(Emitter):
         self.file_path = config.get('file_path') or './out'
         os.makedirs(self.file_path, exist_ok=True)
         self.db_path = os.path.join(self.file_path, config.get('db_file') or 'history.db')
+
+        subsample = config.get('subsample')
+        self.subsample = 1 if subsample is None else int(subsample)
+        if self.subsample < 1:
+            raise ValueError(
+                f'SQLiteEmitter subsample must be >= 1, got {self.subsample}'
+            )
 
         self._conn = sqlite3.connect(self.db_path, isolation_level=None)
         _init_history_db(self._conn)
@@ -505,6 +521,14 @@ class SQLiteEmitter(Emitter):
     def update(self, state) -> Dict:
         if self._conn is None:
             raise RuntimeError('SQLiteEmitter has been closed')
+        # Advance the true composite tick counter on every call; only persist
+        # the row when this tick falls on the subsample cadence. Ticks 0,
+        # subsample, 2*subsample, ... are written (first tick always kept).
+        step = self._step
+        self._step += 1
+        if step % self.subsample != 0:
+            return {}
+
         global_time = state.get('global_time') if isinstance(state, dict) else None
         # Strip live Edge/process instances the same way RAMEmitter does;
         # otherwise wires that pull in process objects break JSON serialization.
@@ -516,9 +540,8 @@ class SQLiteEmitter(Emitter):
         self._conn.execute(
             'INSERT INTO history '
             '(simulation_id, step, global_time, state) VALUES (?, ?, ?, ?)',
-            (self.simulation_id, self._step, global_time, payload),
+            (self.simulation_id, step, global_time, payload),
         )
-        self._step += 1
         return {}
 
     def query(self, paths=None, query=None):

--- a/process_bigraph/emitter.py
+++ b/process_bigraph/emitter.py
@@ -285,10 +285,18 @@ def _init_history_db(conn):
             simulation_id TEXT PRIMARY KEY,
             name TEXT,
             started_at TEXT NOT NULL,
+            completed_at TEXT,
+            elapsed_seconds REAL,
             composite_config TEXT,
             metadata TEXT
         )
     ''')
+    # Migrate older dbs that predate completed_at / elapsed_seconds.
+    existing = {row[1] for row in conn.execute("PRAGMA table_info(simulations)")}
+    if 'completed_at' not in existing:
+        conn.execute('ALTER TABLE simulations ADD COLUMN completed_at TEXT')
+    if 'elapsed_seconds' not in existing:
+        conn.execute('ALTER TABLE simulations ADD COLUMN elapsed_seconds REAL')
 
 
 def save_simulation_metadata(db_path, simulation_id, composite_config=None,
@@ -326,10 +334,10 @@ def save_simulation_metadata(db_path, simulation_id, composite_config=None,
 def list_simulations(db_path) -> List[Dict]:
     '''Return all recorded simulations in a history db, newest first.
 
-    Each entry has ``simulation_id``, ``name``, ``started_at``, ``step_count``,
-    and ``has_config`` (True if a composite_config was saved). No core or
-    Composite is required — use this to browse a db long after the runs
-    that produced it.
+    Each entry has ``simulation_id``, ``name``, ``started_at``,
+    ``completed_at``, ``elapsed_seconds``, ``step_count``, and ``has_config``
+    (True if a composite_config was saved). No core or Composite is required
+    — use this to browse a db long after the runs that produced it.
     '''
     if not os.path.exists(db_path):
         return []
@@ -337,14 +345,15 @@ def list_simulations(db_path) -> List[Dict]:
     try:
         _init_history_db(conn)
         rows = conn.execute('''
-            SELECT s.simulation_id, s.name, s.started_at, s.composite_config,
+            SELECT s.simulation_id, s.name, s.started_at, s.completed_at,
+                   s.elapsed_seconds, s.composite_config,
                    (SELECT COUNT(*) FROM history h WHERE h.simulation_id = s.simulation_id)
             FROM simulations s
             ORDER BY s.started_at DESC
         ''').fetchall()
         # Also include sims that have history rows but no metadata row
         orphan_rows = conn.execute('''
-            SELECT h.simulation_id, NULL, NULL, NULL, COUNT(*)
+            SELECT h.simulation_id, NULL, NULL, NULL, NULL, NULL, COUNT(*)
             FROM history h
             WHERE h.simulation_id NOT IN (SELECT simulation_id FROM simulations)
             GROUP BY h.simulation_id
@@ -357,10 +366,13 @@ def list_simulations(db_path) -> List[Dict]:
             'simulation_id': sid,
             'name': name,
             'started_at': started_at,
+            'completed_at': completed_at,
+            'elapsed_seconds': elapsed,
             'step_count': step_count,
             'has_config': cfg is not None,
         }
-        for (sid, name, started_at, cfg, step_count) in list(rows) + list(orphan_rows)
+        for (sid, name, started_at, completed_at, elapsed, cfg, step_count)
+        in list(rows) + list(orphan_rows)
     ]
 
 
@@ -398,14 +410,17 @@ def load_simulation_metadata(db_path, simulation_id) -> Optional[Dict]:
     '''Return the ``simulations`` row for a sim, or ``None`` if missing.
 
     Result dict has ``simulation_id``, ``name``, ``started_at``,
-    ``composite_config`` (already parsed from JSON), and ``metadata``.
+    ``completed_at``, ``elapsed_seconds``, ``composite_config`` (parsed
+    from JSON), and ``metadata``.
     '''
     if not os.path.exists(db_path):
         return None
     conn = sqlite3.connect(db_path)
     try:
+        _init_history_db(conn)
         row = conn.execute(
-            'SELECT simulation_id, name, started_at, composite_config, metadata '
+            'SELECT simulation_id, name, started_at, completed_at, '
+            'elapsed_seconds, composite_config, metadata '
             'FROM simulations WHERE simulation_id = ?',
             (simulation_id,),
         ).fetchone()
@@ -413,14 +428,35 @@ def load_simulation_metadata(db_path, simulation_id) -> Optional[Dict]:
         conn.close()
     if row is None:
         return None
-    sid, name, started_at, cfg, meta = row
+    sid, name, started_at, completed_at, elapsed, cfg, meta = row
     return {
         'simulation_id': sid,
         'name': name,
         'started_at': started_at,
+        'completed_at': completed_at,
+        'elapsed_seconds': elapsed,
         'composite_config': json.loads(cfg) if cfg else None,
         'metadata': json.loads(meta) if meta else None,
     }
+
+
+def mark_simulation_finished(db_path, simulation_id, elapsed_seconds=None):
+    '''Stamp ``completed_at`` (UTC now) and ``elapsed_seconds`` on a run.
+
+    Call this right after ``sim.run()`` returns. Safe to call multiple
+    times — each call just overwrites the two fields.
+    '''
+    conn = sqlite3.connect(db_path, isolation_level=None)
+    try:
+        _init_history_db(conn)
+        completed_at = datetime.datetime.utcnow().isoformat(timespec='seconds') + 'Z'
+        conn.execute(
+            'UPDATE simulations SET completed_at = ?, elapsed_seconds = ? '
+            'WHERE simulation_id = ?',
+            (completed_at, elapsed_seconds, simulation_id),
+        )
+    finally:
+        conn.close()
 
 
 class SQLiteEmitter(Emitter):

--- a/process_bigraph/emitter.py
+++ b/process_bigraph/emitter.py
@@ -485,6 +485,13 @@ class SQLiteEmitter(Emitter):
     fires the emitter very often (small intervals, long runs) and you don't
     need every tick in the archive — it's the cheapest way to shrink the
     write volume without losing the simulation's time axis.
+
+    ``batch_size`` buffers up to N recorded rows in memory and flushes them
+    in a single SQL transaction (default 1 = write each row immediately).
+    With ``batch_size=100`` the per-row fsync overhead is amortized across
+    the batch, giving a large speedup on high-frequency runs. Unflushed
+    rows are guaranteed to be written on ``close()`` and on the next
+    ``query()``; a hard crash before flush loses the buffered rows.
     '''
     config_schema = {
         **Emitter.config_schema,
@@ -493,6 +500,7 @@ class SQLiteEmitter(Emitter):
         'simulation_id': {'_type': 'string', '_default': None},
         'name': {'_type': 'string', '_default': None},
         'subsample': {'_type': 'integer', '_default': 1},
+        'batch_size': {'_type': 'integer', '_default': 1},
     }
 
     def __init__(self, config, core):
@@ -509,6 +517,13 @@ class SQLiteEmitter(Emitter):
                 f'SQLiteEmitter subsample must be >= 1, got {self.subsample}'
             )
 
+        batch_size = config.get('batch_size')
+        self.batch_size = 1 if batch_size is None else int(batch_size)
+        if self.batch_size < 1:
+            raise ValueError(
+                f'SQLiteEmitter batch_size must be >= 1, got {self.batch_size}'
+            )
+
         self._conn = sqlite3.connect(self.db_path, isolation_level=None)
         _init_history_db(self._conn)
 
@@ -517,6 +532,7 @@ class SQLiteEmitter(Emitter):
             save_simulation_metadata(self.db_path, self.simulation_id, name=name)
 
         self._step = 0
+        self._batch = []
 
     def update(self, state) -> Dict:
         if self._conn is None:
@@ -534,18 +550,35 @@ class SQLiteEmitter(Emitter):
         # otherwise wires that pull in process objects break JSON serialization.
         clean = tree_copy(state)
         payload = json.dumps(clean, default=_json_default)
+        self._batch.append((self.simulation_id, step, global_time, payload))
+        if len(self._batch) >= self.batch_size:
+            self._flush_batch()
+        return {}
+
+    def _flush_batch(self):
+        '''Write any buffered rows in a single SQL transaction.'''
+        if not self._batch or self._conn is None:
+            return
         # Plain INSERT (not OR REPLACE): `step` is a per-run monotonic
         # counter, so a PK conflict here would indicate a real bug — fail
         # loudly rather than silently overwriting a row.
-        self._conn.execute(
-            'INSERT INTO history '
-            '(simulation_id, step, global_time, state) VALUES (?, ?, ?, ?)',
-            (self.simulation_id, step, global_time, payload),
-        )
-        return {}
+        self._conn.execute('BEGIN')
+        try:
+            self._conn.executemany(
+                'INSERT INTO history '
+                '(simulation_id, step, global_time, state) VALUES (?, ?, ?, ?)',
+                self._batch,
+            )
+            self._conn.execute('COMMIT')
+        except Exception:
+            self._conn.execute('ROLLBACK')
+            raise
+        self._batch.clear()
 
     def query(self, paths=None, query=None):
         paths = _resolve_query_paths(paths, query)
+        # Flush so buffered-but-unwritten rows are visible to the read.
+        self._flush_batch()
         # Route through the standalone helper so the in-process and post-hoc
         # retrieval paths go through the same code.
         return load_history(self.db_path, self.simulation_id, paths=paths)
@@ -553,13 +586,16 @@ class SQLiteEmitter(Emitter):
     def close(self):
         '''Close the underlying SQLite connection explicitly.
 
-        Call this when you are done with the emitter — for example, at the
-        end of a script — so WAL data is flushed deterministically. After
-        calling ``close`` the emitter can no longer record new rows.
+        Flushes any buffered rows (from ``batch_size > 1``) so nothing is
+        lost, then closes the connection. After calling ``close`` the
+        emitter can no longer record new rows.
         '''
         if self._conn is not None:
-            self._conn.close()
-            self._conn = None
+            try:
+                self._flush_batch()
+            finally:
+                self._conn.close()
+                self._conn = None
 
     def __del__(self):
         try:

--- a/process_bigraph/emitter.py
+++ b/process_bigraph/emitter.py
@@ -16,9 +16,10 @@ import json
 import copy
 import uuid
 import sqlite3
+import datetime
 # import pytest
 import numpy as np
-from typing import Dict
+from typing import Dict, List, Optional
 
 from bigraph_schema import get_path, set_path, is_schema_key, Edge
 from process_bigraph.composite import Composite, Step, find_instance_paths
@@ -253,6 +254,166 @@ def _json_default(value):
     raise TypeError(f'Object of type {type(value).__name__} is not JSON serializable')
 
 
+def _init_history_db(conn):
+    '''Create both history and simulations tables. Safe to call repeatedly.'''
+    conn.execute('PRAGMA journal_mode=WAL')
+    conn.execute('PRAGMA synchronous=NORMAL')
+    conn.execute('''
+        CREATE TABLE IF NOT EXISTS history (
+            simulation_id TEXT NOT NULL,
+            step INTEGER NOT NULL,
+            global_time REAL,
+            state TEXT NOT NULL,
+            PRIMARY KEY (simulation_id, step)
+        )
+    ''')
+    conn.execute(
+        'CREATE INDEX IF NOT EXISTS idx_history_sim_time '
+        'ON history(simulation_id, global_time)'
+    )
+    conn.execute('''
+        CREATE TABLE IF NOT EXISTS simulations (
+            simulation_id TEXT PRIMARY KEY,
+            name TEXT,
+            started_at TEXT NOT NULL,
+            composite_config TEXT,
+            metadata TEXT
+        )
+    ''')
+
+
+def save_simulation_metadata(db_path, simulation_id, composite_config=None,
+                             metadata=None, name=None):
+    '''Write or update the ``simulations`` row for a run.
+
+    Call once per simulation, typically right after building the Composite,
+    to record the config that produced the history rows. Idempotent: fields
+    passed as ``None`` leave any existing value untouched, so you can fill
+    in ``name`` first and ``composite_config`` later without clobbering.
+    '''
+    conn = sqlite3.connect(db_path, isolation_level=None)
+    try:
+        _init_history_db(conn)
+        conn.execute(
+            'INSERT INTO simulations '
+            '(simulation_id, name, started_at, composite_config, metadata) '
+            'VALUES (?, ?, ?, ?, ?) '
+            'ON CONFLICT(simulation_id) DO UPDATE SET '
+            '  name = COALESCE(excluded.name, simulations.name), '
+            '  composite_config = COALESCE(excluded.composite_config, simulations.composite_config), '
+            '  metadata = COALESCE(excluded.metadata, simulations.metadata)',
+            (
+                simulation_id,
+                name,
+                datetime.datetime.utcnow().isoformat(timespec='seconds') + 'Z',
+                json.dumps(composite_config, default=_json_default) if composite_config is not None else None,
+                json.dumps(metadata, default=_json_default) if metadata is not None else None,
+            ),
+        )
+    finally:
+        conn.close()
+
+
+def list_simulations(db_path) -> List[Dict]:
+    '''Return all recorded simulations in a history db, newest first.
+
+    Each entry has ``simulation_id``, ``name``, ``started_at``, ``step_count``,
+    and ``has_config`` (True if a composite_config was saved). No core or
+    Composite is required — use this to browse a db long after the runs
+    that produced it.
+    '''
+    if not os.path.exists(db_path):
+        return []
+    conn = sqlite3.connect(db_path)
+    try:
+        _init_history_db(conn)
+        rows = conn.execute('''
+            SELECT s.simulation_id, s.name, s.started_at, s.composite_config,
+                   (SELECT COUNT(*) FROM history h WHERE h.simulation_id = s.simulation_id)
+            FROM simulations s
+            ORDER BY s.started_at DESC
+        ''').fetchall()
+        # Also include sims that have history rows but no metadata row
+        orphan_rows = conn.execute('''
+            SELECT h.simulation_id, NULL, NULL, NULL, COUNT(*)
+            FROM history h
+            WHERE h.simulation_id NOT IN (SELECT simulation_id FROM simulations)
+            GROUP BY h.simulation_id
+        ''').fetchall()
+    finally:
+        conn.close()
+
+    return [
+        {
+            'simulation_id': sid,
+            'name': name,
+            'started_at': started_at,
+            'step_count': step_count,
+            'has_config': cfg is not None,
+        }
+        for (sid, name, started_at, cfg, step_count) in list(rows) + list(orphan_rows)
+    ]
+
+
+def load_history(db_path, simulation_id, paths: Optional[List] = None) -> List[Dict]:
+    '''Load a simulation's history from a db file. No core/Composite needed.
+
+    Returns the same shape that ``SQLiteEmitter.query()`` returns, so plot
+    and analysis code that consumed RAM/JSON emitter output works unchanged.
+    '''
+    if not os.path.exists(db_path):
+        return []
+    conn = sqlite3.connect(db_path)
+    try:
+        cursor = conn.execute(
+            'SELECT state FROM history WHERE simulation_id = ? ORDER BY step',
+            (simulation_id,),
+        )
+        history = [json.loads(row[0]) for row in cursor.fetchall()]
+    finally:
+        conn.close()
+
+    if isinstance(paths, list):
+        results = []
+        for t in history:
+            result = {}
+            for path in paths:
+                element = get_path(t, path)
+                result = set_path(result, path, element)
+            results.append(result)
+        return results
+    return history
+
+
+def load_simulation_metadata(db_path, simulation_id) -> Optional[Dict]:
+    '''Return the ``simulations`` row for a sim, or ``None`` if missing.
+
+    Result dict has ``simulation_id``, ``name``, ``started_at``,
+    ``composite_config`` (already parsed from JSON), and ``metadata``.
+    '''
+    if not os.path.exists(db_path):
+        return None
+    conn = sqlite3.connect(db_path)
+    try:
+        row = conn.execute(
+            'SELECT simulation_id, name, started_at, composite_config, metadata '
+            'FROM simulations WHERE simulation_id = ?',
+            (simulation_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    if row is None:
+        return None
+    sid, name, started_at, cfg, meta = row
+    return {
+        'simulation_id': sid,
+        'name': name,
+        'started_at': started_at,
+        'composite_config': json.loads(cfg) if cfg else None,
+        'metadata': json.loads(meta) if meta else None,
+    }
+
+
 class SQLiteEmitter(Emitter):
     '''Append simulation state to a SQLite database each timestep.
 
@@ -260,12 +421,17 @@ class SQLiteEmitter(Emitter):
     file is a single ``.db`` file that can be opened with any SQLite client,
     queried with SQL, and kept for long-term storage. Multiple simulations
     can share one file — rows are partitioned by ``simulation_id``.
+
+    To record the composite config or other metadata alongside the history
+    rows, call :func:`save_simulation_metadata` after constructing the
+    Composite — the emitter itself only writes the per-step history rows.
     '''
     config_schema = {
         **Emitter.config_schema,
         'file_path': {'_type': 'string', '_default': './out'},
         'db_file': {'_type': 'string', '_default': 'history.db'},
         'simulation_id': {'_type': 'string', '_default': None},
+        'name': {'_type': 'string', '_default': None},
     }
 
     def __init__(self, config, core):
@@ -276,21 +442,12 @@ class SQLiteEmitter(Emitter):
         self.db_path = os.path.join(self.file_path, config.get('db_file') or 'history.db')
 
         self._conn = sqlite3.connect(self.db_path, isolation_level=None)
-        self._conn.execute('PRAGMA journal_mode=WAL')
-        self._conn.execute('PRAGMA synchronous=NORMAL')
-        self._conn.execute('''
-            CREATE TABLE IF NOT EXISTS history (
-                simulation_id TEXT NOT NULL,
-                step INTEGER NOT NULL,
-                global_time REAL,
-                state TEXT NOT NULL,
-                PRIMARY KEY (simulation_id, step)
-            )
-        ''')
-        self._conn.execute(
-            'CREATE INDEX IF NOT EXISTS idx_history_sim_time '
-            'ON history(simulation_id, global_time)'
-        )
+        _init_history_db(self._conn)
+
+        name = config.get('name')
+        if name is not None:
+            save_simulation_metadata(self.db_path, self.simulation_id, name=name)
+
         self._step = 0
 
     def update(self, state) -> Dict:

--- a/process_bigraph/emitter.py
+++ b/process_bigraph/emitter.py
@@ -8,13 +8,14 @@ Emitters are steps that observe a composite simulation's state and emit data to 
 - Define emitter steps programmatically
 - Insert emitters into a running composite
 - Collect data from emitter steps
-- Implement concrete emitters (RAM, console, JSON)
+- Implement concrete emitters (RAM, console, JSON, SQLite)
 '''
 
 import os
 import json
 import copy
 import uuid
+import sqlite3
 # import pytest
 import numpy as np
 from typing import Dict
@@ -240,6 +241,93 @@ class JSONEmitter(Emitter):
                 results.append(result)
             return results
         return data
+
+
+def _json_default(value):
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, (np.integer,)):
+        return int(value)
+    if isinstance(value, (np.floating,)):
+        return float(value)
+    raise TypeError(f'Object of type {type(value).__name__} is not JSON serializable')
+
+
+class SQLiteEmitter(Emitter):
+    '''Append simulation state to a SQLite database each timestep.
+
+    One row per step, with the full state tree stored as JSON. The database
+    file is a single ``.db`` file that can be opened with any SQLite client,
+    queried with SQL, and kept for long-term storage. Multiple simulations
+    can share one file — rows are partitioned by ``simulation_id``.
+    '''
+    config_schema = {
+        **Emitter.config_schema,
+        'file_path': {'_type': 'string', '_default': './out'},
+        'db_file': {'_type': 'string', '_default': 'history.db'},
+        'simulation_id': {'_type': 'string', '_default': None},
+    }
+
+    def __init__(self, config, core):
+        super().__init__(config, core)
+        self.simulation_id = config.get('simulation_id') or str(uuid.uuid4())
+        self.file_path = config.get('file_path') or './out'
+        os.makedirs(self.file_path, exist_ok=True)
+        self.db_path = os.path.join(self.file_path, config.get('db_file') or 'history.db')
+
+        self._conn = sqlite3.connect(self.db_path, isolation_level=None)
+        self._conn.execute('PRAGMA journal_mode=WAL')
+        self._conn.execute('PRAGMA synchronous=NORMAL')
+        self._conn.execute('''
+            CREATE TABLE IF NOT EXISTS history (
+                simulation_id TEXT NOT NULL,
+                step INTEGER NOT NULL,
+                global_time REAL,
+                state TEXT NOT NULL,
+                PRIMARY KEY (simulation_id, step)
+            )
+        ''')
+        self._conn.execute(
+            'CREATE INDEX IF NOT EXISTS idx_history_sim_time '
+            'ON history(simulation_id, global_time)'
+        )
+        self._step = 0
+
+    def update(self, state) -> Dict:
+        global_time = state.get('global_time') if isinstance(state, dict) else None
+        payload = json.dumps(state, default=_json_default)
+        self._conn.execute(
+            'INSERT OR REPLACE INTO history '
+            '(simulation_id, step, global_time, state) VALUES (?, ?, ?, ?)',
+            (self.simulation_id, self._step, global_time, payload),
+        )
+        self._step += 1
+        return {}
+
+    def query(self, query=None):
+        cursor = self._conn.execute(
+            'SELECT state FROM history WHERE simulation_id = ? ORDER BY step',
+            (self.simulation_id,),
+        )
+        history = [json.loads(row[0]) for row in cursor.fetchall()]
+
+        if isinstance(query, list):
+            results = []
+            for t in history:
+                result = {}
+                for path in query:
+                    element = get_path(t, path)
+                    result = set_path(result, path, element)
+                results.append(result)
+            return results
+        return history
+
+    def __del__(self):
+        try:
+            if getattr(self, '_conn', None) is not None:
+                self._conn.close()
+        except Exception:
+            pass
 
 
 # ====================

--- a/tests.py
+++ b/tests.py
@@ -1277,6 +1277,50 @@ def test_sqlite_emitter_query_paths_kwarg(core):
     e.close()
 
 
+def test_sqlite_emitter_subsample(core):
+    '''subsample=N writes every Nth composite tick (first tick always
+    kept) and preserves the original step number in the stored row.'''
+    tmp = tempfile.mkdtemp(prefix='sqlite_subsample_')
+    e = SQLiteEmitter({
+        'emit': {'global_time': 'node', 'v': 'node'},
+        'file_path': tmp, 'simulation_id': 'sim',
+        'subsample': 5,
+    }, core=core)
+
+    # Feed 20 ticks — ticks at step 0, 5, 10, 15 should land in the db.
+    for i in range(20):
+        e.update({'global_time': float(i), 'v': i})
+    e.close()
+
+    history = load_history(os.path.join(tmp, 'history.db'), 'sim')
+    assert len(history) == 4
+    assert [row['v'] for row in history] == [0, 5, 10, 15]
+    assert [row['global_time'] for row in history] == [0.0, 5.0, 10.0, 15.0]
+
+    # The recorded `step` column is the real composite tick, not a
+    # collapsed index — verify via a direct SQL read.
+    conn = sqlite3.connect(os.path.join(tmp, 'history.db'))
+    try:
+        steps = [r[0] for r in conn.execute(
+            'SELECT step FROM history WHERE simulation_id = ? ORDER BY step',
+            ('sim',),
+        ).fetchall()]
+    finally:
+        conn.close()
+    assert steps == [0, 5, 10, 15]
+
+
+def test_sqlite_emitter_subsample_rejects_bad_value(core):
+    '''subsample < 1 is nonsensical — refuse at construction time.'''
+    tmp = tempfile.mkdtemp(prefix='sqlite_subsample_bad_')
+    with pytest.raises(ValueError):
+        SQLiteEmitter({
+            'emit': {},
+            'file_path': tmp, 'simulation_id': 'sim',
+            'subsample': 0,
+        }, core=core)
+
+
 def test_sqlite_emitter_close(core):
     '''close() should release the connection deterministically, make further
     updates fail loudly, and leave the db usable from a fresh connection.'''

--- a/tests.py
+++ b/tests.py
@@ -1321,6 +1321,70 @@ def test_sqlite_emitter_subsample_rejects_bad_value(core):
         }, core=core)
 
 
+def test_sqlite_emitter_batch_size(core):
+    '''batch_size buffers up to N rows and flushes them in one transaction.
+    Close and query must flush pending rows so no data is lost.'''
+    tmp = tempfile.mkdtemp(prefix='sqlite_batch_')
+    e = SQLiteEmitter({
+        'emit': {'global_time': 'node', 'v': 'node'},
+        'file_path': tmp, 'simulation_id': 'sim',
+        'batch_size': 5,
+    }, core=core)
+
+    db_path = os.path.join(tmp, 'history.db')
+    conn = sqlite3.connect(db_path)
+    try:
+        # Feed 3 rows — below the batch threshold, nothing on disk yet.
+        for i in range(3):
+            e.update({'global_time': float(i), 'v': i})
+        (pending,) = conn.execute(
+            'SELECT COUNT(*) FROM history WHERE simulation_id=?', ('sim',)
+        ).fetchone()
+        assert pending == 0, f'expected 0 rows before flush, got {pending}'
+
+        # query() forces a flush so the reader sees a consistent view.
+        assert len(e.query()) == 3
+        (after_query,) = conn.execute(
+            'SELECT COUNT(*) FROM history WHERE simulation_id=?', ('sim',)
+        ).fetchone()
+        assert after_query == 3
+
+        # Cross a batch boundary: 3 already flushed by query(), feed 5 more
+        # — the 5th triggers auto-flush.
+        for i in range(3, 8):
+            e.update({'global_time': float(i), 'v': i})
+        (after_boundary,) = conn.execute(
+            'SELECT COUNT(*) FROM history WHERE simulation_id=?', ('sim',)
+        ).fetchone()
+        assert after_boundary == 8
+
+        # Remaining buffered rows flush on close().
+        for i in range(8, 10):
+            e.update({'global_time': float(i), 'v': i})
+        e.close()
+        (final,) = conn.execute(
+            'SELECT COUNT(*) FROM history WHERE simulation_id=?', ('sim',)
+        ).fetchone()
+        assert final == 10
+    finally:
+        conn.close()
+
+    # Final sanity check that the data is intact and in order.
+    history = load_history(db_path, 'sim')
+    assert [row['v'] for row in history] == list(range(10))
+
+
+def test_sqlite_emitter_batch_size_rejects_bad_value(core):
+    '''batch_size < 1 makes no sense — refuse at construction.'''
+    tmp = tempfile.mkdtemp(prefix='sqlite_batch_bad_')
+    with pytest.raises(ValueError):
+        SQLiteEmitter({
+            'emit': {},
+            'file_path': tmp, 'simulation_id': 'sim',
+            'batch_size': 0,
+        }, core=core)
+
+
 def test_sqlite_emitter_close(core):
     '''close() should release the connection deterministically, make further
     updates fail loudly, and leave the db usable from a fresh connection.'''

--- a/tests.py
+++ b/tests.py
@@ -1143,6 +1143,53 @@ def test_ram_emitter(core):
     assert 'valueA' in results2[0] and 'valueB' not in results2[0]
     print(results2)
 
+def test_sqlite_emitter(core, tmp_path=None):
+    import tempfile
+    tmp_dir = tmp_path or tempfile.mkdtemp(prefix='sqlite_emitter_')
+    composite_spec = {
+        'increase': {
+            '_type': 'process',
+            'address': 'local:IncreaseProcess',
+            'config': {'rate': 0.3},
+            'interval': 1.0,
+            'inputs': {'level': ['value']},
+            'outputs': {'level': ['value']}}}
+    composite = Composite({'state': composite_spec}, core)
+
+    emitter_spec = {
+        '_type': 'step',
+        'address': 'local:SQLiteEmitter',
+        'config': {
+            'emit': {'global_time': 'node', 'value': 'node'},
+            'file_path': str(tmp_dir),
+            'db_file': 'test_history.db',
+        },
+        'inputs': {'global_time': ['global_time'], 'value': ['value']},
+    }
+    from bigraph_schema import set_path
+    composite.merge({}, set_path({}, ('emitter',), emitter_spec))
+    _, instance = core.traverse(composite.schema, composite.state, ('emitter',))
+    composite.step_paths[('emitter',)] = instance
+    composite.build_step_network()
+
+    composite.run(10)
+
+    results = composite.state['emitter']['instance'].query()
+    assert len(results) >= 10
+    assert results[-1]['global_time'] == 10
+    assert 'value' in results[-1]
+
+    # verify the db file exists and survives re-opening
+    import sqlite3, os
+    db_path = os.path.join(str(tmp_dir), 'test_history.db')
+    assert os.path.exists(db_path)
+    conn = sqlite3.connect(db_path)
+    (count,) = conn.execute('SELECT COUNT(*) FROM history').fetchone()
+    assert count >= 10
+    conn.close()
+    print(results)
+
+
 def test_json_emitter(core):
     composite_spec = {
         'increase': {

--- a/tests.py
+++ b/tests.py
@@ -4,30 +4,37 @@ Tests for Process Bigraph
 =========================
 """
 
+import os
 import sys
 import random
 import inspect
-import numpy as np
+import socket
+import sqlite3
+import tempfile
 
+import numpy as np
 import pytest
 from urllib.parse import urlparse, urlunparse
 
 from bigraph_schema.schema import Path, make_default
-from process_bigraph import allocate_core
+from bigraph_schema import set_path as bs_set_path
 
+from process_bigraph import allocate_core
 from process_bigraph.composite import (
     Process, Step, Composite, merge_collections, match_star_path, as_process, as_step,
 )
-
-from process_bigraph.emitter import emitter_from_wires, gather_emitter_results, add_emitter_to_composite
+from process_bigraph.emitter import (
+    emitter_from_wires, gather_emitter_results, add_emitter_to_composite,
+    SQLiteEmitter,
+    save_simulation_metadata, mark_simulation_finished,
+    list_simulations, load_history, load_simulation_metadata,
+)
 from process_bigraph.protocols.rest import rest_get, rest_post
 from process_bigraph.types import ProcessLink, StepLink
 
 from process_bigraph.processes.examples import IncreaseProcess
 from process_bigraph.processes.growth_division import grow_divide_agent, Grow, Divide
 from process_bigraph.processes.dynamic_structure import DynamicWorker
-
-import socket
 
 
 def _port_open(host: str, port: int, timeout: float = 0.2) -> bool:
@@ -1144,7 +1151,6 @@ def test_ram_emitter(core):
     print(results2)
 
 def test_sqlite_emitter(core, tmp_path=None):
-    import tempfile
     tmp_dir = tmp_path or tempfile.mkdtemp(prefix='sqlite_emitter_')
     composite_spec = {
         'increase': {
@@ -1166,8 +1172,7 @@ def test_sqlite_emitter(core, tmp_path=None):
         },
         'inputs': {'global_time': ['global_time'], 'value': ['value']},
     }
-    from bigraph_schema import set_path
-    composite.merge({}, set_path({}, ('emitter',), emitter_spec))
+    composite.merge({}, bs_set_path({}, ('emitter',), emitter_spec))
     _, instance = core.traverse(composite.schema, composite.state, ('emitter',))
     composite.step_paths[('emitter',)] = instance
     composite.build_step_network()
@@ -1180,14 +1185,124 @@ def test_sqlite_emitter(core, tmp_path=None):
     assert 'value' in results[-1]
 
     # verify the db file exists and survives re-opening
-    import sqlite3, os
     db_path = os.path.join(str(tmp_dir), 'test_history.db')
     assert os.path.exists(db_path)
     conn = sqlite3.connect(db_path)
     (count,) = conn.execute('SELECT COUNT(*) FROM history').fetchone()
     assert count >= 10
     conn.close()
-    print(results)
+
+
+def test_sqlite_emitter_retrieval_helpers(core):
+    '''The standalone helpers must let callers inspect and load a run
+    without touching a Composite or a core — this is the main post-hoc
+    analysis use case.'''
+    tmp = tempfile.mkdtemp(prefix='sqlite_retrieval_')
+    db_path = os.path.join(tmp, 'history.db')
+
+    # Two runs sharing the same db file, plus metadata for one.
+    e1 = SQLiteEmitter({
+        'emit': {'global_time': 'node'},
+        'file_path': tmp, 'simulation_id': 'run-A', 'name': 'alpha',
+    }, core=core)
+    for i in range(4):
+        e1.update({'global_time': float(i)})
+    save_simulation_metadata(
+        db_path, 'run-A',
+        composite_config={'cells': {}},
+        metadata={'experiment': 'alpha', 'notes': 'first run'},
+    )
+    mark_simulation_finished(db_path, 'run-A', elapsed_seconds=12.5)
+    e1.close()
+
+    e2 = SQLiteEmitter({
+        'emit': {'global_time': 'node'},
+        'file_path': tmp, 'simulation_id': 'run-B',
+    }, core=core)
+    for i in range(2):
+        e2.update({'global_time': float(i)})
+    e2.close()
+
+    # list_simulations: ordered newest-first, exposes completion fields.
+    sims = {s['simulation_id']: s for s in list_simulations(db_path)}
+    assert set(sims) == {'run-A', 'run-B'}
+    assert sims['run-A']['step_count'] == 4
+    assert sims['run-A']['elapsed_seconds'] == 12.5
+    assert sims['run-A']['completed_at'] is not None
+    assert sims['run-A']['has_config'] is True
+    # run-B had no metadata row written, so it's reported without config info.
+    assert sims['run-B']['step_count'] == 2
+    assert sims['run-B']['has_config'] is False
+    assert sims['run-B']['elapsed_seconds'] is None
+
+    # load_history: same shape as emitter.query(), unfiltered and filtered.
+    history = load_history(db_path, 'run-A')
+    assert len(history) == 4
+    assert history[-1]['global_time'] == 3.0
+    filtered = load_history(db_path, 'run-A', paths=[['global_time']])
+    assert filtered == [{'global_time': t} for t in (0.0, 1.0, 2.0, 3.0)]
+
+    # load_simulation_metadata: round-trips the composite config + metadata.
+    meta = load_simulation_metadata(db_path, 'run-A')
+    assert meta['name'] == 'alpha'
+    assert meta['composite_config'] == {'cells': {}}
+    assert meta['metadata']['experiment'] == 'alpha'
+    assert meta['elapsed_seconds'] == 12.5
+    assert load_simulation_metadata(db_path, 'nope') is None
+
+
+def test_sqlite_emitter_query_paths_kwarg(core):
+    '''``query()`` should accept the new ``paths`` kwarg and still accept
+    the legacy ``query`` kwarg for back-compat.'''
+    tmp = tempfile.mkdtemp(prefix='sqlite_paths_kwarg_')
+    e = SQLiteEmitter({
+        'emit': {'global_time': 'node', 'a': 'node', 'b': 'node'},
+        'file_path': tmp, 'simulation_id': 'sim',
+    }, core=core)
+    for i in range(3):
+        e.update({'global_time': float(i), 'a': i, 'b': i * 2})
+
+    # Unfiltered.
+    assert len(e.query()) == 3
+
+    # New kwarg.
+    assert e.query(paths=[['a']]) == [{'a': 0}, {'a': 1}, {'a': 2}]
+
+    # Legacy kwarg still honored.
+    assert e.query(query=[['a']]) == [{'a': 0}, {'a': 1}, {'a': 2}]
+
+    # When both are given, ``paths`` wins.
+    assert e.query(paths=[['a']], query=[['b']]) == [{'a': 0}, {'a': 1}, {'a': 2}]
+
+    e.close()
+
+
+def test_sqlite_emitter_close(core):
+    '''close() should release the connection deterministically, make further
+    updates fail loudly, and leave the db usable from a fresh connection.'''
+    tmp = tempfile.mkdtemp(prefix='sqlite_close_')
+    e = SQLiteEmitter({
+        'emit': {'global_time': 'node'},
+        'file_path': tmp, 'simulation_id': 'sim',
+    }, core=core)
+    e.update({'global_time': 0.0})
+    e.close()
+
+    # Idempotent: calling close again is a no-op.
+    e.close()
+
+    # New writes must fail loudly rather than silently dropping data.
+    with pytest.raises(RuntimeError):
+        e.update({'global_time': 1.0})
+
+    # The file is intact and readable via a fresh connection.
+    db_path = os.path.join(tmp, 'history.db')
+    conn = sqlite3.connect(db_path)
+    try:
+        (count,) = conn.execute('SELECT COUNT(*) FROM history').fetchone()
+        assert count == 1
+    finally:
+        conn.close()
 
 
 def test_json_emitter(core):


### PR DESCRIPTION
## Summary
- Add `SQLiteEmitter`: durable, queryable simulation history with a `simulations` table tracking `completed_at` / `elapsed_seconds`, post-hoc retrieval helpers, harmonized query API, `close()`, `subsample` and `batch_size` options, schema-dataclass handling, and Edge filtering.
- Add bundle save/load (`process_bigraph/bundle.py`) and the `doc/emitters.md` topic guide (linked from README).
- Composite refinements: sentinels, triggers, division (`divide` structural updates + realization), compiled view cache, and a serialization cleanup so `serialize` always returns JSON-ready output (no special encode key).

## Test plan
- [ ] `pytest tests.py` passes locally
- [ ] Run an example simulation with `SQLiteEmitter` and verify `simulations` rows + `completed_at` / `elapsed_seconds` populate
- [ ] Exercise `batch_size` and `subsample` options on a high-frequency run
- [ ] Save and reload a bundle round-trip
- [ ] Skim `doc/emitters.md` rendered on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)