### PR TITLE
feat(SQLiteEmitter): persist emit schema to simulations table

### DIFF
--- a/process_bigraph/emitter.py
+++ b/process_bigraph/emitter.py
@@ -324,7 +324,8 @@ def _init_history_db(conn):
             completed_at TEXT,
             elapsed_seconds REAL,
             composite_config TEXT,
-            metadata TEXT
+            metadata TEXT,
+            emit_schema TEXT
         )
     ''')
     # Migrate older dbs that predate completed_at / elapsed_seconds.
@@ -333,6 +334,8 @@ def _init_history_db(conn):
         conn.execute('ALTER TABLE simulations ADD COLUMN completed_at TEXT')
     if 'elapsed_seconds' not in existing:
         conn.execute('ALTER TABLE simulations ADD COLUMN elapsed_seconds REAL')
+    if 'emit_schema' not in existing:
+        conn.execute('ALTER TABLE simulations ADD COLUMN emit_schema TEXT')
 
 
 def save_simulation_metadata(db_path, simulation_id, composite_config=None,
@@ -363,6 +366,33 @@ def save_simulation_metadata(db_path, simulation_id, composite_config=None,
                 json.dumps(metadata, default=_json_default) if metadata is not None else None,
             ),
         )
+    finally:
+        conn.close()
+
+
+def load_emit_schema(db_path, simulation_id) -> dict:
+    '''Return the recorded emit schema for one simulation, or {} if missing.
+
+    The schema is whatever was passed as the ``emit`` config to SQLiteEmitter:
+    a mapping of port name -> bigraph-schema type string. Returns an empty
+    dict when the db file doesn't exist, or when no row matches the
+    simulation_id, or when the emit_schema column is NULL.
+    '''
+    if not os.path.exists(db_path):
+        return {}
+    conn = sqlite3.connect(db_path, isolation_level=None)
+    try:
+        _init_history_db(conn)  # ensures column exists for legacy DBs
+        row = conn.execute(
+            'SELECT emit_schema FROM simulations WHERE simulation_id = ?',
+            (simulation_id,),
+        ).fetchone()
+        if not row or not row[0]:
+            return {}
+        try:
+            return json.loads(row[0])
+        except (json.JSONDecodeError, TypeError):
+            return {}
     finally:
         conn.close()
 
@@ -555,6 +585,19 @@ class SQLiteEmitter(Emitter):
 
         self._conn = sqlite3.connect(self.db_path, isolation_level=None)
         _init_history_db(self._conn)
+
+        # Persist emit_schema for this simulation_id (idempotent upsert).
+        emit_schema = config.get('emit') or {}
+        if emit_schema:
+            now_iso = datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+            self._conn.execute(
+                'INSERT INTO simulations '
+                '(simulation_id, started_at, emit_schema) '
+                'VALUES (?, ?, ?) '
+                'ON CONFLICT(simulation_id) DO UPDATE SET '
+                '  emit_schema = excluded.emit_schema',
+                (self.simulation_id, now_iso, json.dumps(emit_schema, default=_json_default)),
+            )
 
         name = config.get('name')
         if name is not None:

--- a/tests.py
+++ b/tests.py
@@ -27,6 +27,7 @@ from process_bigraph.emitter import (
     SQLiteEmitter,
     save_simulation_metadata, mark_simulation_finished,
     list_simulations, load_history, load_simulation_metadata,
+    load_emit_schema,
 )
 from process_bigraph.protocols.rest import rest_get, rest_post
 from process_bigraph.types import ProcessLink, StepLink
@@ -2144,6 +2145,39 @@ def test_partial_process_link_update(core):
     assert after['config'] == original_config
     assert after['inputs'] == original_inputs
     assert after['outputs'] == original_outputs
+
+
+def test_sqlite_emitter_persists_schema(core, tmp_path):
+    '''emit_schema must be round-tripped to / from the simulations table.'''
+    emit = {'level': 'float', 'time': 'float'}
+    e = SQLiteEmitter({
+        'emit': emit,
+        'file_path': str(tmp_path),
+        'db_file': 'history.db',
+        'simulation_id': 'sim-schema-1',
+    }, core=core)
+    e.close()
+    db = str(tmp_path / 'history.db')
+    schema = load_emit_schema(db, 'sim-schema-1')
+    assert schema == emit
+
+
+def test_load_emit_schema_returns_empty_for_missing_run(core, tmp_path):
+    '''load_emit_schema returns {} for an unknown simulation_id.'''
+    SQLiteEmitter({
+        'emit': {'level': 'float'},
+        'file_path': str(tmp_path),
+        'db_file': 'history.db',
+        'simulation_id': 'sim-schema-2',
+    }, core=core).close()
+    db = str(tmp_path / 'history.db')
+    assert load_emit_schema(db, 'no-such-sim') == {}
+
+
+def test_load_emit_schema_returns_empty_when_db_missing(tmp_path):
+    '''load_emit_schema returns {} when the db file does not exist.'''
+    db = str(tmp_path / 'never-created.db')
+    assert load_emit_schema(db, 'sim-1') == {}
 
 
 def make_test_core():


### PR DESCRIPTION
## Summary

Adds an \`emit_schema TEXT\` column to the SQLite emitter's \`simulations\` table
and persists the emitter's \`emit\` config there at init time. New helper
\`load_emit_schema(db_path, simulation_id) -> dict\` returns the parsed schema
without instantiating an Emitter.

## Motivation

Downstream tooling (process-bigraph workspaces using the Investigations
dashboard) need to introspect what observables a recorded run emits and
their types — to type-check post-hoc visualizations against the data, render
the right plots, and surface errors when a visualization expects an
observable the run didn't emit. Today they have to infer schema from the
first history row, which is fragile (string-typed observables look the same
as JSON-stringified scalars; map-typed observables are hard to distinguish
from nested state). Persisting the schema at init time gives downstream
consumers a single source of truth.

## What changed

- \`_init_history_db\`: \`simulations\` table grows an \`emit_schema TEXT\`
  column. ALTER TABLE migration for existing DBs follows the existing
  \`completed_at\` / \`elapsed_seconds\` pattern.
- \`SQLiteEmitter.__init__\`: after schema bootstrap, writes
  \`config.get('emit')\` as JSON into the row for its \`simulation_id\`,
  via \`INSERT ... ON CONFLICT DO UPDATE\`.
- New module-level helper \`load_emit_schema(db_path, simulation_id) -> dict\`.

## Test plan

- [x] \`test_sqlite_emitter_persists_schema\` — round-trips a 2-key schema.
- [x] \`test_load_emit_schema_returns_empty_for_missing_run\` — unknown
      simulation_id returns \`{}\`.
- [x] \`test_load_emit_schema_returns_empty_when_db_missing\` — missing
      file returns \`{}\`.
- [x] Existing emitter tests pass (7 pre-existing failures on main are unrelated).

No API changes to existing entry points — purely additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)