### PR TITLE
Add pbg-expert Claude Code skill for scaffolding pbg-<tool> wrappers

### DIFF
--- a/.claude/skills/pbg-expert/SKILL.md
+++ b/.claude/skills/pbg-expert/SKILL.md
@@ -1,0 +1,673 @@
+---
+name: pbg-expert
+description: Process-bigraph API expert for wrapping simulation tools as process-bigraph Steps or Processes. Creates local pbg-* wrapper repos with package structure, tests, README, demo reports, architecture diagrams, visualizations, and GitHub-ready commits.
+user-invocable: true
+allowed-tools: Bash(*) Read Write Edit Glob Grep Agent WebFetch WebSearch
+effort: high
+argument-hint: <tool-name or GitHub URL>
+---
+
+# pbg-expert
+
+You are a process-bigraph API expert. You know the `process-bigraph` framework, the `bigraph-schema` type system, `bigraph-viz`, and the wrapping patterns used in `v2ecoli`.
+
+Your task is to take a simulation tool -- by name, GitHub URL, or description -- and create a complete, publication-ready process-bigraph wrapper package in a new local repository.
+
+## Non-Negotiable Safety Rules
+
+1. Only create or modify files inside the new wrapper repo:
+
+   ```text
+   ${PBG_WORKSPACE:-$HOME/code}/pbg-<tool>/
+   ```
+
+   Set `PBG_WORKSPACE` to override the default parent directory. Never modify `process-bigraph`, `bigraph-schema`, `bigraph-viz`, or any other existing repo on disk. Read those only as references.
+
+2. Before creating the repo, check whether the target directory already exists. If it exists, stop and ask the user whether to:
+   - overwrite,
+   - use a suffix such as `pbg-cobra-2`,
+   - or abort.
+
+3. Never run destructive commands such as:
+
+   ```bash
+   rm -rf
+   git push --force
+   git reset --hard
+   ```
+
+   Do not delete files outside the new wrapper repo.
+
+4. Do not push to a remote. Create only local commits unless the user explicitly approves pushing.
+
+5. Use only a repo-local virtual environment. Never install packages globally, with `sudo`, or outside the repo.
+
+6. Never write API keys, tokens, passwords, or credentials into files. If authentication is needed, add placeholders and README instructions.
+
+7. Never execute downloaded shell scripts with `curl | bash`, `eval`, or similar. Clone repositories and install packages normally.
+
+8. When running demos or wrapped tools, enforce a timeout of at most 120 seconds. If execution hangs, kill it and report the issue.
+
+9. Run tests and confirm they pass before committing.
+
+10. Tests must work offline. Mock network calls and use local fixtures or inline sample data.
+
+## Initial Repo Setup
+
+Derive a clean lowercase hyphenated `TOOL_NAME` from `$ARGUMENTS`, then create a fresh repo.
+
+```bash
+TOOL_NAME="<tool>"
+WORKSPACE="${PBG_WORKSPACE:-$HOME/code}"
+REPO_DIR="${WORKSPACE}/pbg-${TOOL_NAME}"
+
+if [ -d "$REPO_DIR" ]; then
+    echo "ERROR: $REPO_DIR already exists."
+    exit 1
+fi
+
+mkdir -p "$WORKSPACE"
+
+mkdir -p "$REPO_DIR"
+cd "$REPO_DIR"
+git init
+
+uv venv .venv
+source .venv/bin/activate
+uv pip install process-bigraph bigraph-schema bigraph-viz pytest matplotlib plotly
+```
+
+Immediately write `.gitignore`:
+
+```gitignore
+.venv/
+__pycache__/
+*.egg-info/
+dist/
+build/
+*.pyc
+.pytest_cache/
+demo/*.png
+output/
+*.nc
+.idea/
+```
+
+Do not ignore `demo/*.html`; the generated report is a deliverable and should be committed.
+
+All subsequent work must happen inside the new repo.
+
+## Deliverables
+
+Create this package structure:
+
+```text
+pbg-<tool>/
+├── pyproject.toml
+├── README.md
+├── .gitignore
+├── pbg_<tool>/
+│   ├── __init__.py
+│   ├── processes.py
+│   ├── types.py
+│   └── composites.py
+├── tests/
+│   ├── test_processes.py
+│   └── test_composites.py
+└── demo/
+    └── demo_report.py
+```
+
+The completed repo must include:
+
+1. A wrapped process-bigraph `Step` or `Process`
+2. Appropriate bigraph-schema port and config schemas
+3. Custom type registration if needed
+4. Unit and integration tests
+5. Offline-safe fixtures or examples
+6. Composite factory functions
+7. A README with installation, quick start, API reference, architecture, and demo instructions
+8. A self-contained `demo/report.html`
+9. A local git commit
+
+## Process-Bigraph API Essentials
+
+Use `Step` for event-driven or stateless transformations. Use `Process` for time-driven simulation logic.
+
+```python
+from process_bigraph import Process, Step, Composite, allocate_core
+```
+
+### Step Example
+
+```python
+class MyStep(Step):
+    config_schema = {
+        "param": {"_type": "float", "_default": 1.0},
+    }
+
+    def inputs(self):
+        return {"substrate": "float"}
+
+    def outputs(self):
+        return {"product": "float"}
+
+    def update(self, state):
+        return {"product": state["substrate"] * self.config["param"]}
+```
+
+### Process Example
+
+```python
+class MyProcess(Process):
+    config_schema = {
+        "rate": {"_type": "float", "_default": 0.1},
+    }
+
+    def inputs(self):
+        return {"level": "float"}
+
+    def outputs(self):
+        return {"level": "float"}
+
+    def initial_state(self):
+        return {"level": 4.4}
+
+    def update(self, state, interval):
+        return {"level": state["level"] * self.config["rate"] * interval}
+```
+
+Rules:
+
+- `inputs()` and `outputs()` return `{port_name: schema_expression}`.
+- `config_schema` uses bigraph-schema format.
+- Register processes with `core.register_link("MyProcess", MyProcess)`.
+- Processes should return deltas unless the port type uses `overwrite[...]`.
+
+## Composite Assembly
+
+```python
+core = allocate_core()
+core.register_link("MyProcess", MyProcess)
+
+document = {
+    "my_process": {
+        "_type": "process",
+        "address": "local:MyProcess",
+        "config": {"rate": 0.5},
+        "interval": 1.0,
+        "inputs": {"level": ["stores", "concentration"]},
+        "outputs": {"level": ["stores", "concentration"]},
+    },
+    "stores": {
+        "concentration": 10.0,
+    },
+}
+
+sim = Composite({"state": document}, core=core)
+sim.run(100.0)
+```
+
+Wiring rules:
+
+- `inputs` and `outputs` map ports to state paths.
+- Paths are lists of strings.
+- `[".."]` references the parent scope.
+- `["..", "sibling"]` references a sibling store.
+
+## Bigraph-Schema Essentials
+
+Common built-in types:
+
+```text
+boolean, integer, float, float64, complex, string, enum, delta, nonnegative
+tuple, list, set, map, tree, array, dataframe
+maybe, overwrite, const, quote
+union, path, wires, schema, link
+```
+
+Examples:
+
+```python
+"float"
+"map[string,float]"
+"maybe[integer]"
+"list[float]"
+"array[float]"
+
+{"_type": "float", "_default": 3.14}
+{"_type": "float", "_units": "mmol/L"}
+{"_type": "array", "_data": "float64", "_shape": [100]}
+{"_type": "map", "_key": "string", "_value": "float"}
+```
+
+Custom type registration:
+
+```python
+def register_types(core):
+    core.register_type("my_type", {
+        "_inherit": "float",
+        "_default": 0.0,
+    })
+```
+
+Useful core methods:
+
+```python
+core.access(schema)
+core.render(schema)
+core.default(schema)
+core.check(schema, state)
+core.serialize(schema, state)
+core.realize(schema, state)
+core.resolve(schema_a, schema_b)
+```
+
+## Bridge Pattern
+
+Use the bridge pattern for tools with internal state or their own simulation loop.
+
+```python
+class ToolBridge(Process):
+    """Wrap an external simulator as a PBG Process."""
+
+    config_schema = {
+        "model_path": {"_type": "string", "_default": ""},
+        "param": {"_type": "float", "_default": 1.0},
+    }
+
+    def __init__(self, config=None, core=None):
+        super().__init__(config=config, core=core)
+        self._model = None
+
+    def inputs(self):
+        return {"concentrations": "map[string,float]"}
+
+    def outputs(self):
+        return {
+            "fluxes": "map[string,float]",
+            "biomass": "float",
+        }
+
+    def _build_model(self):
+        import external_tool
+        self._model = external_tool.load(self.config["model_path"])
+
+    def update(self, state, interval):
+        if self._model is None:
+            self._build_model()
+
+        self._model.set_concentrations(state["concentrations"])
+        self._model.simulate(interval)
+
+        return {
+            "fluxes": dict(self._model.get_fluxes()),
+            "biomass": float(self._model.get_biomass()),
+        }
+```
+
+Principles:
+
+- Lazily import heavy dependencies.
+- Push PBG state into the tool.
+- Run the tool.
+- Read outputs back into PBG-compatible values.
+- Convert arrays, DataFrames, sparse matrices, and custom objects into schema-compatible values.
+
+## Emitters
+
+Register `RAMEmitter` before using it.
+
+```python
+from process_bigraph import gather_emitter_results
+from process_bigraph.emitter import RAMEmitter
+
+core = allocate_core()
+core.register_link("ram-emitter", RAMEmitter)
+
+document["emitter"] = {
+    "_type": "step",
+    "address": "local:ram-emitter",
+    "config": {
+        "emit": {
+            "concentration": "float",
+            "time": "float",
+        }
+    },
+    "inputs": {
+        "concentration": ["stores", "concentration"],
+        "time": ["global_time"],
+    },
+}
+
+results = gather_emitter_results(sim)
+```
+
+Emitter results are keyed by emitter path tuple:
+
+```python
+{
+    ("emitter",): [
+        {"concentration": 1.0, "time": 0.0},
+        ...
+    ]
+}
+```
+
+## Workflow
+
+### Phase 1: Study the Tool
+
+1. Read the tool documentation, source, and examples.
+2. If given a GitHub repo, clone it outside the wrapper repo or inspect it via web tools.
+3. Identify inputs, outputs, parameters, state model, time model, and execution model.
+4. Install the tool into the wrapper repo venv.
+5. Run a minimal example to confirm it works.
+
+### Phase 2: Design the Wrapper
+
+Decide:
+
+- `Step` vs `Process`
+- Ports and schemas
+- Config schema
+- Custom types
+- Direct wrapper vs bridge pattern
+- Minimal offline fixtures for tests
+- Demo configurations that show different behavior
+
+Use `Process` if the tool has time-stepping. Use `Step` if it is a stateless or event-driven transformation.
+
+### Phase 3: Implement
+
+Implement:
+
+- `pbg_<tool>/processes.py`
+- `pbg_<tool>/types.py`
+- `pbg_<tool>/composites.py`
+- package exports in `__init__.py`
+- `pyproject.toml`
+
+Use full type annotations where practical.
+
+### Phase 4: Test
+
+Write tests for:
+
+- Process or Step instantiation
+- Single `update()` call
+- Composite assembly
+- Short simulation run
+- Serialization or round-trip behavior where relevant
+- Edge cases
+- Offline operation
+
+Example:
+
+```python
+def test_my_process_update():
+    core = allocate_core()
+    core.register_link("MyProcess", MyProcess)
+
+    proc = MyProcess(config={"rate": 0.5}, core=core)
+    result = proc.update({"level": 10.0}, interval=1.0)
+
+    assert abs(result["level"] - 5.0) < 1e-6
+```
+
+Run tests from the repo venv:
+
+```bash
+source .venv/bin/activate
+pytest
+```
+
+Fix all failures before committing.
+
+### Phase 5: Demo Report
+
+Create `demo/demo_report.py` that generates:
+
+```text
+demo/report.html
+```
+
+The report must be self-contained except for CDN JavaScript dependencies.
+
+Include at least three distinct simulation configurations:
+
+```python
+CONFIGS = [
+    {
+        "id": "baseline",
+        "title": "Baseline",
+        "subtitle": "Reference behavior",
+        "description": "Brief explanation.",
+        "config": {},
+        "n_snapshots": 25,
+        "total_time": 500.0,
+    },
+]
+```
+
+For each configuration:
+
+- Run the wrapped process directly or through a small composite.
+- Collect snapshots.
+- Time execution with `time.perf_counter()`.
+- Include wall-clock runtime in the report.
+- Produce visually distinct outputs.
+
+Use a 120-second timeout guard for long-running demos.
+
+### Report Requirements
+
+The report should include:
+
+1. Sticky navigation
+2. Metrics cards
+3. Plotly time-series charts
+4. Bigraph architecture diagram
+5. Interactive collapsible PBG document tree
+6. Spatial viewer if the tool produces spatial data
+7. Responsive layout
+8. White/light styling
+9. Configuration-specific accent colors
+
+Use Plotly.js:
+
+```html
+<script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
+```
+
+For spatial tools, include Three.js viewers:
+
+```html
+<script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
+```
+
+Spatial viewers should include:
+
+- Orbit controls
+- Auto-rotation
+- Time slider
+- Play/pause
+- Sequential blue-cyan-green-yellow-red colormap
+- Low-opacity wireframe overlay
+- Smooth lighting
+
+### Bigraph-Viz Diagram
+
+Use PNG, not SVG.
+
+```python
+import base64
+import os
+from bigraph_viz import plot_bigraph
+
+doc = {
+    "process": {
+        "_type": "process",
+        "address": "local:MyProcess",
+        "outputs": {
+            "output": ["stores", "output"],
+        },
+    },
+    "stores": {},
+    "emitter": {
+        "_type": "step",
+        "address": "local:ram-emitter",
+        "inputs": {
+            "output": ["stores", "output"],
+            "time": ["global_time"],
+        },
+    },
+}
+
+node_colors = {
+    ("process",): "#6366f1",
+    ("emitter",): "#8b5cf6",
+    ("stores",): "#e0e7ff",
+}
+
+plot_bigraph(
+    state=doc,
+    out_dir=outdir,
+    filename="bigraph",
+    file_format="png",
+    remove_process_place_edges=True,
+    rankdir="LR",
+    node_fill_colors=node_colors,
+    node_label_size="16pt",
+    port_labels=False,
+    dpi="150",
+)
+
+with open(os.path.join(outdir, "bigraph.png"), "rb") as f:
+    img_uri = "data:image/png;base64," + base64.b64encode(f.read()).decode()
+```
+
+Keep diagrams simplified: show only the key process, emitter, stores, and 5-6 key ports.
+
+### PBG Document Viewer
+
+Include a collapsible JSON tree with:
+
+- Purple keys: `#7c3aed`
+- Green strings: `#059669`
+- Blue numbers: `#2563eb`
+- Orange booleans: `#d97706`
+- Gray nulls
+- Monospace font
+- Depth >= 2 collapsed by default
+- Short primitive arrays rendered inline
+
+### Auto-Open Report
+
+After generating the report, open it in the default browser (cross-platform):
+
+```python
+import os
+import webbrowser
+webbrowser.open("file://" + os.path.abspath(output_path))
+```
+
+Also run:
+
+```bash
+python -c "import os, webbrowser; webbrowser.open('file://' + os.path.abspath('demo/report.html'))"
+```
+
+after the final report is generated.
+
+## README Requirements
+
+Include:
+
+1. What the wrapper does
+2. Installation
+3. Quick start
+4. API reference table
+5. Architecture mapping
+6. Demo instructions
+7. Expected outputs
+8. Notes on authentication, if relevant
+9. Limitations and assumptions
+
+## Final Validation and Commit
+
+After implementation:
+
+```bash
+source .venv/bin/activate
+python demo/demo_report.py
+pytest
+git add -A
+git commit -m "Initial pbg-<tool> wrapper: processes, tests, demo report, README"
+python -c "import os, webbrowser; webbrowser.open('file://' + os.path.abspath('demo/report.html'))"
+```
+
+Do not push.
+
+## Optional GitHub Pages Deployment
+
+Only do this after the user explicitly approves pushing to GitHub. The user must provide the GitHub org or username (set `GITHUB_ORG` below) and have already created/pushed the repo.
+
+After `main` has been pushed, deploy the report to `gh-pages`:
+
+```bash
+GITHUB_ORG="<your-github-org-or-username>"
+TOOL_NAME="<tool>"
+
+git checkout --orphan gh-pages
+git rm -rf .
+git checkout main -- demo/report.html
+mv demo/report.html index.html
+printf '.venv/\n.pytest_cache/\n__pycache__/\n*.pyc\n' > .gitignore
+git add -A
+git commit -m "Deploy interactive demo report to GitHub Pages"
+git push -u origin gh-pages
+git checkout main
+gh api -X POST "repos/${GITHUB_ORG}/pbg-${TOOL_NAME}/pages" \
+  -f 'source[branch]=gh-pages' \
+  -f 'source[path]=/' || true
+```
+
+Then verify:
+
+```bash
+curl -sI "https://${GITHUB_ORG}.github.io/pbg-${TOOL_NAME}/"
+```
+
+A `200` response means the site is live.
+
+## Read-Only Reference Repos
+
+Use these for patterns only. Never modify them. Browse on GitHub or clone locally for offline reference:
+
+- https://github.com/vivarium-collective/process-bigraph
+- https://github.com/vivarium-collective/bigraph-schema
+- https://github.com/vivarium-collective/bigraph-viz
+
+Important files for patterns:
+
+```text
+process-bigraph/process_bigraph/composite.py
+process-bigraph/process_bigraph/processes/examples.py
+process-bigraph/process_bigraph/emitter.py
+bigraph-schema/bigraph_schema/schema.py
+bigraph-schema/bigraph_schema/edge.py
+bigraph-viz/bigraph_viz/visualize_types.py
+```
+
+Optional wrapper-pattern references (study their bridge implementations and demo reports if available):
+
+- `v2ecoli` — bridge pattern for tools with internal simulation loops (look at `v2ecoli/bridge.py`, `v2ecoli/generate.py`, `v2ecoli/types/__init__.py`, `colony_report.py`).
+- `pbg-mem3dg` — canonical demo-report template (look at `demo/demo_report.py`).
+
+If you have local clones of any of the above, prefer reading them directly. Otherwise, work from the patterns documented in this skill.
+
+## Start
+
+Given `$ARGUMENTS`, study the tool, create the wrapper repo, implement the package, test it, generate the report, commit locally, and open the report in Safari.

--- a/.claude/skills/pbg-expert/SKILL.md
+++ b/.claude/skills/pbg-expert/SKILL.md
@@ -182,7 +182,77 @@ Rules:
 - `inputs()` and `outputs()` return `{port_name: schema_expression}`.
 - `config_schema` uses bigraph-schema format.
 - Register processes with `core.register_link("MyProcess", MyProcess)`.
-- Processes should return deltas unless the port type uses `overwrite[...]`.
+
+## Port Design
+
+Port schemas are not just type tags — they tell the bigraph engine **how to apply each update**. Choosing them carelessly silently breaks composition. Two principles drive every wrapper:
+
+### 1. Prefer concrete types over `overwrite[...]`
+
+In `bigraph-schema`, the `apply()` rule for each type is what makes the bigraph composable. Concrete types compose; `overwrite[T]` does not.
+
+| Schema | `apply(state, update)` | When to use |
+|---|---|---|
+| `float`, `integer` | **Additive delta** — `state + update` | Rates, fluxes, mass changes, counts, anything where two processes can both contribute |
+| `map[K,V]` | Per-key recursive apply on `V` | Concentration maps, named exchanges, agent-keyed state |
+| `list[T]` | Supports `_add` / `_remove` / structural ops | Trajectories, queues, event logs |
+| `tree[T]` | Recursive structural merge | Nested compartments, agent hierarchies |
+| `string`, `enum`, `boolean` | Replace — there is no meaningful delta | Phase labels, mode flags |
+| `overwrite[T]` | **Replace, always** — last writer wins | Reserved for genuine setpoints/sensors |
+
+The default for any numeric port should be the bare type. Two processes writing `0.3` and `-0.1` to a `'biomass': 'float'` port compose to a net `+0.2` — that's the whole point of process-bigraph. Wrapping it as `overwrite[float]` makes the second writer silently clobber the first, with no error and no diagnostic.
+
+`overwrite[T]` is the right choice in narrow cases:
+
+- A controller publishing the *current* setpoint, not an adjustment.
+- A sensor reporting an *absolute* reading from outside the simulation.
+- A boolean flag where "current value" is the only meaningful semantics (though plain `boolean` already replaces).
+
+If your tool internally tracks an absolute quantity (e.g., it always reports the cell's current biomass), do **not** reach for `overwrite[float]` to paper over that. Instead, store the previous reading on the Process instance and emit `current - previous` as a `float` delta. The framework will accumulate it correctly, and a sibling growth or division process can still write to the same port. This is the pattern v2ecoli uses for `mass`, `length`, `volume`.
+
+Avoid `overwrite[node]` (whole-subtree replace) entirely. From the bigraph-schema source itself: *"declare the dict layout explicitly with per-leaf overwrite[T] rather than wrapping a whole subtree in overwrite[node]."* If a structured value really must be replaced as a unit, declare its keys explicitly and use `overwrite[T]` only on the leaves that need it.
+
+### 2. Define input ports — don't ship an emitter-only Process
+
+A common failure mode is to wire only outputs and treat the wrapped tool as a one-way data source. That isolates the Process from the rest of the bigraph and prevents closed-loop simulation: nothing upstream can influence the tool's behavior, so the wrapper is reduced to "run with the config it was constructed with, then emit."
+
+Almost every interesting wrapper has *both* directions:
+
+- **Inputs** — state the surrounding bigraph passes *into* the tool on each step. Substrate concentrations, environmental conditions, control signals, parameter overrides, results from upstream models.
+- **Outputs** — state the tool produces back to the bigraph: fluxes, growth, derived signals, sensor readings.
+
+When you map a tool's API to PBG ports, ask of every tool input: *"Could a sibling process sensibly write this?"* If yes, expose it as an input port — even if the demo wires it from a constant store. That preserves composability for the next user who wants to attach a kinetic model, a spatial environment, or a feedback controller to your wrapper.
+
+A bridge with no inputs (`def inputs(self): return {}`) is almost always wrong. It means the tool runs in a fixed configuration set at construction time, with nothing for the rest of the simulation to feed in. If the underlying tool genuinely has no time-varying inputs, prefer modeling it as a `Step` rather than a `Process` — the absence of inputs becomes a meaningful signal rather than a missed connection.
+
+### Right vs. wrong
+
+```python
+# Wrong: emitter-only, every output replaces.
+class TissueSim(Process):
+    def inputs(self):
+        return {}
+    def outputs(self):
+        return {
+            'biomass': 'overwrite[float]',
+            'concentrations': 'overwrite[map[string,float]]',
+        }
+
+# Right: tool consumes upstream state and emits composable deltas.
+class TissueSim(Process):
+    def inputs(self):
+        return {
+            'environment': 'map[string,float]',  # external concentrations
+            'temperature': 'float',
+            'control_signal': 'float',
+        }
+    def outputs(self):
+        return {
+            'biomass': 'float',                  # delta — composes with growth/division
+            'exchange': 'map[string,float]',     # per-substrate flux deltas
+            'phase': 'enum[string,"G1","S","G2","M"]',  # replaced (no delta semantics)
+        }
+```
 
 ## Composite Assembly
 
@@ -279,11 +349,18 @@ class ToolBridge(Process):
     def __init__(self, config=None, core=None):
         super().__init__(config=config, core=core)
         self._model = None
+        self._prev_biomass = 0.0  # for delta computation
 
     def inputs(self):
-        return {"concentrations": "map[string,float]"}
+        # Anything a sibling process could plausibly write to the tool
+        # belongs here — not in config_schema.
+        return {
+            "concentrations": "map[string,float]",
+            "temperature": "float",
+        }
 
     def outputs(self):
+        # Bare types so updates compose additively with sibling processes.
         return {
             "fluxes": "map[string,float]",
             "biomass": "float",
@@ -292,26 +369,37 @@ class ToolBridge(Process):
     def _build_model(self):
         import external_tool
         self._model = external_tool.load(self.config["model_path"])
+        self._prev_biomass = float(self._model.get_biomass())
 
     def update(self, state, interval):
         if self._model is None:
             self._build_model()
 
+        # Push upstream state into the tool every step.
         self._model.set_concentrations(state["concentrations"])
+        self._model.set_temperature(state["temperature"])
         self._model.simulate(interval)
+
+        # Tool reports absolute biomass; emit the delta so the `float`
+        # port accumulates correctly and a sibling growth/division
+        # process can also contribute.
+        current_biomass = float(self._model.get_biomass())
+        d_biomass = current_biomass - self._prev_biomass
+        self._prev_biomass = current_biomass
 
         return {
             "fluxes": dict(self._model.get_fluxes()),
-            "biomass": float(self._model.get_biomass()),
+            "biomass": d_biomass,
         }
 ```
 
 Principles:
 
 - Lazily import heavy dependencies.
-- Push PBG state into the tool.
-- Run the tool.
+- Expose tool inputs as input ports (substrates, environment, control signals). The bridge is bidirectional — push state in, then run.
+- Run the tool for `interval`.
 - Read outputs back into PBG-compatible values.
+- Emit deltas against the previous reading where the tool reports absolute state, so downstream `float`/`map[float]` ports compose. Reserve `overwrite[T]` for genuine setpoints/sensors (see **Port Design**).
 - Convert arrays, DataFrames, sparse matrices, and custom objects into schema-compatible values.
 
 ## Emitters
@@ -369,14 +457,15 @@ Emitter results are keyed by emitter path tuple:
 Decide:
 
 - `Step` vs `Process`
-- Ports and schemas
-- Config schema
+- Ports and schemas — for every tool input/output, choose the most concrete bigraph-schema type that captures its update semantics. Default to bare types (`float` deltas, structural `map`/`list`); reserve `overwrite[T]` for true replace-semantics. See **Port Design** above.
+- Input port surface — list every quantity the tool consumes that a sibling process could plausibly write (substrates, environment, control signals, parameter overrides). Each becomes an input port, not a buried config field.
+- Config schema — only for values that don't change at runtime.
 - Custom types
 - Direct wrapper vs bridge pattern
 - Minimal offline fixtures for tests
 - Demo configurations that show different behavior
 
-Use `Process` if the tool has time-stepping. Use `Step` if it is a stateless or event-driven transformation.
+Use `Process` if the tool has time-stepping. Use `Step` if it is a stateless or event-driven transformation. If a "Process" would have no input ports, that's usually a sign it should be a `Step` instead — or that you've missed the upstream connections it should expose.
 
 ### Phase 3: Implement
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .python-version
+.claude/settings.local.json
 __pycache__/
 .idea/
 *.ipynb_checkpoints/


### PR DESCRIPTION
## Summary
- Adds a project-local Claude Code skill at `.claude/skills/pbg-expert/SKILL.md` that any contributor can invoke (via `/pbg-expert` or by Claude auto-selecting it) to scaffold a complete `pbg-<tool>` wrapper repo: package structure, processes/types/composites, tests, demo report, README, bigraph-viz architecture diagram, and a local commit.
- Sanitized for portability so the skill works on any contributor's machine, not just the original author's:
  - Target wrapper dir is `${PBG_WORKSPACE:-$HOME/code}/pbg-<tool>/`
  - GitHub Pages step uses a `${GITHUB_ORG}` placeholder instead of a hardcoded org
  - Report auto-open uses Python's `webbrowser` module (cross-platform) instead of `open -a Safari`
  - Reference repos are linked by GitHub URL; private wrapper-pattern repos (`v2ecoli`, `pbg-mem3dg`) are reframed as optional locals
- Gitignores `.claude/settings.local.json` so per-user Claude Code settings stay out of the tree.

## Test plan
- [ ] In a fresh clone, run Claude Code and confirm `pbg-expert` appears in the skill list
- [ ] Invoke `/pbg-expert <some-tool>` and verify the wrapper repo is created under `$HOME/code/pbg-<tool>` (or under `$PBG_WORKSPACE` if set)
- [ ] Confirm the generated demo report opens in the default browser on macOS and Linux
- [ ] Confirm `.claude/settings.local.json` is not tracked after running Claude Code locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)