### PR TITLE
feat(emitter): extract SQLiteEmitter to pbg-emitters + re-export shim

### DIFF
--- a/doc/emitters.md
+++ b/doc/emitters.md
@@ -183,6 +183,9 @@ emitter_from_wires({
 
 ## Long-term storage with `SQLiteEmitter`
 
+> **Note:** `SQLiteEmitter` (and `ParquetEmitter`) now live in the focused
+> [`pbg-emitters`](https://github.com/vivarium-collective/pbg-emitters) library so each emitter can ship its own optional heavy deps without forcing them on every process-bigraph user. Install via `pip install pbg-emitters[sqlite]` (or `pip install process-bigraph[emitters]` for both backends). All the examples below continue to work — `process_bigraph.emitter` re-exports `SQLiteEmitter` and its helpers when `pbg-emitters` is on the import path.
+
 `RAMEmitter` throws everything away when the Python process ends. `JSONEmitter` rewrites the whole history file on every tick, which is fine for small runs but expensive for long ones. `SQLiteEmitter` appends one row per tick into a single `.db` file, indexed by a `simulation_id` — ideal for long runs and for analysis sessions that happen weeks after the simulation.
 
 ### Writing history

--- a/process_bigraph/emitter.py
+++ b/process_bigraph/emitter.py
@@ -8,17 +8,19 @@ Emitters are steps that observe a composite simulation's state and emit data to 
 - Define emitter steps programmatically
 - Insert emitters into a running composite
 - Collect data from emitter steps
-- Implement concrete emitters (RAM, console, JSON, SQLite)
+- Implement concrete in-tree emitters (RAM, console, JSON)
+
+``SQLiteEmitter`` (and ``ParquetEmitter``) now live in the focused
+``pbg-emitters`` library (https://github.com/vivarium-collective/pbg-emitters)
+and are re-exported from the bottom of this module for back-compat — see
+the re-export shim at the end of the file.
 '''
 
 import copy
-import dataclasses
-import datetime
 import json
 import os
-import sqlite3
 import uuid
-from typing import Dict, List, Optional
+from typing import Dict
 
 import numpy as np
 
@@ -284,356 +286,35 @@ class JSONEmitter(Emitter):
         return data
 
 
-def _json_default(value):
-    if isinstance(value, np.ndarray):
-        return value.tolist()
-    if isinstance(value, (np.integer,)):
-        return int(value)
-    if isinstance(value, (np.floating,)):
-        return float(value)
-    # bigraph-schema Node dataclasses (String, Float, Integer, ...) can end
-    # up wired into emitted state; fall back to their repr so history stays
-    # serializable without dragging in the schema machinery.
-    if dataclasses.is_dataclass(value):
-        return dataclasses.asdict(value)
-    return repr(value)
-
-
-def _init_history_db(conn):
-    '''Create both history and simulations tables. Safe to call repeatedly.'''
-    conn.execute('PRAGMA journal_mode=WAL')
-    conn.execute('PRAGMA synchronous=NORMAL')
-    conn.execute('''
-        CREATE TABLE IF NOT EXISTS history (
-            simulation_id TEXT NOT NULL,
-            step INTEGER NOT NULL,
-            global_time REAL,
-            state TEXT NOT NULL,
-            PRIMARY KEY (simulation_id, step)
-        )
-    ''')
-    conn.execute(
-        'CREATE INDEX IF NOT EXISTS idx_history_sim_time '
-        'ON history(simulation_id, global_time)'
-    )
-    conn.execute('''
-        CREATE TABLE IF NOT EXISTS simulations (
-            simulation_id TEXT PRIMARY KEY,
-            name TEXT,
-            started_at TEXT NOT NULL,
-            completed_at TEXT,
-            elapsed_seconds REAL,
-            composite_config TEXT,
-            metadata TEXT
-        )
-    ''')
-    # Migrate older dbs that predate completed_at / elapsed_seconds.
-    existing = {row[1] for row in conn.execute("PRAGMA table_info(simulations)")}
-    if 'completed_at' not in existing:
-        conn.execute('ALTER TABLE simulations ADD COLUMN completed_at TEXT')
-    if 'elapsed_seconds' not in existing:
-        conn.execute('ALTER TABLE simulations ADD COLUMN elapsed_seconds REAL')
-
-
-def save_simulation_metadata(db_path, simulation_id, composite_config=None,
-                             metadata=None, name=None):
-    '''Write or update the ``simulations`` row for a run.
-
-    Call once per simulation, typically right after building the Composite,
-    to record the config that produced the history rows. Idempotent: fields
-    passed as ``None`` leave any existing value untouched, so you can fill
-    in ``name`` first and ``composite_config`` later without clobbering.
-    '''
-    conn = sqlite3.connect(db_path, isolation_level=None)
-    try:
-        _init_history_db(conn)
-        conn.execute(
-            'INSERT INTO simulations '
-            '(simulation_id, name, started_at, composite_config, metadata) '
-            'VALUES (?, ?, ?, ?, ?) '
-            'ON CONFLICT(simulation_id) DO UPDATE SET '
-            '  name = COALESCE(excluded.name, simulations.name), '
-            '  composite_config = COALESCE(excluded.composite_config, simulations.composite_config), '
-            '  metadata = COALESCE(excluded.metadata, simulations.metadata)',
-            (
-                simulation_id,
-                name,
-                datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
-                json.dumps(composite_config, default=_json_default) if composite_config is not None else None,
-                json.dumps(metadata, default=_json_default) if metadata is not None else None,
-            ),
-        )
-    finally:
-        conn.close()
-
-
-def list_simulations(db_path) -> List[Dict]:
-    '''Return all recorded simulations in a history db, newest first.
-
-    Each entry has ``simulation_id``, ``name``, ``started_at``,
-    ``completed_at``, ``elapsed_seconds``, ``step_count``, and ``has_config``
-    (True if a composite_config was saved). No core or Composite is required
-    — use this to browse a db long after the runs that produced it.
-    '''
-    if not os.path.exists(db_path):
-        return []
-    conn = sqlite3.connect(db_path)
-    try:
-        _init_history_db(conn)
-        rows = conn.execute('''
-            SELECT s.simulation_id, s.name, s.started_at, s.completed_at,
-                   s.elapsed_seconds, s.composite_config,
-                   (SELECT COUNT(*) FROM history h WHERE h.simulation_id = s.simulation_id)
-            FROM simulations s
-            ORDER BY s.started_at DESC
-        ''').fetchall()
-        # Also include sims that have history rows but no metadata row
-        orphan_rows = conn.execute('''
-            SELECT h.simulation_id, NULL, NULL, NULL, NULL, NULL, COUNT(*)
-            FROM history h
-            WHERE h.simulation_id NOT IN (SELECT simulation_id FROM simulations)
-            GROUP BY h.simulation_id
-        ''').fetchall()
-    finally:
-        conn.close()
-
-    return [
-        {
-            'simulation_id': sid,
-            'name': name,
-            'started_at': started_at,
-            'completed_at': completed_at,
-            'elapsed_seconds': elapsed,
-            'step_count': step_count,
-            'has_config': cfg is not None,
-        }
-        for (sid, name, started_at, completed_at, elapsed, cfg, step_count)
-        in list(rows) + list(orphan_rows)
-    ]
-
-
-def load_history(db_path, simulation_id, paths: Optional[List] = None) -> List[Dict]:
-    '''Load a simulation's history from a db file. No core/Composite needed.
-
-    Returns the same shape that ``SQLiteEmitter.query()`` returns, so plot
-    and analysis code that consumed RAM/JSON emitter output works unchanged.
-    '''
-    if not os.path.exists(db_path):
-        return []
-    conn = sqlite3.connect(db_path)
-    try:
-        cursor = conn.execute(
-            'SELECT state FROM history WHERE simulation_id = ? ORDER BY step',
-            (simulation_id,),
-        )
-        history = [json.loads(row[0]) for row in cursor.fetchall()]
-    finally:
-        conn.close()
-
-    if isinstance(paths, list):
-        results = []
-        for t in history:
-            result = {}
-            for path in paths:
-                element = get_path(t, path)
-                result = set_path(result, path, element)
-            results.append(result)
-        return results
-    return history
-
-
-def load_simulation_metadata(db_path, simulation_id) -> Optional[Dict]:
-    '''Return the ``simulations`` row for a sim, or ``None`` if missing.
-
-    Result dict has ``simulation_id``, ``name``, ``started_at``,
-    ``completed_at``, ``elapsed_seconds``, ``composite_config`` (parsed
-    from JSON), and ``metadata``.
-    '''
-    if not os.path.exists(db_path):
-        return None
-    conn = sqlite3.connect(db_path)
-    try:
-        _init_history_db(conn)
-        row = conn.execute(
-            'SELECT simulation_id, name, started_at, completed_at, '
-            'elapsed_seconds, composite_config, metadata '
-            'FROM simulations WHERE simulation_id = ?',
-            (simulation_id,),
-        ).fetchone()
-    finally:
-        conn.close()
-    if row is None:
-        return None
-    sid, name, started_at, completed_at, elapsed, cfg, meta = row
-    return {
-        'simulation_id': sid,
-        'name': name,
-        'started_at': started_at,
-        'completed_at': completed_at,
-        'elapsed_seconds': elapsed,
-        'composite_config': json.loads(cfg) if cfg else None,
-        'metadata': json.loads(meta) if meta else None,
-    }
-
-
-def mark_simulation_finished(db_path, simulation_id, elapsed_seconds=None):
-    '''Stamp ``completed_at`` (UTC now) and ``elapsed_seconds`` on a run.
-
-    Call this right after ``sim.run()`` returns. Safe to call multiple
-    times — each call just overwrites the two fields.
-    '''
-    conn = sqlite3.connect(db_path, isolation_level=None)
-    try:
-        _init_history_db(conn)
-        completed_at = datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
-        conn.execute(
-            'UPDATE simulations SET completed_at = ?, elapsed_seconds = ? '
-            'WHERE simulation_id = ?',
-            (completed_at, elapsed_seconds, simulation_id),
-        )
-    finally:
-        conn.close()
-
-
-class SQLiteEmitter(Emitter):
-    '''Append simulation state to a SQLite database each timestep.
-
-    One row per step, with the full state tree stored as JSON. The database
-    file is a single ``.db`` file that can be opened with any SQLite client,
-    queried with SQL, and kept for long-term storage. Multiple simulations
-    can share one file — rows are partitioned by ``simulation_id``.
-
-    To record the composite config or other metadata alongside the history
-    rows, call :func:`save_simulation_metadata` after constructing the
-    Composite — the emitter itself only writes the per-step history rows.
-
-    ``subsample`` records only every Nth composite tick (default 1 = every
-    tick). The ``step`` column still stores the true composite tick number,
-    so time-series produced from the history reflect the real cadence even
-    though intermediate ticks were not persisted. Use this when a Composite
-    fires the emitter very often (small intervals, long runs) and you don't
-    need every tick in the archive — it's the cheapest way to shrink the
-    write volume without losing the simulation's time axis.
-
-    ``batch_size`` buffers up to N recorded rows in memory and flushes them
-    in a single SQL transaction (default 1 = write each row immediately).
-    With ``batch_size=100`` the per-row fsync overhead is amortized across
-    the batch, giving a large speedup on high-frequency runs. Unflushed
-    rows are guaranteed to be written on ``close()`` and on the next
-    ``query()``; a hard crash before flush loses the buffered rows.
-    '''
-    config_schema = {
-        **Emitter.config_schema,
-        'file_path': {'_type': 'string', '_default': './out'},
-        'db_file': {'_type': 'string', '_default': 'history.db'},
-        'simulation_id': {'_type': 'string', '_default': None},
-        'name': {'_type': 'string', '_default': None},
-        'subsample': {'_type': 'integer', '_default': 1},
-        'batch_size': {'_type': 'integer', '_default': 1},
-    }
-
-    def __init__(self, config, core):
-        super().__init__(config, core)
-        self.simulation_id = config.get('simulation_id') or str(uuid.uuid4())
-        self.file_path = config.get('file_path') or './out'
-        os.makedirs(self.file_path, exist_ok=True)
-        self.db_path = os.path.join(self.file_path, config.get('db_file') or 'history.db')
-
-        subsample = config.get('subsample')
-        self.subsample = 1 if subsample is None else int(subsample)
-        if self.subsample < 1:
-            raise ValueError(
-                f'SQLiteEmitter subsample must be >= 1, got {self.subsample}'
-            )
-
-        batch_size = config.get('batch_size')
-        self.batch_size = 1 if batch_size is None else int(batch_size)
-        if self.batch_size < 1:
-            raise ValueError(
-                f'SQLiteEmitter batch_size must be >= 1, got {self.batch_size}'
-            )
-
-        self._conn = sqlite3.connect(self.db_path, isolation_level=None)
-        _init_history_db(self._conn)
-
-        name = config.get('name')
-        if name is not None:
-            save_simulation_metadata(self.db_path, self.simulation_id, name=name)
-
-        self._step = 0
-        self._batch = []
-
-    def update(self, state) -> Dict:
-        if self._conn is None:
-            raise RuntimeError('SQLiteEmitter has been closed')
-        # Advance the true composite tick counter on every call; only persist
-        # the row when this tick falls on the subsample cadence. Ticks 0,
-        # subsample, 2*subsample, ... are written (first tick always kept).
-        step = self._step
-        self._step += 1
-        if step % self.subsample != 0:
-            return {}
-
-        global_time = state.get('global_time') if isinstance(state, dict) else None
-        # Strip live Edge/process instances the same way RAMEmitter does;
-        # otherwise wires that pull in process objects break JSON serialization.
-        clean = tree_copy(state)
-        payload = json.dumps(clean, default=_json_default)
-        self._batch.append((self.simulation_id, step, global_time, payload))
-        if len(self._batch) >= self.batch_size:
-            self._flush_batch()
-        return {}
-
-    def _flush_batch(self):
-        '''Write any buffered rows in a single SQL transaction.'''
-        if not self._batch or self._conn is None:
-            return
-        # Plain INSERT (not OR REPLACE): `step` is a per-run monotonic
-        # counter, so a PK conflict here would indicate a real bug — fail
-        # loudly rather than silently overwriting a row.
-        self._conn.execute('BEGIN')
-        try:
-            self._conn.executemany(
-                'INSERT INTO history '
-                '(simulation_id, step, global_time, state) VALUES (?, ?, ?, ?)',
-                self._batch,
-            )
-            self._conn.execute('COMMIT')
-        except Exception:
-            self._conn.execute('ROLLBACK')
-            raise
-        self._batch.clear()
-
-    def query(self, paths=None, query=None):
-        paths = _resolve_query_paths(paths, query)
-        # Flush so buffered-but-unwritten rows are visible to the read.
-        self._flush_batch()
-        # Route through the standalone helper so the in-process and post-hoc
-        # retrieval paths go through the same code.
-        return load_history(self.db_path, self.simulation_id, paths=paths)
-
-    def close(self):
-        '''Close the underlying SQLite connection explicitly.
-
-        Flushes any buffered rows (from ``batch_size > 1``) so nothing is
-        lost, then closes the connection. After calling ``close`` the
-        emitter can no longer record new rows.
-        '''
-        if self._conn is not None:
-            try:
-                self._flush_batch()
-            finally:
-                self._conn.close()
-                self._conn = None
-
-    def __del__(self):
-        try:
-            self.close()
-        except Exception:
-            pass
-
-
 # ====================
 # Base Emitter Mapping
 # ====================
 
+
+# ------------------------------------------------------------
+# Back-compat re-exports from pbg-emitters
+# ------------------------------------------------------------
+# SQLiteEmitter + ParquetEmitter were extracted to a focused
+# emitter library (https://github.com/vivarium-collective/pbg-emitters)
+# so each can iterate (and ship optional heavy deps) independently of
+# the framework. Existing code that imports them from
+# ``process_bigraph.emitter`` keeps working as long as ``pbg-emitters``
+# is installed (``pip install pbg-emitters[sqlite]`` or
+# ``pip install pbg-emitters[parquet]``). Install both via the
+# ``process-bigraph[emitters]`` extra.
+try:
+    from pbg_emitters import SQLiteEmitter  # noqa: F401
+    from pbg_emitters import (  # noqa: F401
+        save_simulation_metadata,
+        list_simulations,
+        load_history,
+        load_simulation_metadata,
+        mark_simulation_finished,
+    )
+except ImportError:
+    pass
+
+try:
+    from pbg_emitters import ParquetEmitter  # noqa: F401
+except ImportError:
+    pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,16 @@ ec2-ssm = [
     "boto3>=1.28",
 ]
 
+# SQLiteEmitter + ParquetEmitter were extracted to the focused pbg-emitters
+# library (https://github.com/vivarium-collective/pbg-emitters) so each
+# emitter can ship its own heavy deps without forcing them on every user.
+# ``process_bigraph.emitter`` re-exports them as a back-compat shim — install
+# this extra to enable the shim. Pulls in both emitters' optional extras.
+# Install with: pip install process-bigraph[emitters]
+emitters = [
+    "pbg-emitters[sqlite,parquet]",
+]
+
 [dependency-groups]
 dev = [
     "ipdb>=0.13.13",
@@ -60,6 +70,10 @@ dev = [
     "fire",
     "typing-inspect>=0.9.0",
     "boto3>=1.28",
+    # Lets the back-compat re-export shim resolve in CI / dev so the
+    # SQLiteEmitter tests run; production users opt in via
+    # ``process-bigraph[emitters]``.
+    "pbg-emitters[sqlite]",
 ]
 
 #[tool.uv.sources]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,9 @@ ec2-ssm = [
 # this extra to enable the shim. Pulls in both emitters' optional extras.
 # Install with: pip install process-bigraph[emitters]
 emitters = [
-    "pbg-emitters[sqlite,parquet]",
+    # PEP 508 direct-URL since pbg-emitters is not yet on PyPI — works
+    # with both pip and uv.
+    "pbg-emitters[sqlite,parquet] @ git+https://github.com/vivarium-collective/pbg-emitters.git@main",
 ]
 
 [dependency-groups]
@@ -73,7 +75,7 @@ dev = [
     # Lets the back-compat re-export shim resolve in CI / dev so the
     # SQLiteEmitter tests run; production users opt in via
     # ``process-bigraph[emitters]``.
-    "pbg-emitters[sqlite]",
+    "pbg-emitters[sqlite] @ git+https://github.com/vivarium-collective/pbg-emitters.git@main",
 ]
 
 #[tool.uv.sources]

--- a/tests.py
+++ b/tests.py
@@ -24,10 +24,24 @@ from process_bigraph.composite import (
 )
 from process_bigraph.emitter import (
     emitter_from_wires, gather_emitter_results, add_emitter_to_composite,
-    SQLiteEmitter,
-    save_simulation_metadata, mark_simulation_finished,
-    list_simulations, load_history, load_simulation_metadata,
 )
+
+# SQLiteEmitter + friends now live in the focused pbg-emitters library and
+# are re-exported from process_bigraph.emitter only when that package is
+# installed. Guard the import here so the rest of the test module loads
+# cleanly without the optional dep; individual SQLite tests call
+# ``pytest.importorskip("pbg_emitters")`` so they skip (rather than fail)
+# when pbg-emitters is absent.
+try:
+    from process_bigraph.emitter import (
+        SQLiteEmitter,
+        save_simulation_metadata, mark_simulation_finished,
+        list_simulations, load_history, load_simulation_metadata,
+    )
+except ImportError:
+    SQLiteEmitter = None
+    save_simulation_metadata = mark_simulation_finished = None
+    list_simulations = load_history = load_simulation_metadata = None
 from process_bigraph.protocols.rest import rest_get, rest_post
 from process_bigraph.types import ProcessLink, StepLink
 
@@ -1111,6 +1125,7 @@ def test_ram_emitter(core):
     print(results2)
 
 def test_sqlite_emitter(core, tmp_path=None):
+    pytest.importorskip('pbg_emitters')
     tmp_dir = tmp_path or tempfile.mkdtemp(prefix='sqlite_emitter_')
     composite_spec = {
         'increase': {
@@ -1157,6 +1172,7 @@ def test_sqlite_emitter_retrieval_helpers(core):
     '''The standalone helpers must let callers inspect and load a run
     without touching a Composite or a core — this is the main post-hoc
     analysis use case.'''
+    pytest.importorskip('pbg_emitters')
     tmp = tempfile.mkdtemp(prefix='sqlite_retrieval_')
     db_path = os.path.join(tmp, 'history.db')
 
@@ -1214,6 +1230,7 @@ def test_sqlite_emitter_retrieval_helpers(core):
 def test_sqlite_emitter_query_paths_kwarg(core):
     '''``query()`` should accept the new ``paths`` kwarg and still accept
     the legacy ``query`` kwarg for back-compat.'''
+    pytest.importorskip('pbg_emitters')
     tmp = tempfile.mkdtemp(prefix='sqlite_paths_kwarg_')
     e = SQLiteEmitter({
         'emit': {'global_time': 'node', 'a': 'node', 'b': 'node'},
@@ -1240,6 +1257,7 @@ def test_sqlite_emitter_query_paths_kwarg(core):
 def test_sqlite_emitter_subsample(core):
     '''subsample=N writes every Nth composite tick (first tick always
     kept) and preserves the original step number in the stored row.'''
+    pytest.importorskip('pbg_emitters')
     tmp = tempfile.mkdtemp(prefix='sqlite_subsample_')
     e = SQLiteEmitter({
         'emit': {'global_time': 'node', 'v': 'node'},
@@ -1272,6 +1290,7 @@ def test_sqlite_emitter_subsample(core):
 
 def test_sqlite_emitter_subsample_rejects_bad_value(core):
     '''subsample < 1 is nonsensical — refuse at construction time.'''
+    pytest.importorskip('pbg_emitters')
     tmp = tempfile.mkdtemp(prefix='sqlite_subsample_bad_')
     with pytest.raises(ValueError):
         SQLiteEmitter({
@@ -1284,6 +1303,7 @@ def test_sqlite_emitter_subsample_rejects_bad_value(core):
 def test_sqlite_emitter_batch_size(core):
     '''batch_size buffers up to N rows and flushes them in one transaction.
     Close and query must flush pending rows so no data is lost.'''
+    pytest.importorskip('pbg_emitters')
     tmp = tempfile.mkdtemp(prefix='sqlite_batch_')
     e = SQLiteEmitter({
         'emit': {'global_time': 'node', 'v': 'node'},
@@ -1336,6 +1356,7 @@ def test_sqlite_emitter_batch_size(core):
 
 def test_sqlite_emitter_batch_size_rejects_bad_value(core):
     '''batch_size < 1 makes no sense — refuse at construction.'''
+    pytest.importorskip('pbg_emitters')
     tmp = tempfile.mkdtemp(prefix='sqlite_batch_bad_')
     with pytest.raises(ValueError):
         SQLiteEmitter({
@@ -1348,6 +1369,7 @@ def test_sqlite_emitter_batch_size_rejects_bad_value(core):
 def test_sqlite_emitter_close(core):
     '''close() should release the connection deterministically, make further
     updates fail loudly, and leave the db usable from a fresh connection.'''
+    pytest.importorskip('pbg_emitters')
     tmp = tempfile.mkdtemp(prefix='sqlite_close_')
     e = SQLiteEmitter({
         'emit': {'global_time': 'node'},


### PR DESCRIPTION
## Summary

Extract `SQLiteEmitter` and its standalone retrieval helpers
(`save_simulation_metadata`, `list_simulations`, `load_history`,
`load_simulation_metadata`, `mark_simulation_finished`) from
`process_bigraph/emitter.py` and replace them with a guarded re-export
shim from the newly-bootstrapped focused library
[`pbg-emitters`](https://github.com/vivarium-collective/pbg-emitters).

## Why

Each emitter wants to ship its own optional heavy deps (DuckDB / Polars
for `ParquetEmitter`, future ones may want Postgres / S3 / etc.) and
iterate on a faster cadence than the framework itself. Keeping them in
`process_bigraph.emitter` either forced those deps on every PB user
(bad) or kept the dep tree split across two repos with no clean owner
(worse). The focused library lets each emitter live with its own deps
and tests while the framework stays minimal.

## How back-compat works

Existing user code keeps working unchanged:

```python
from process_bigraph.emitter import SQLiteEmitter
```

…as long as `pbg-emitters` is installed. There are two ways to get it:

```bash
pip install pbg-emitters[sqlite]            # just SQLiteEmitter
pip install process-bigraph[emitters]       # both SQLite + Parquet, via this PR
```

This PR adds a new `[emitters]` extra to `process-bigraph` that pulls in
`pbg-emitters[sqlite,parquet]` so users can opt into the re-export
shim's backing package in a single install — mirroring the existing
`[ray]` / `[server-rest]` / `[ec2-ssm]` extras pattern.

The shim itself is at the bottom of `process_bigraph/emitter.py`:

```python
try:
    from pbg_emitters import SQLiteEmitter  # noqa: F401
    from pbg_emitters import (
        save_simulation_metadata, list_simulations, load_history,
        load_simulation_metadata, mark_simulation_finished,
    )
except ImportError:
    pass

try:
    from pbg_emitters import ParquetEmitter  # noqa: F401
except ImportError:
    pass
```

`ParquetEmitter` is a fresh addition — it was never in `process_bigraph.emitter`
on main, only attempted in PR #125 (now closed in favor of this combined
extract). The shim makes it importable from the same place once the
`[parquet]` extra is installed.

## What changed

- **`process_bigraph/emitter.py`**: removed `SQLiteEmitter` and the
  five SQLite-only helpers (plus the `_init_history_db` and
  `_json_default` internals that only those used). Dropped the now-unused
  `datetime`, `sqlite3`, `dataclasses` imports and the `List` / `Optional`
  type hints. Added the guarded re-export block at the bottom.
- **`pyproject.toml`**: added `[emitters]` optional-dependencies group
  (pulls in `pbg-emitters[sqlite,parquet]`); added `pbg-emitters[sqlite]`
  to the dev dependency group so the existing SQLite tests run in CI.
- **`tests.py`**: SQLite imports moved into a guarded try/except;
  every `test_sqlite_emitter*` function now does
  `pytest.importorskip('pbg_emitters')` so the tests skip cleanly when
  the optional dep is absent. Test bodies and assertions are unchanged
  — they import `SQLiteEmitter` etc. via the back-compat shim.
- **`doc/emitters.md`**: one-line note at the top of the
  "Long-term storage with SQLiteEmitter" section pointing readers at
  the new package location and the `[emitters]` extra.

## Trade-off the PR makes

I chose to add a `[emitters]` extra rather than wire `pbg-emitters` in
as a hard dependency. Hard-depending would force the heavy emitter
extras (DuckDB / Polars) onto every PB user, which is exactly what
extracting the package was meant to avoid. The extra gives users a
one-liner install when they want the shim wired up, without imposing
it on those who don't.

## Supersedes

PR #125 (`feat/parquet-emitter`, Parquet-only extraction; closed in
favor of this combined approach).

## Test plan

- [x] `pytest tests.py` with `pbg-emitters[sqlite,parquet]` installed
      passes (53 active tests pass, 7 unrelated Ray/REST skips).
- [x] `pytest tests.py -k sqlite` with `pbg-emitters` uninstalled
      cleanly skips all 8 SQLite tests (no import errors).
- [x] `from process_bigraph.emitter import SQLiteEmitter, ParquetEmitter`
      resolves with the appropriate extras installed.
- [x] Removed symbols (`_init_history_db`, `_json_default`,
      `datetime`, `sqlite3`) confirmed unused elsewhere in
      `process_bigraph/` before deletion.