### PR TITLE
fix: scope engine global state per-composite/per-core (P0)

### DIFF
--- a/process_bigraph/composite.py
+++ b/process_bigraph/composite.py
@@ -1002,7 +1002,27 @@ class Step(Open):
 
     _cache: str = 'none'
     _schema_version: Optional[str] = None
-    _by_hash_cache: Dict[Any, Any] = {}
+    # Per-instance by-hash result cache. Declared here only as a ``None``
+    # sentinel so the attribute always exists; the real dict is created
+    # lazily *per Step instance* by ``_get_by_hash_cache``. It is NOT a
+    # shared class-level mutable — that would leak cached results across
+    # every Step of this type and across every Composite in the process.
+    # Because the dict lives on the instance, it is garbage-collected with
+    # the Step (and therefore with its owning Composite).
+    _by_hash_cache: Optional[Dict[Any, Any]] = None
+
+    def _get_by_hash_cache(self) -> Dict[Any, Any]:
+        """Return this instance's by-hash cache, creating it on first use.
+
+        The cache is stored in the instance ``__dict__`` so two Step
+        instances (e.g. the same Step type used in two different
+        Composites running in one process) never share cached results.
+        """
+        cache = self.__dict__.get('_by_hash_cache')
+        if cache is None:
+            cache = {}
+            self._by_hash_cache = cache
+        return cache
 
     def triggers(self):
         """Return the subset of input ports that trigger this step.
@@ -1063,9 +1083,10 @@ class Step(Open):
         keyed by ``(_schema_version, hash)``. Hits skip ``update()``
         entirely and return the prior output.
         """
-        cache_key = self._cache_key(state) if self._cache == 'by_hash' else None
+        cache = self._get_by_hash_cache() if self._cache == 'by_hash' else None
+        cache_key = self._cache_key(state) if cache is not None else None
         if cache_key is not None:
-            cached = type(self)._by_hash_cache.get(cache_key)
+            cached = cache.get(cache_key)
             if cached is not None:
                 return SyncUpdate(cached)
 
@@ -1073,7 +1094,7 @@ class Step(Open):
         if scatter_port is None:
             result = self.update(state)
             if cache_key is not None:
-                type(self)._by_hash_cache[cache_key] = result
+                cache[cache_key] = result
             return SyncUpdate(result)
 
         match_set = state.get(scatter_port)
@@ -1107,7 +1128,7 @@ class Step(Open):
         }
 
         if cache_key is not None:
-            type(self)._by_hash_cache[cache_key] = aggregated
+            cache[cache_key] = aggregated
         return SyncUpdate(aggregated)
 
     def _cache_key(self, state: Dict[str, Any]) -> Tuple[str, str]:

--- a/process_bigraph/types/process.py
+++ b/process_bigraph/types/process.py
@@ -7,6 +7,7 @@ This module extends bigraph_schema by defining new schema node classes used by p
 """
 
 import importlib
+import threading
 import typing
 import numpy as np
 from plum import dispatch
@@ -228,15 +229,73 @@ def register_types(core):
 # ``SharedProcess`` entry in the document's ``process`` store.
 # ============================================================================
 
+# Per-``core`` shared-process registries are the primary store: each
+# Composite owns its own ``core`` (``allocate_core`` returns a fresh core
+# per call), so scoping the registry on the core isolates one simulation's
+# shared processes from another's even when several Composites run in the
+# same process or across the ThreadPoolExecutor used by ``parallel_steps`` /
+# ``parallel_processes``. The module-level dict below is only a fallback for
+# the (unusual) case where a dispatch is reached without a core, and is what
+# ``clear_shared_processes`` / ``get_shared_process`` operate on for
+# backwards compatibility.
 _shared_processes: typing.Dict[str, object] = {}
 
+# Guards lazy creation of per-core registries and writes into both the
+# per-core and the module-level fallback dicts. Registry mutation happens at
+# realize/divide time (composite init / load / division), not on the
+# parallel update hot path, so contention is negligible.
+_shared_processes_lock = threading.Lock()
 
-def clear_shared_processes():
-    """Clear the shared-process registry (e.g. between simulations)."""
-    _shared_processes.clear()
+# Attribute used to stash the per-core registry on a ``core`` instance.
+_CORE_REGISTRY_ATTR = '_shared_process_registry'
 
 
-def get_shared_process(process_id):
+def _core_shared_processes(core) -> typing.Dict[str, object]:
+    """Return the shared-process registry scoped to ``core``.
+
+    Created lazily on first use and stored on the core instance, so it is
+    garbage-collected with the core (and therefore with its Composite) and
+    never leaks results into a different simulation's core. Falls back to the
+    module-level dict when ``core`` is ``None`` (no scope available).
+    """
+    if core is None:
+        return _shared_processes
+    registry = getattr(core, _CORE_REGISTRY_ATTR, None)
+    if registry is None:
+        with _shared_processes_lock:
+            registry = getattr(core, _CORE_REGISTRY_ATTR, None)
+            if registry is None:
+                registry = {}
+                setattr(core, _CORE_REGISTRY_ATTR, registry)
+    return registry
+
+
+def clear_shared_processes(core=None):
+    """Clear a shared-process registry (e.g. between simulations).
+
+    With ``core`` given, clears that core's scoped registry; otherwise
+    clears the module-level fallback dict.
+    """
+    if core is None:
+        with _shared_processes_lock:
+            _shared_processes.clear()
+    else:
+        registry = getattr(core, _CORE_REGISTRY_ATTR, None)
+        if registry is not None:
+            with _shared_processes_lock:
+                registry.clear()
+
+
+def get_shared_process(process_id, core=None):
+    """Look up a registered shared-process instance by id.
+
+    Prefers ``core``'s scoped registry when provided; otherwise consults the
+    module-level fallback dict.
+    """
+    if core is not None:
+        instance = _core_shared_processes(core).get(process_id)
+        if instance is not None:
+            return instance
     return _shared_processes.get(process_id)
 
 
@@ -355,7 +414,15 @@ def realize(core, schema: SharedProcess, state, path=()):
                   f"{process_id}: {e}", flush=True)
 
     if process_id is not None:
-        _shared_processes[process_id] = instance
+        # ``_core_shared_processes`` does its own locked lazy-create; the
+        # dict item assignment itself is atomic under CPython, so no extra
+        # lock is needed here (and acquiring one would re-enter the
+        # non-reentrant lock taken inside the helper → deadlock).
+        _core_shared_processes(core)[process_id] = instance
+        # Stamp the id on the instance so serialize/bundle of a
+        # SharedProcessRef can reverse-resolve it WITHOUT consulting any
+        # (potentially cross-simulation) global registry.
+        instance._shared_process_id = process_id
 
     instance._shared_address = address if isinstance(address, str) else (
         f"local:!{cls.__module__}.{cls.__name__}")
@@ -475,6 +542,12 @@ def _lookup_shared_process_id(state):
     """
     if isinstance(state, tuple) and len(state) > 0:
         state = state[0]
+    # Prefer the id stamped on the instance at realize time — this avoids
+    # depending on any global/per-core registry from a context (serialize/
+    # bundle) that has no ``core`` handle.
+    stamped = getattr(state, '_shared_process_id', None)
+    if isinstance(stamped, str):
+        return stamped
     for pid, inst in _shared_processes.items():
         if inst is state:
             return pid
@@ -520,10 +593,16 @@ def realize(core, schema: SharedProcessRef, state, path=()):
     if process_id is None:
         return schema, state, []
 
-    instance = _shared_processes.get(process_id)
+    registry = _core_shared_processes(core)
+    instance = registry.get(process_id)
     if instance is None:
+        # Fall back to the module-level registry for any path that realized
+        # the SharedProcess without a core scope.
+        instance = _shared_processes.get(process_id)
+    if instance is None:
+        available = sorted(set(registry.keys()) | set(_shared_processes.keys()))
         raise RuntimeError(
             f"SharedProcessRef at {path}: process_id '{process_id}' "
-            f"not found. Available: {sorted(_shared_processes.keys())}. "
+            f"not found. Available: {available}. "
             f"Ensure SharedProcess entries are realized before refs.")
     return schema, instance, []

--- a/tests.py
+++ b/tests.py
@@ -2296,6 +2296,122 @@ def test_parallel_processes_single_process_path(core):
     assert abs(sim.state["level"] - 3.375) < 1e-12
 
 
+def test_by_hash_cache_is_per_instance(core):
+    """A ``_cache='by_hash'`` Step must keep its memoization cache on the
+    *instance*, not on the class. Two Steps of the same type (e.g. one per
+    Composite) running in one process must not share cached results — a
+    cache hit on one must never suppress recomputation on the other.
+
+    Regression guard: when the cache lived in a class-level dict, the
+    second instance's first invoke with the same (config, state) hash
+    silently returned the first instance's result and skipped ``update``,
+    leaking results across simulations and growing without bound.
+    """
+    calls = []
+
+    class _CachedStep(Step):
+        _cache = 'by_hash'
+        _schema_version = 'v1'
+
+        def inputs(self):
+            return {'x': 'float'}
+
+        def outputs(self):
+            return {'y': 'float'}
+
+        def update(self, state):
+            calls.append(id(self))
+            return {'y': state['x'] + 1.0}
+
+    a = _CachedStep(core=core)
+    b = _CachedStep(core=core)
+
+    # First invoke on `a`: computes + caches.
+    assert a.invoke({'x': 1.0}).get() == {'y': 2.0}
+    assert len(calls) == 1
+    # Same (config, state) again on `a`: cache HIT, no recompute — the
+    # by-hash optimisation must still work *within* a single instance.
+    assert a.invoke({'x': 1.0}).get() == {'y': 2.0}
+    assert len(calls) == 1
+
+    # `b` is a different instance with an identical cache key. It must NOT
+    # see `a`'s cache: it recomputes (correct result, fresh update call).
+    assert b.invoke({'x': 1.0}).get() == {'y': 2.0}
+    assert len(calls) == 2
+
+    # The caches are distinct dict objects, each holding only its own entry,
+    # and the class never accumulates a shared cache.
+    assert a._by_hash_cache is not b._by_hash_cache
+    assert len(a._by_hash_cache) == 1
+    assert len(b._by_hash_cache) == 1
+    assert _CachedStep.__dict__.get('_by_hash_cache') is None
+
+
+class _SharedRegProc:
+    """Minimal stand-in for a shared process instance used to exercise the
+    per-core ``_shared_processes`` registry through the realize dispatch.
+
+    It deliberately does NOT subclass Edge/Process: ``SharedProcess.realize``
+    instantiates the class as ``cls(config)`` with no core, which Edge
+    forbids. Only the attributes the dispatch touches are provided.
+    """
+
+    def __init__(self, config):
+        self.config = config
+        self.core = None
+
+
+def test_shared_process_registry_per_core():
+    """The shared-process registry must be scoped per ``core`` so two
+    simulations (two Composites / two cores) in one process cannot clobber
+    each other's shared process registered under the same id.
+
+    Regression guard: the registry used to be a single module-level dict,
+    so the second core's ``realize`` overwrote the first core's entry under
+    the same id, and every later lookup resolved to the wrong instance.
+    """
+    from bigraph_schema.methods import realize as realize_mm, serialize as serialize_mm
+    from process_bigraph.types.process import (
+        SharedProcess, SharedProcessRef, _core_shared_processes,
+        get_shared_process, _shared_processes, _lookup_shared_process_id)
+
+    core1 = make_test_core()
+    core2 = make_test_core()
+    addr = f'local:!{__name__}._SharedRegProc'
+    sp = SharedProcess()
+
+    # Both cores register a shared process under the SAME id 'proc' but with
+    # different configs.
+    _, r1, _ = realize_mm(
+        core1, sp, {'address': addr, 'config': {'rate': 0.1}}, path=('proc',))
+    _, r2, _ = realize_mm(
+        core2, sp, {'address': addr, 'config': {'rate': 0.9}}, path=('proc',))
+
+    # No cross-core clobbering: each core resolves to its own instance.
+    assert r1[0].config['rate'] == 0.1
+    assert r2[0].config['rate'] == 0.9
+    assert get_shared_process('proc', core=core1).config['rate'] == 0.1
+    assert get_shared_process('proc', core=core2).config['rate'] == 0.9
+
+    # Registries are distinct per core, and the module-level fallback dict
+    # is not used at all when a core scope is available.
+    assert _core_shared_processes(core1) is not _core_shared_processes(core2)
+    assert _shared_processes == {}
+
+    # The instance is stamped with its id so reverse-lookup (used by
+    # serialize/bundle of a ref, which have no core handle) needs no global.
+    assert r1[0]._shared_process_id == 'proc'
+    assert _lookup_shared_process_id(r1) == 'proc'
+
+    # SharedProcessRef resolves against its own core's registry.
+    spr = SharedProcessRef()
+    _, ref1, _ = realize_mm(core1, spr, 'proc', path=('ref',))
+    _, ref2, _ = realize_mm(core2, spr, 'proc', path=('ref',))
+    assert ref1.config['rate'] == 0.1
+    assert ref2.config['rate'] == 0.9
+    assert serialize_mm(spr, r1) == 'proc'
+
+
 @pytest.mark.slow
 def test_ray_process_pool_shared_across_clients(core):
     """Two RayProcess clients with the same (class, config) must share one


### PR DESCRIPTION
## P0 — cross-simulation state leakage in the engine

Two globals leaked across simulations and were unsafe under `parallel_steps`/`parallel_processes`:

- **`Step._by_hash_cache`** was class-level (shared across all Step instances and all composites, never cleared) → unbounded growth + cross-sim result leakage. Now **per-instance** (lazy dict, GC’d with the composite); within-run caching preserved.
- **`_shared_processes`** was a module-level dict → a second sim registering a `SharedProcess` under the same id clobbered the first. Now scoped **per-core** (`core._shared_process_registry`, lock-guarded for the in-process thread pool); ids stamped at realize time so serialize/bundle no longer need the global. No multimethod dispatch signatures changed; module-level dict kept as a core-aware back-compat fallback.

**Tests:** 47 pass / 15 slow-skip; new per-instance and per-core isolation tests; `test_parallel_processes_matches_serial` green.

⚠️ **Review note:** `SharedProcess` has **no in-repo tests/usages** — it is exercised by **v2ecoli** (Requester/Evolver, rng/internal-state round-trip). Recommend a v2ecoli lineage smoke-test before merging this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)