### PR TITLE
feat: CompositeSpec — unified composite declaration

### DIFF
--- a/docs/superpowers/plans/2026-06-28-composite-spec-unified-declaration.md
+++ b/docs/superpowers/plans/2026-06-28-composite-spec-unified-declaration.md
@@ -786,10 +786,12 @@ def test_top_level_exports():
 
 ```python
 from process_bigraph.composite_spec import (
-    CompositeSpec, composite_spec, discover_specs, regenerate_default_state,
-    register, get, all_specs, clear_registry, normalize_type, CANONICAL_TYPES,
+    CompositeSpec, discover_specs, regenerate_default_state,
+    normalize_type, CANONICAL_TYPES,
 )
 ```
+
+**Naming note (do NOT export the decorator or registry fns at top level):** the decorator is named `composite_spec` — the SAME name as the module. Exporting it from `__init__` would rebind the `process_bigraph.composite_spec` package attribute to the function, shadowing the module, which breaks every `from process_bigraph import composite_spec as cs; cs.get()/cs.composite_spec()` access pattern (used by the existing tests AND by Tasks 7/9). So leave the decorator + `register`/`get`/`all_specs`/`clear_registry` on the module: they are reached as `process_bigraph.composite_spec.composite_spec`, `.get`, etc. (which is how the existing tests already use them via `cs.*`). `from process_bigraph.composite_spec import composite_spec` also still works for anyone wanting the decorator directly. The top-level package exposes only the non-colliding names above. The Task-6 test below passes either way (`hasattr(pbg, "composite_spec")` is true for the module).
 
 - [ ] **Step 4: Run → pass.** Also run the WHOLE process-bigraph suite to confirm no import cycle: `.venv/bin/python -m pytest -q` (composite_spec imports `process_bigraph.Composite` lazily inside methods, so no cycle at import time).
 

--- a/docs/superpowers/plans/2026-06-28-composite-spec-unified-declaration.md
+++ b/docs/superpowers/plans/2026-06-28-composite-spec-unified-declaration.md
@@ -1,0 +1,1214 @@
+# CompositeSpec — Unified Composite Declaration — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Lift the two existing pbg-superpowers composite front-ends (static `composite_spec.py` + code `composite_generator.py`) into ONE declarative `CompositeSpec` descriptor in process-bigraph, carrying all metadata, producing a runtime `Composite`, and resolving to a saved default state for ParCa-free dashboard display.
+
+**Architecture:** A `process_bigraph.composite_spec` module defines the `CompositeSpec` dataclass + a `@composite_spec` decorator + a registry + `discover_specs` + `regenerate_default_state`. pbg-superpowers' two modules become thin shims delegating to it (existing usage unchanged). The dashboard resolves against the process-bigraph registry, displays from `CompositeSpec.default_state()`, and the explorer's hardcoded remote-build error is replaced by the server's real notice.
+
+**Tech Stack:** Python 3.12, `dataclasses`, stdlib `importlib`/`json`, `yaml` (PyYAML), pytest (`python_files = *.py`, `python_functions = test*`), `bigraph_schema.allocate_core`, `process_bigraph.Composite`.
+
+## Global Constraints
+
+- **No new runtime dependencies.** Only stdlib + already-present `yaml`, `bigraph_schema`, `process_bigraph`.
+- **The local resolve/run paths must stay behaviour-preserving** — existing `@composite_generator` usage in v2ecoli (13 generators) and all `*.composite.yaml` files keep working through the shim. Removing the shim is OUT of scope.
+- **Exactly one of `state` / `builder`** is set on a `CompositeSpec`; `schema` accompanies `state` only; `default_state_ref` requires `builder`.
+- **Canonical parameter types** = `{"integer", "float", "string", "boolean", "list", "map"}`. Aliases normalize on construction: `int→integer`, `number→float`, `double→float`, `str→string`, `bool→boolean`, `array→list`, `object→map`, `dict→map`. Unknown types pass through unchanged (no raise).
+- **A Composite DOCUMENT is `{schema, state, …}`** — generator builders may return extra exec keys (`skip_initial_steps`, `sequential_steps`, `flow_order`, `run_steps_on_init`); `to_document`/`to_composite` forward the WHOLE document verbatim, never narrowed to `{state, schema}`.
+- **`core_extensions` are load-bearing** — applied to the core BEFORE the builder runs.
+- **Worktrees:** process-bigraph work is in `/Users/eranagmon/code/pbg-composite-spec` (branch `feat/composite-spec`). Tasks 7–8 (pbg-superpowers) and 9–10 (vivarium-dashboard) each need their own worktree off `origin/main` — create at task start (see each task). Proof (Task 11) spans v2ecoli + autopoiesis worktrees.
+- **Test command (process-bigraph):** `cd /Users/eranagmon/code/pbg-composite-spec && .venv/bin/python -m pytest process_bigraph/tests/test_composite_spec.py -v`. Ruff: `.venv/bin/ruff check process_bigraph/composite_spec.py`.
+
+## The Canonical Contract (every task depends on these exact signatures)
+
+```python
+# process_bigraph/composite_spec.py
+CANONICAL_TYPES = {"integer", "float", "string", "boolean", "list", "map"}
+
+@dataclass
+class CompositeSpec:
+    id: str                                    # canonical "<module>.<name>"
+    name: str
+    description: str = ""
+    tags: list = field(default_factory=list)
+    parameters: dict = field(default_factory=dict)      # {name: {type, default, description?, choices?}}
+    default_n_steps: "int | None" = None
+    visualizations: list = field(default_factory=list)
+    analyses: list = field(default_factory=list)
+    emitters: list = field(default_factory=list)        # [{address, config?, paths?}]
+    requires: dict = field(default_factory=dict)        # {processes: [...], types: [...]}
+    schema: dict = field(default_factory=dict)          # bigraph-schema store types (static only)
+    state: "dict | None" = None                         # static body (exactly one of state/builder)
+    builder: "Callable | str | None" = None             # generator: callable or dotted "pkg.mod:fn"
+    default_state_ref: "str | None" = None              # generator saved-state artifact filename
+    module: str = ""                                    # owning module (for discovery/display)
+    core_extensions: list = field(default_factory=list) # callables (core) -> core | None; not serialized
+
+    # properties / methods
+    @property
+    def kind(self) -> str: ...                          # "generator" if builder else "spec"
+    def to_dict(self) -> dict: ...                       # portable JSON (builder -> dotted str; core_extensions dropped)
+    @classmethod
+    def from_dict(cls, d: dict) -> "CompositeSpec": ...
+    @classmethod
+    def from_file(cls, path) -> "CompositeSpec": ...     # parse *.composite.{yaml,json}
+    def to_document(self, overrides=None, core=None) -> dict: ...   # resolved {schema, state, …}
+    def to_composite(self, overrides=None, core=None):  ...         # -> process_bigraph.Composite
+    def default_state(self, base_dir=None) -> "dict | None": ...    # display state; never builds
+
+def normalize_type(t: str) -> str: ...
+def composite_spec(*, name, description="", parameters=None, visualizations=None,
+                   emitters=None, analyses=None, tags=None, default_n_steps=None,
+                   core_extensions=None, default_state_ref=None): ...   # decorator -> registers CompositeSpec(builder=fn)
+def register(spec: CompositeSpec) -> None: ...
+def get(spec_id: str) -> "CompositeSpec | None": ...
+def all_specs() -> "dict[str, CompositeSpec]": ...
+def clear_registry() -> None: ...
+def discover_specs(workspace=None) -> "dict[str, CompositeSpec]": ...
+def regenerate_default_state(spec: CompositeSpec, base_dir, core=None) -> "Path": ...
+```
+
+---
+
+### Task 1: `CompositeSpec` dataclass — fields, type normalization, validation, JSON round-trip
+
+**Files:**
+- Create: `process_bigraph/composite_spec.py`
+- Create: `process_bigraph/tests/__init__.py` (empty)
+- Test: `process_bigraph/tests/test_composite_spec.py`
+
+**Interfaces — Produces:** `CompositeSpec` dataclass (fields per the Contract above), `normalize_type(t)`, `CANONICAL_TYPES`, `CompositeSpec.kind`, `.to_dict()`, `.from_dict(d)`. Validation runs in `__post_init__`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# process_bigraph/tests/test_composite_spec.py
+import pytest
+from process_bigraph.composite_spec import CompositeSpec, normalize_type, CANONICAL_TYPES
+
+
+def test_normalize_type_aliases():
+    assert normalize_type("int") == "integer"
+    assert normalize_type("number") == "float"
+    assert normalize_type("bool") == "boolean"
+    assert normalize_type("object") == "map"
+    assert normalize_type("array") == "list"
+    assert normalize_type("string") == "string"
+    assert normalize_type("unknownX") == "unknownX"  # pass-through
+
+
+def test_static_spec_normalizes_param_types():
+    s = CompositeSpec(id="m.c", name="c", state={"x": 1},
+                      parameters={"seed": {"type": "int", "default": 0},
+                                  "rate": {"type": "number", "default": 1.0}})
+    assert s.parameters["seed"]["type"] == "integer"
+    assert s.parameters["rate"]["type"] == "float"
+    assert s.kind == "spec"
+
+
+def test_generator_spec_kind():
+    s = CompositeSpec(id="m.g", name="g", builder="m:g")
+    assert s.kind == "generator"
+
+
+def test_exactly_one_of_state_or_builder():
+    with pytest.raises(ValueError, match="exactly one"):
+        CompositeSpec(id="m.x", name="x")  # neither
+    with pytest.raises(ValueError, match="exactly one"):
+        CompositeSpec(id="m.x", name="x", state={}, builder="m:x")  # both
+
+
+def test_schema_only_with_state():
+    with pytest.raises(ValueError, match="schema"):
+        CompositeSpec(id="m.g", name="g", builder="m:g", schema={"pop": "tree"})
+
+
+def test_default_state_ref_requires_builder():
+    with pytest.raises(ValueError, match="default_state_ref"):
+        CompositeSpec(id="m.c", name="c", state={"x": 1}, default_state_ref="x.json")
+
+
+def test_to_dict_from_dict_round_trip_static():
+    s = CompositeSpec(id="m.c", name="c", description="d", tags=["t"],
+                      state={"x": "${seed}"}, schema={"pop": "tree"},
+                      parameters={"seed": {"type": "integer", "default": 0}},
+                      requires={"processes": ["P"], "types": ["ty"]},
+                      emitters=[{"address": "local:RAMEmitter"}], default_n_steps=10)
+    d = s.to_dict()
+    assert d["state"] == {"x": "${seed}"} and d["schema"] == {"pop": "tree"}
+    assert d["requires"] == {"processes": ["P"], "types": ["ty"]}
+    s2 = CompositeSpec.from_dict(d)
+    assert s2 == s
+
+
+def test_to_dict_serializes_builder_callable_to_dotted():
+    def fn(core=None):
+        return {"state": {}}
+    s = CompositeSpec(id="m.g", name="g", builder=fn, module="m")
+    d = s.to_dict()
+    # a callable serializes to "<module>:<qualname>"; core_extensions are dropped
+    assert isinstance(d["builder"], str) and d["builder"].endswith(":fn")
+    assert "core_extensions" not in d
+```
+
+- [ ] **Step 2: Run → fail.** `cd /Users/eranagmon/code/pbg-composite-spec && .venv/bin/python -m pytest process_bigraph/tests/test_composite_spec.py -v` → ModuleNotFound / NameError.
+
+- [ ] **Step 3: Implement** `process_bigraph/composite_spec.py`:
+
+```python
+"""Unified composite declaration for process-bigraph.
+
+A CompositeSpec is the declarative descriptor a composite is authored as —
+either inline data (``state`` + optional ``schema``) for a static composite, or
+a ``builder`` callable for a generator composite. It carries the dashboard/UI
+metadata (parameters, default_n_steps, visualizations, analyses, emitters,
+requires) and produces a runtime ``process_bigraph.Composite``.
+
+This unifies (and is the new home of) the two front-ends that previously lived
+separately in pbg-superpowers: the static ``composite_spec`` spec-file format
+and the ``composite_generator`` decorator. Those become thin shims over this.
+"""
+from __future__ import annotations
+
+import importlib
+import json
+import re
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Any, Callable
+
+CANONICAL_TYPES = {"integer", "float", "string", "boolean", "list", "map"}
+
+_TYPE_ALIASES = {
+    "integer": "integer", "int": "integer",
+    "float": "float", "number": "float", "double": "float",
+    "string": "string", "str": "string",
+    "boolean": "boolean", "bool": "boolean",
+    "list": "list", "array": "list",
+    "map": "map", "object": "map", "dict": "map",
+}
+
+
+def normalize_type(t: str) -> str:
+    """Map a parameter ``type`` string onto the canonical vocabulary.
+
+    Known aliases collapse (int→integer, number→float, bool→boolean,
+    object→map, array→list); an unknown type passes through unchanged.
+    """
+    return _TYPE_ALIASES.get(t, t)
+
+
+@dataclass
+class CompositeSpec:
+    id: str
+    name: str
+    description: str = ""
+    tags: list = field(default_factory=list)
+    parameters: dict = field(default_factory=dict)
+    default_n_steps: "int | None" = None
+    visualizations: list = field(default_factory=list)
+    analyses: list = field(default_factory=list)
+    emitters: list = field(default_factory=list)
+    requires: dict = field(default_factory=dict)
+    schema: dict = field(default_factory=dict)
+    state: "dict | None" = None
+    builder: "Callable | str | None" = None
+    default_state_ref: "str | None" = None
+    module: str = ""
+    core_extensions: list = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.name, str) or not self.name:
+            raise ValueError("CompositeSpec.name is required (non-empty string)")
+        has_state = self.state is not None
+        has_builder = self.builder is not None
+        if has_state == has_builder:
+            raise ValueError("CompositeSpec needs exactly one of `state` or `builder`")
+        if has_builder and self.schema:
+            raise ValueError("`schema` is for static specs; a generator's schema comes "
+                             "from the builder document")
+        if self.default_state_ref is not None and not has_builder:
+            raise ValueError("`default_state_ref` requires a `builder`")
+        # normalize parameter types in place
+        for pdef in self.parameters.values():
+            if isinstance(pdef, dict) and "type" in pdef:
+                pdef["type"] = normalize_type(pdef["type"])
+
+    @property
+    def kind(self) -> str:
+        return "generator" if self.builder is not None else "spec"
+
+    def to_dict(self) -> dict:
+        d = asdict(self)
+        d.pop("core_extensions", None)  # callables are not serializable
+        if callable(self.builder):
+            d["builder"] = f"{getattr(self.builder, '__module__', self.module)}:" \
+                           f"{self.builder.__qualname__}"
+        return d
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "CompositeSpec":
+        d = dict(d)
+        d.pop("core_extensions", None)
+        return cls(**d)
+```
+
+- [ ] **Step 4: Run → pass.** Same command. All 8 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/eranagmon/code/pbg-composite-spec
+git add process_bigraph/composite_spec.py process_bigraph/tests/
+git commit -m "feat(composite-spec): CompositeSpec dataclass + type normalization + JSON round-trip"
+```
+
+---
+
+### Task 2: Resolution — `substitute_parameters`, `to_document`, `to_composite`, `default_state` (inline)
+
+**Files:**
+- Modify: `process_bigraph/composite_spec.py`
+- Test: `process_bigraph/tests/test_composite_spec.py` (append)
+
+**Interfaces — Consumes:** `CompositeSpec` (Task 1), `process_bigraph.Composite`, `bigraph_schema.allocate_core`. **Produces:** module-level `substitute_parameters(state, params, overrides=None)`; `CompositeSpec.to_document(overrides=None, core=None)`, `.to_composite(overrides=None, core=None)`, `.default_state(base_dir=None)` (inline-state path; the artifact path lands in Task 5).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+from process_bigraph.composite_spec import substitute_parameters
+
+
+def test_substitute_full_and_inline():
+    params = {"seed": {"type": "integer", "default": 0}, "tag": {"type": "string", "default": "x"}}
+    state = {"a": "${seed}", "b": "v-${tag}", "c": 5}
+    out = substitute_parameters(state, params, {"seed": 7, "tag": "z"})
+    assert out == {"a": 7, "b": "v-z", "c": 5}  # full placeholder typed; inline stringified
+
+
+def test_to_document_static_substitutes_schema_and_state():
+    s = CompositeSpec(id="m.c", name="c", state={"x": "${seed}"}, schema={"pop": "tree"},
+                      parameters={"seed": {"type": "integer", "default": 3}})
+    doc = s.to_document()
+    assert doc == {"schema": {"pop": "tree"}, "state": {"x": 3}}
+
+
+def test_to_document_generator_passes_whole_document():
+    def build(core=None, *, seed=0):
+        return {"state": {"s": seed}, "skip_initial_steps": True, "flow_order": ["a"]}
+    s = CompositeSpec(id="m.g", name="g", builder=build,
+                      parameters={"seed": {"type": "integer", "default": 0}})
+    doc = s.to_document({"seed": 9})
+    assert doc == {"state": {"s": 9}, "skip_initial_steps": True, "flow_order": ["a"]}
+
+
+def test_to_document_rejects_unknown_override():
+    s = CompositeSpec(id="m.c", name="c", state={}, parameters={"seed": {"type": "integer", "default": 0}})
+    with pytest.raises(KeyError):
+        s.to_document({"nope": 1})
+
+
+def test_to_composite_static_returns_runnable_composite():
+    s = CompositeSpec(id="m.c", name="c", state={"v": 1.0})
+    comp = s.to_composite()
+    from process_bigraph import Composite
+    assert isinstance(comp, Composite)
+
+
+def test_to_composite_applies_core_extensions_before_build():
+    seen = {}
+    def ext(core):
+        seen["ran"] = True
+        return core
+    def build(core=None):
+        seen["built_after_ext"] = seen.get("ran", False)
+        return {"state": {}}
+    s = CompositeSpec(id="m.g", name="g", builder=build, core_extensions=[ext])
+    s.to_composite()
+    assert seen["ran"] and seen["built_after_ext"]
+
+
+def test_default_state_inline():
+    s = CompositeSpec(id="m.c", name="c", state={"v": 1})
+    assert s.default_state() == {"v": 1}
+```
+
+- [ ] **Step 2: Run → fail.** `substitute_parameters` / `to_document` undefined.
+
+- [ ] **Step 3: Implement** — append to `process_bigraph/composite_spec.py`:
+
+```python
+_FULL_PLACEHOLDER = re.compile(r"^\$\{([a-zA-Z_][a-zA-Z0-9_]*)\}$")
+_INLINE_PLACEHOLDER = re.compile(r"\$\{([a-zA-Z_][a-zA-Z0-9_]*)\}")
+
+
+def _cast(value: Any, declared_type: "str | None") -> Any:
+    if declared_type is None:
+        return value
+    t = normalize_type(declared_type)
+    if t == "float":
+        return float(value)
+    if t == "integer":
+        return int(value)
+    if t == "string":
+        return str(value)
+    if t == "boolean":
+        if isinstance(value, str):
+            return value.strip().lower() in ("true", "1", "yes")
+        return bool(value)
+    return value
+
+
+def _resolve_value(value, params, overrides):
+    if not isinstance(value, str):
+        return value
+    m = _FULL_PLACEHOLDER.match(value)
+    if m:
+        pname = m.group(1)
+        if pname not in params:
+            raise KeyError(f"parameter '{pname}' referenced in state but not declared")
+        pdef = params[pname]
+        raw = overrides.get(pname, pdef.get("default"))
+        if raw is None and "default" not in pdef:
+            raise KeyError(f"parameter '{pname}' has no default and no override")
+        return _cast(raw, pdef.get("type"))
+    if _INLINE_PLACEHOLDER.search(value):
+        def repl(match):
+            pname = match.group(1)
+            if pname not in params:
+                raise KeyError(f"parameter '{pname}' referenced in state but not declared")
+            raw = overrides.get(pname, params[pname].get("default"))
+            return str(raw)
+        return _INLINE_PLACEHOLDER.sub(repl, value)
+    return value
+
+
+def substitute_parameters(state, params, overrides=None):
+    """Recursively substitute ``${name}`` placeholders. Returns a new structure."""
+    overrides = overrides or {}
+    if isinstance(state, dict):
+        return {k: substitute_parameters(v, params, overrides) for k, v in state.items()}
+    if isinstance(state, list):
+        return [substitute_parameters(v, params, overrides) for v in state]
+    return _resolve_value(state, params, overrides)
+
+
+def _resolve_builder(builder, module):
+    """Resolve a builder callable; a dotted ``pkg.mod:fn`` string is imported."""
+    if callable(builder):
+        return builder
+    mod_name, _, qual = str(builder).partition(":")
+    mod = importlib.import_module(mod_name or module)
+    obj = mod
+    for part in qual.split("."):
+        obj = getattr(obj, part)
+    return obj
+```
+
+Then add these methods to the `CompositeSpec` class body (place after `from_dict`):
+
+```python
+    def _merged_params(self, overrides):
+        overrides = overrides or {}
+        unknown = set(overrides) - set(self.parameters)
+        if unknown:
+            raise KeyError(f"unknown override(s): {sorted(unknown)}")
+        merged = {k: v.get("default") for k, v in self.parameters.items()}
+        merged.update(overrides)
+        return merged
+
+    def to_document(self, overrides=None, core=None) -> dict:
+        if self.kind == "spec":
+            return {
+                "schema": substitute_parameters(self.schema, self.parameters, overrides),
+                "state": substitute_parameters(self.state, self.parameters, overrides),
+            }
+        fn = _resolve_builder(self.builder, self.module)
+        return fn(core=core, **self._merged_params(overrides))
+
+    def to_composite(self, overrides=None, core=None):
+        from process_bigraph import Composite, allocate_core
+        if core is None:
+            core = allocate_core()
+        for ext in self.core_extensions:
+            ext(core)
+        doc = self.to_document(overrides, core=core)
+        return Composite(doc, core=core)
+
+    def default_state(self, base_dir=None) -> "dict | None":
+        if self.state is not None:
+            return self.state
+        return None  # generator artifact path implemented in Task 5
+```
+
+Note `_merged_params` rejects unknown override keys (matches the test). A builder that
+accepts a `config_overrides` map declares it as a parameter, so deep-path overrides
+flow through the normal merge — no special handling here.
+
+- [ ] **Step 4: Run → pass.** All Task-2 tests green; Task-1 tests still green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add process_bigraph/composite_spec.py process_bigraph/tests/test_composite_spec.py
+git commit -m "feat(composite-spec): to_document/to_composite/default_state + parameter substitution"
+```
+
+---
+
+### Task 3: `@composite_spec` decorator + registry
+
+**Files:**
+- Modify: `process_bigraph/composite_spec.py`
+- Test: `process_bigraph/tests/test_composite_spec.py` (append)
+
+**Interfaces — Produces:** module registry `_REGISTRY: dict[str, CompositeSpec]`; `register(spec)`, `get(spec_id)`, `all_specs()`, `clear_registry()`; `composite_spec(*, name, description="", parameters=None, visualizations=None, emitters=None, analyses=None, tags=None, default_n_steps=None, core_extensions=None)` decorator returning the original fn and registering a `CompositeSpec(id="<module>.<name>", builder=fn, …)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+from process_bigraph import composite_spec as cs
+
+
+def test_decorator_registers_generator(monkeypatch):
+    cs.clear_registry()
+
+    @cs.composite_spec(name="demo", description="d",
+                       parameters={"seed": {"type": "int", "default": 0}},
+                       emitters=[{"address": "local:RAMEmitter"}], default_n_steps=5)
+    def demo(core=None, *, seed=0):
+        return {"state": {"s": seed}}
+
+    spec_id = f"{demo.__module__}.demo"
+    spec = cs.get(spec_id)
+    assert spec is not None and spec.kind == "generator"
+    assert spec.parameters["seed"]["type"] == "integer"  # normalized
+    assert spec.default_n_steps == 5 and spec.builder is demo
+    assert demo(seed=2) == {"state": {"s": 2}}  # decorator returns the original fn
+
+
+def test_register_get_all_clear():
+    cs.clear_registry()
+    s = CompositeSpec(id="m.c", name="c", state={})
+    cs.register(s)
+    assert cs.get("m.c") is s
+    assert "m.c" in cs.all_specs()
+    cs.clear_registry()
+    assert cs.get("m.c") is None
+```
+
+- [ ] **Step 2: Run → fail.** `composite_spec`/`register` undefined.
+
+- [ ] **Step 3: Implement** — append to `process_bigraph/composite_spec.py`:
+
+```python
+_REGISTRY: "dict[str, CompositeSpec]" = {}
+
+
+def register(spec: CompositeSpec) -> None:
+    _REGISTRY[spec.id] = spec
+
+
+def get(spec_id: str) -> "CompositeSpec | None":
+    return _REGISTRY.get(spec_id)
+
+
+def all_specs() -> "dict[str, CompositeSpec]":
+    return dict(_REGISTRY)
+
+
+def clear_registry() -> None:
+    _REGISTRY.clear()
+
+
+def composite_spec(*, name, description="", parameters=None, visualizations=None,
+                   emitters=None, analyses=None, tags=None, default_n_steps=None,
+                   core_extensions=None, default_state_ref=None):
+    """Decorator: register a generator function as a CompositeSpec.
+
+    The wrapped fn becomes the spec's ``builder``; its id is
+    ``"<fn.__module__>.<name>"``. Returns the original fn unchanged.
+    """
+    def decorate(fn):
+        spec = CompositeSpec(
+            id=f"{fn.__module__}.{name}",
+            name=name,
+            description=description or (fn.__doc__ or "").strip().split("\n")[0],
+            tags=list(tags or []),
+            parameters=dict(parameters or {}),
+            default_n_steps=default_n_steps,
+            visualizations=list(visualizations or []),
+            analyses=list(analyses or []),
+            emitters=list(emitters or []),
+            builder=fn,
+            module=fn.__module__,
+            default_state_ref=default_state_ref,
+            core_extensions=list(core_extensions or []),
+        )
+        register(spec)
+        return fn
+    return decorate
+```
+
+- [ ] **Step 4: Run → pass.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add process_bigraph/composite_spec.py process_bigraph/tests/test_composite_spec.py
+git commit -m "feat(composite-spec): @composite_spec decorator + module registry"
+```
+
+---
+
+### Task 4: `from_file` loader + `discover_specs`
+
+**Files:**
+- Modify: `process_bigraph/composite_spec.py`
+- Test: `process_bigraph/tests/test_composite_spec.py` (append)
+
+**Interfaces — Consumes:** `yaml`. **Produces:** `CompositeSpec.from_file(path)` (parses a `*.composite.{yaml,json}` into a static-or-generator spec, normalizing types, carrying `schema`/`requires.{processes,types}`/`analyses`/`visualizations`/`default_n_steps`/`emitters`); `discover_specs(workspace=None)` — imports bigraph-schema-dependent packages (triggering decorators) and scans `<workspace>/**/*.composite.{yaml,json}`, merging both into `_REGISTRY` and returning it.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+import textwrap
+
+
+def test_from_file_static_yaml(tmp_path):
+    p = tmp_path / "g.composite.yaml"
+    p.write_text(textwrap.dedent("""
+        name: growth
+        description: demo
+        tags: [a]
+        requires:
+          processes: [P]
+          types: [ty]
+        schema:
+          population: tree
+        parameters:
+          seed: {type: int, default: 0}
+        state:
+          v: "${seed}"
+    """), encoding="utf-8")
+    s = CompositeSpec.from_file(p)
+    assert s.kind == "spec" and s.name == "growth"
+    assert s.schema == {"population": "tree"}
+    assert s.requires == {"processes": ["P"], "types": ["ty"]}
+    assert s.parameters["seed"]["type"] == "integer"  # normalized
+    assert s.id.endswith(".growth")
+
+
+def test_from_file_generator_with_builder_ref(tmp_path):
+    p = tmp_path / "b.composite.json"
+    p.write_text(json.dumps({
+        "name": "bgen", "builder": "process_bigraph.composite_spec:normalize_type",
+        "default_state_ref": "bgen.default-state.json",
+        "parameters": {}}), encoding="utf-8")
+    s = CompositeSpec.from_file(p)
+    assert s.kind == "generator" and s.default_state_ref == "bgen.default-state.json"
+
+
+def test_discover_specs_scans_workspace_files(tmp_path):
+    cs.clear_registry()
+    comp = tmp_path / "composites"
+    comp.mkdir()
+    (comp / "x.composite.yaml").write_text("name: xc\nstate: {a: 1}\n", encoding="utf-8")
+    found = cs.discover_specs(workspace=tmp_path)
+    assert any(s.name == "xc" for s in found.values())
+```
+
+- [ ] **Step 2: Run → fail.** `from_file`/`discover_specs` undefined.
+
+- [ ] **Step 3: Implement** — add `from_file` as a `CompositeSpec` classmethod and `discover_specs` at module level:
+
+```python
+    @classmethod
+    def from_file(cls, path) -> "CompositeSpec":
+        path = Path(path)
+        text = path.read_text(encoding="utf-8")
+        raw = json.loads(text) if path.suffix.lower() == ".json" else yaml.safe_load(text)
+        if not isinstance(raw, dict):
+            raise ValueError(f"composite spec {path} must parse to a dict")
+        name = raw.get("name")
+        # id: prefer an explicit id, else "<file-stem-stripped>.<name>"; keep stable + simple
+        stem = path.name.replace(".composite.yaml", "").replace(".composite.json", "")
+        spec_id = raw.get("id") or f"{stem}.{name}"
+        builder = raw.get("builder")
+        return cls(
+            id=spec_id, name=name, description=raw.get("description", ""),
+            tags=list(raw.get("tags") or []),
+            parameters=dict(raw.get("parameters") or {}),
+            default_n_steps=raw.get("default_n_steps"),
+            visualizations=list(raw.get("visualizations") or []),
+            analyses=list(raw.get("analyses") or []),
+            emitters=list(raw.get("emitters") or []),
+            requires=dict(raw.get("requires") or {}),
+            schema=dict(raw.get("schema") or {}) if builder is None else {},
+            state=raw.get("state") if builder is None else None,
+            builder=builder,
+            default_state_ref=raw.get("default_state_ref"),
+            module=raw.get("module", ""),
+        )
+```
+
+```python
+def discover_specs(workspace=None) -> "dict[str, CompositeSpec]":
+    """Populate + return the registry: import decorator-registered generators
+    AND scan a workspace for ``*.composite.{yaml,json}`` files."""
+    try:
+        from pbg_superpowers.composite_generator import discover_generators
+        discover_generators()  # fires @composite_spec / @composite_generator on import
+    except Exception:
+        pass  # discovery of code generators is best-effort
+    if workspace is not None:
+        for pat in ("*.composite.yaml", "*.composite.json"):
+            for fp in Path(workspace).rglob(pat):
+                try:
+                    register(CompositeSpec.from_file(fp))
+                except Exception:
+                    continue  # a malformed file must not break discovery
+    return all_specs()
+```
+
+(The `discover_generators` import is the transition bridge; after the shim lands — Task 7 —
+it triggers the same `@composite_spec` registrations. The file scan is independent of it.)
+
+- [ ] **Step 4: Run → pass.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add process_bigraph/composite_spec.py process_bigraph/tests/test_composite_spec.py
+git commit -m "feat(composite-spec): from_file loader + discover_specs (decorator + file merge)"
+```
+
+---
+
+### Task 5: `regenerate_default_state` + artifact-backed `default_state`
+
+**Files:**
+- Modify: `process_bigraph/composite_spec.py`
+- Test: `process_bigraph/tests/test_composite_spec.py` (append)
+
+**Interfaces — Consumes:** `CompositeSpec.to_composite` (Task 2), `Composite.serialize_state()`. **Produces:** `regenerate_default_state(spec, base_dir, core=None) -> Path` (runs the builder with defaults, writes `<base_dir>/<default_state_ref>` containing `{"state": <serialized>, "_provenance": {param_signature}}`); `CompositeSpec.default_state(base_dir=None)` extended so a generator reads its artifact's `state`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def test_regenerate_and_read_default_state(tmp_path):
+    def build(core=None, *, seed=0):
+        return {"state": {"count": seed + 1}}
+    s = CompositeSpec(id="m.g", name="g", builder=build,
+                      parameters={"seed": {"type": "integer", "default": 4}},
+                      default_state_ref="g.default-state.json")
+    from process_bigraph.composite_spec import regenerate_default_state
+    out = regenerate_default_state(s, tmp_path)
+    assert out.exists()
+    # display reads the saved state, no rebuild
+    assert s.default_state(base_dir=tmp_path) == {"count": 5}
+
+
+def test_default_state_missing_artifact_returns_none(tmp_path):
+    s = CompositeSpec(id="m.g", name="g", builder=lambda core=None: {"state": {}},
+                      default_state_ref="absent.json")
+    assert s.default_state(base_dir=tmp_path) is None
+```
+
+- [ ] **Step 2: Run → fail.** `regenerate_default_state` undefined; `default_state` returns None for the artifact case.
+
+- [ ] **Step 3: Implement** — replace `default_state` and add `regenerate_default_state`:
+
+```python
+    def default_state(self, base_dir=None) -> "dict | None":
+        if self.state is not None:
+            return self.state
+        if self.default_state_ref and base_dir is not None:
+            artifact = Path(base_dir) / self.default_state_ref
+            if artifact.is_file():
+                data = json.loads(artifact.read_text(encoding="utf-8"))
+                return data.get("state", data)
+        return None
+```
+
+```python
+def regenerate_default_state(spec: CompositeSpec, base_dir, core=None) -> "Path":
+    """Run a generator's builder with default params, serialize the materialized
+    state, and write the ``default_state_ref`` artifact (+ a provenance stamp).
+
+    This is the one step that needs the heavy build environment (e.g. a ParCa
+    cache for v2ecoli baseline). Display thereafter reads the artifact, no build.
+    """
+    if spec.kind != "generator" or not spec.default_state_ref:
+        raise ValueError("regenerate_default_state requires a generator with default_state_ref")
+    comp = spec.to_composite(core=core)
+    state = comp.serialize_state()
+    param_sig = {k: v.get("default") for k, v in spec.parameters.items()}
+    out = Path(base_dir) / spec.default_state_ref
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps({"state": state, "_provenance": {"param_signature": param_sig}},
+                              indent=2), encoding="utf-8")
+    return out
+```
+
+- [ ] **Step 4: Run → pass.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add process_bigraph/composite_spec.py process_bigraph/tests/test_composite_spec.py
+git commit -m "feat(composite-spec): regenerate_default_state + artifact-backed default_state"
+```
+
+---
+
+### Task 6: Export from `process_bigraph.__init__`
+
+**Files:**
+- Modify: `process_bigraph/__init__.py:3-8`
+- Test: `process_bigraph/tests/test_composite_spec.py` (append)
+
+**Interfaces — Produces:** top-level imports `from process_bigraph import CompositeSpec, composite_spec, discover_specs`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_top_level_exports():
+    import process_bigraph as pbg
+    assert hasattr(pbg, "CompositeSpec")
+    assert hasattr(pbg, "composite_spec")      # the decorator
+    assert hasattr(pbg, "discover_specs")
+```
+
+- [ ] **Step 2: Run → fail.** AttributeError.
+
+- [ ] **Step 3: Implement** — add to `process_bigraph/__init__.py` after the existing `from process_bigraph.composite import (...)` block (around line 6):
+
+```python
+from process_bigraph.composite_spec import (
+    CompositeSpec, composite_spec, discover_specs, regenerate_default_state,
+    register, get, all_specs, clear_registry, normalize_type, CANONICAL_TYPES,
+)
+```
+
+- [ ] **Step 4: Run → pass.** Also run the WHOLE process-bigraph suite to confirm no import cycle: `.venv/bin/python -m pytest -q` (composite_spec imports `process_bigraph.Composite` lazily inside methods, so no cycle at import time).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add process_bigraph/__init__.py process_bigraph/tests/test_composite_spec.py
+git commit -m "feat(composite-spec): export CompositeSpec API from process_bigraph"
+```
+
+---
+
+### Task 7: pbg-superpowers shim — `composite_generator` delegates to process-bigraph
+
+**Worktree (create first):** `git -C /Users/eranagmon/code/pbg-superpowers worktree add -b feat/composite-spec-shim /Users/eranagmon/code/pbg-spec-shim origin/main` — work in `/Users/eranagmon/code/pbg-spec-shim`.
+
+**Files:**
+- Modify: `pbg_superpowers/composite_generator.py` (decorator + `build_generator` + `discover_generators` delegate; keep `GeneratorEntry`, `emitter_defaults`, `apply_core_extensions`, `install_default_emitters` intact for the dashboard's reads)
+- Test: `tests/test_composite_generator.py` (append delegation tests)
+
+**Interfaces — Consumes:** `process_bigraph.composite_spec` (Tasks 1–6). **Produces:** unchanged public surface — `@composite_generator(...)` still works and registers into the process-bigraph registry; `_REGISTRY` reflects those registrations as `GeneratorEntry`-compatible objects; `build_generator(entry, overrides)` returns the builder document; `discover_generators()` returns the entries.
+
+**Constraint:** the dashboard reads these `entry` attributes today — preserve them all: `.id, .name, .description, .parameters, .module, .default_n_steps, .visualizations, .emitters, .core_extensions, .func`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_composite_generator.py (append)
+def test_composite_generator_registers_into_process_bigraph_registry():
+    from process_bigraph import composite_spec as cs
+    from pbg_superpowers.composite_generator import composite_generator, build_generator
+    cs.clear_registry()
+
+    @composite_generator(name="shimdemo", parameters={"seed": {"type": "int", "default": 1}})
+    def shimdemo(core=None, *, seed=1):
+        return {"state": {"s": seed}}
+
+    spec_id = f"{shimdemo.__module__}.shimdemo"
+    spec = cs.get(spec_id)
+    assert spec is not None and spec.parameters["seed"]["type"] == "integer"
+    # build_generator delegates to the spec's document
+    assert build_generator(spec, overrides={"seed": 3}) == {"state": {"s": 3}}
+```
+
+- [ ] **Step 2: Run → fail.** Old `composite_generator` writes its own `_REGISTRY`, not process-bigraph's.
+
+- [ ] **Step 3: Implement** — in `pbg_superpowers/composite_generator.py`:
+  1. Keep the `GeneratorEntry` dataclass (the dashboard's read shape) and `emitter_defaults`/`apply_core_extensions`/`install_default_emitters` as-is.
+  2. Make `composite_generator(...)` build a `process_bigraph.composite_spec.CompositeSpec` (via `cs.composite_spec(...)`), then ALSO register a `GeneratorEntry` view so `_REGISTRY` exposes the dashboard-read attributes. Implement `_REGISTRY` as a module object whose `get`/`__contains__`/`values`/`items` read from `cs.all_specs()` and wrap each `CompositeSpec` in a `GeneratorEntry` (mapping `spec.builder→.func`, `spec.*→.*`). Simplest correct form:
+
+```python
+from process_bigraph import composite_spec as _cs
+
+def composite_generator(*, name, description="", parameters=None, visualizations=None,
+                        emitters=None, default_n_steps=None, core_extensions=None,
+                        default_state_ref=None):
+    _validate_emitters(emitters, name)
+    def decorate(fn):
+        _cs.composite_spec(
+            name=name, description=description, parameters=parameters,
+            visualizations=visualizations, emitters=emitters,
+            default_n_steps=default_n_steps, core_extensions=core_extensions,
+            default_state_ref=default_state_ref,
+        )(fn)
+        return fn
+    return decorate
+
+
+def _entry_for(spec):
+    """Adapt a process-bigraph CompositeSpec to the GeneratorEntry the dashboard reads."""
+    return GeneratorEntry(
+        id=spec.id, name=spec.name, description=spec.description,
+        parameters=spec.parameters, func=_cs._resolve_builder(spec.builder, spec.module),
+        module=spec.module, default_n_steps=spec.default_n_steps,
+        visualizations=spec.visualizations, emitters=spec.emitters,
+        core_extensions=spec.core_extensions,
+    )
+
+
+class _RegistryView:
+    def get(self, k, default=None):
+        s = _cs.get(k)
+        return _entry_for(s) if s is not None else default
+    def __getitem__(self, k):
+        s = _cs.get(k)
+        if s is None:
+            raise KeyError(k)
+        return _entry_for(s)
+    def __contains__(self, k):
+        return _cs.get(k) is not None
+    def values(self):
+        return [_entry_for(s) for s in _cs.all_specs().values()]
+    def items(self):
+        return [(sid, _entry_for(s)) for sid, s in _cs.all_specs().items()]
+    def __iter__(self):
+        return iter(_cs.all_specs())
+    def __bool__(self):
+        return bool(_cs.all_specs())
+    def clear(self):
+        _cs.clear_registry()
+
+_REGISTRY = _RegistryView()
+
+
+def build_generator(entry, overrides=None, core=None):
+    """Delegate to the CompositeSpec document. ``entry`` may be a GeneratorEntry
+    (has ``.id``) or a CompositeSpec."""
+    spec = _cs.get(getattr(entry, "id", None)) or entry
+    return spec.to_document(overrides, core=core)
+
+
+def discover_generators(extra_search_paths=None):
+    # keep the existing distribution-walking import logic; then return entries
+    _import_bigraph_packages(extra_search_paths)   # existing helper that imports packages
+    return {sid: _entry_for(s) for sid, s in _cs.all_specs().items()
+            if s.kind == "generator"}
+```
+
+  (Keep the existing distribution-walk body of `discover_generators` — extract it into `_import_bigraph_packages` if not already separate. `apply_core_extensions(entry, core)` keeps working: it reads `entry.core_extensions`.)
+
+- [ ] **Step 4: Run → pass.** `cd /Users/eranagmon/code/pbg-spec-shim && python -m pytest tests/test_composite_generator.py -v`. Also run the full `pytest -q` to confirm no regression in the dashboard-facing reads.
+
+- [ ] **Step 5: Commit** `feat(shim): composite_generator delegates to process-bigraph CompositeSpec registry`.
+
+---
+
+### Task 8: pbg-superpowers shim — `composite_spec` (static) + `composite_discovery` delegate
+
+**Worktree:** same `/Users/eranagmon/code/pbg-spec-shim`.
+
+**Files:**
+- Modify: `pbg_superpowers/composite_spec.py` (delegate parsing/substitution/build to process-bigraph; keep `install_default_emitters` call for behaviour parity)
+- Modify: `pbg_superpowers/composite_discovery.py` (`discover_all` returns specs via `CompositeSpec.from_file`)
+- Test: `tests/test_composite_spec.py` (append)
+
+**Interfaces — Consumes:** `process_bigraph.composite_spec`. **Produces:** unchanged signatures — `load_spec(path)`, `validate_spec(spec)`, `substitute_parameters(state, params, overrides)`, `build_composite_from_spec(spec, overrides=None, core=None)`; `discover_all(...)` still returns `{id: {kind, …}}`.
+
+**Constraint:** `build_composite_from_spec` must preserve its existing emitter behaviour (it calls `install_default_emitters` before constructing the Composite) and its `requires.processes` preflight.
+
+- [ ] **Step 1: Write the failing/championing test**
+
+```python
+def test_build_composite_from_spec_uses_unified_substitution():
+    from pbg_superpowers.composite_spec import build_composite_from_spec
+    spec = {"name": "c", "parameters": {"seed": {"type": "int", "default": 2}},
+            "state": {"v": "${seed}"}}
+    comp = build_composite_from_spec(spec, overrides={"seed": 9})
+    # substitution happened via the unified engine (typed int)
+    assert comp.state["v"] == 9 if hasattr(comp, "state") else True
+
+
+def test_substitute_parameters_delegates():
+    from pbg_superpowers import composite_spec as legacy
+    out = legacy.substitute_parameters({"a": "${x}"}, {"x": {"type": "int", "default": 0}}, {"x": 5})
+    assert out == {"a": 5}
+```
+
+- [ ] **Step 2: Run → fail / verify.** (If behaviour already matches, make `substitute_parameters` a re-export to prove single-sourcing.)
+
+- [ ] **Step 3: Implement** — re-point the static module at the unified engine, keeping the wrapper behaviour:
+
+```python
+from process_bigraph.composite_spec import substitute_parameters  # single source
+
+# load_spec stays (file IO). validate_spec stays but widen the allowed types to the
+# canonical vocabulary + aliases (accept what normalize_type accepts) so existing
+# files using integer/boolean/number/object don't raise.
+
+def build_composite_from_spec(spec, overrides=None, core=None):
+    validate_spec(spec)
+    from process_bigraph import Composite, allocate_core
+    from process_bigraph.composite_spec import CompositeSpec
+    if core is None:
+        core = allocate_core()
+    # requires.processes preflight (unchanged)
+    requires = spec.get("requires") or {}
+    proc_required = requires.get("processes") or []
+    link_registry = getattr(core, "link_registry", {}) or {}
+    missing = [p for p in proc_required if p not in link_registry]
+    if missing:
+        raise RuntimeError(f"composite spec '{spec.get('name')}' requires processes "
+                           f"not in registry: {missing}.")
+    cspec = CompositeSpec(
+        id=spec.get("id") or f"spec.{spec.get('name')}", name=spec.get("name"),
+        state=spec.get("state") or {}, schema=dict(spec.get("schema") or {}),
+        parameters=dict(spec.get("parameters") or {}), requires=requires,
+        emitters=list(spec.get("emitters") or []))
+    doc = cspec.to_document(overrides)
+    state = doc["state"]
+    from pbg_superpowers.composite_generator import install_default_emitters
+    state = install_default_emitters(state, spec, core=core)
+    return Composite({"schema": doc.get("schema") or {}, "state": state}, core=core)
+```
+
+  Update `validate_spec` line 57 to accept the canonical+alias type set:
+  `if "type" in pdef and normalize_type(pdef["type"]) not in CANONICAL_TYPES:` (import both from `process_bigraph.composite_spec`).
+  In `composite_discovery.discover_all`, build spec entries via `CompositeSpec.from_file(fp).to_dict()` tagged `kind` (generator entries already come from the generator shim).
+
+- [ ] **Step 4: Run → pass.** `python -m pytest tests/test_composite_spec.py tests/test_composite_generator.py -v` + full `pytest -q`.
+
+- [ ] **Step 5: Commit** `feat(shim): static composite_spec + discovery delegate to process-bigraph; widen type vocab`.
+
+---
+
+### Task 9: Dashboard — resolve against the new contract + structured wiring payload
+
+**Worktree (create first):** `git -C /Users/eranagmon/code/vivarium-dashboard worktree add -b feat/composite-spec-resolve /Users/eranagmon/code/vdash-composite-spec origin/main` — work in `/Users/eranagmon/code/vdash-composite-spec`.
+
+**Files:**
+- Modify: `vivarium_dashboard/lib/composite_resolve.py` (resolve via process-bigraph registry; add `default_state` wiring + `wiring_status`/`notice`)
+- Modify: `vivarium_dashboard/api/app.py` (`/api/composite-resolve` returns 200-with-metadata when wiring is unavailable, not a swallowed 404)
+- Modify: `vivarium_dashboard/lib/models.py` (`CompositeResolvePayload`: add optional `analyses`, `visualizations`, `emitters`, `schema`, `requires`, `tags`, `wiring_status`, `notice`)
+- Test: `tests/test_composite_resolve_dispatch.py` (or the existing composite-resolve test file)
+
+**Interfaces — Consumes:** `process_bigraph.composite_spec.{discover_specs,get}`, `CompositeSpec.default_state`. **Produces:** `resolve_composite(ws_root, spec_id, overrides=None) -> dict | None` returning `{id, name, description, parameters, state, schema, requires, tags, visualizations, analyses, emitters, kind, module, default_n_steps, wiring_status, notice}`. `wiring_status ∈ {"ready", "unavailable"}`.
+
+**Constraint:** a generator whose default-state artifact is missing returns **200 + metadata + `wiring_status:"unavailable"` + honest `notice`**, NOT a swallowed None→404. A genuinely-unregistered id still returns None→404.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def test_resolve_generator_without_artifact_degrades(tmp_path, monkeypatch):
+    from process_bigraph import composite_spec as cs
+    from vivarium_dashboard.lib import composite_resolve as cr
+    cs.clear_registry()
+    cs.register(cs.CompositeSpec(id="m.g", name="g", builder=lambda core=None: {"state": {}},
+                                 default_state_ref="m.g.default-state.json",
+                                 parameters={"seed": {"type": "integer", "default": 0}}))
+    monkeypatch.setattr(cr, "discover_specs", lambda ws=None: cs.all_specs())
+    out = cr.resolve_composite(tmp_path, "m.g")
+    assert out["wiring_status"] == "unavailable" and out["notice"]
+    assert out["parameters"]["seed"]["type"] == "integer"   # metadata present without build
+    assert out["state"] is None
+
+
+def test_resolve_static_ready(tmp_path, monkeypatch):
+    from process_bigraph import composite_spec as cs
+    from vivarium_dashboard.lib import composite_resolve as cr
+    cs.clear_registry()
+    cs.register(cs.CompositeSpec(id="m.c", name="c", state={"v": 1}, schema={"v": "float"}))
+    monkeypatch.setattr(cr, "discover_specs", lambda ws=None: cs.all_specs())
+    out = cr.resolve_composite(tmp_path, "m.c")
+    assert out["wiring_status"] == "ready" and out["state"] == {"v": 1}
+
+
+def test_resolve_unregistered_returns_none(tmp_path, monkeypatch):
+    from process_bigraph import composite_spec as cs
+    from vivarium_dashboard.lib import composite_resolve as cr
+    cs.clear_registry()
+    monkeypatch.setattr(cr, "discover_specs", lambda ws=None: {})
+    assert cr.resolve_composite(tmp_path, "absent") is None
+```
+
+- [ ] **Step 2: Run → fail.**
+
+- [ ] **Step 3: Implement** — rewrite `resolve_composite` in `composite_resolve.py` to use the unified registry (keep `resolve_composite_for_request` from SP-D1 wrapping it for remote builds):
+
+```python
+from process_bigraph.composite_spec import discover_specs, get as _get_spec  # module-level for monkeypatch
+
+def resolve_composite(ws_root, spec_id, overrides=None):
+    ws_root = Path(ws_root)
+    _ws_add_to_sys_path(ws_root)
+    specs = discover_specs(workspace=ws_root)
+    spec = specs.get(spec_id)
+    if spec is None:
+        return None
+    base_dir = _artifact_base_dir(ws_root, spec)   # where default-state artifacts live
+    state = spec.default_state(base_dir=base_dir)
+    wiring_status = "ready" if state is not None else "unavailable"
+    notice = None
+    if wiring_status == "unavailable":
+        notice = (f"default state for generator '{spec.name}' is not generated yet — "
+                  f"run it, or regenerate its default-state artifact to see wiring.")
+    try:
+        from vivarium_dashboard.lib.process_docs import attach_process_docs
+        if state is not None:
+            attach_process_docs(state)
+    except Exception:
+        pass
+    return {
+        "id": spec.id, "name": spec.name, "description": spec.description,
+        "parameters": spec.parameters, "state": state, "schema": spec.schema,
+        "requires": spec.requires, "tags": spec.tags,
+        "visualizations": spec.visualizations, "analyses": spec.analyses,
+        "emitters": spec.emitters, "kind": spec.kind, "module": spec.module,
+        "default_n_steps": spec.default_n_steps, "svg": None,
+        "wiring_status": wiring_status, "notice": notice,
+    }
+```
+
+  Add `_artifact_base_dir(ws_root, spec)` returning the dashboard's existing
+  `api/composite-state/` dir if present else `ws_root` (resolve in code review against
+  the §13 artifact-location decision). In `app.py`, the `/api/composite-resolve` handler
+  returns `CompositeResolvePayload.model_validate(result)` for a non-None result (200,
+  including `wiring_status:"unavailable"`), and only 404s when `result is None`. Add the
+  new optional fields to `CompositeResolvePayload` in `models.py`.
+
+- [ ] **Step 4: Run → pass.** Test command: `cd /Users/eranagmon/code/vdash-composite-spec && PYTHONPATH=$PWD:/Users/eranagmon/code/investigation-contracts /Users/eranagmon/code/v2ecoli/.venv/bin/python -m pytest tests/test_composite_resolve_dispatch.py -v`.
+
+- [ ] **Step 5: Commit** `feat(dashboard): resolve composites via process-bigraph CompositeSpec + structured wiring payload`.
+
+---
+
+### Task 10: Dashboard — Explorer bug fix (remove the hardcoded remote-build error)
+
+**Worktree:** same `/Users/eranagmon/code/vdash-composite-spec`.
+
+**Files:**
+- Modify: `vivarium_dashboard/static/walkthrough.js:~4176-4190` (`_ceFetch`)
+- Modify: `vivarium_dashboard/static/walkthrough.js` (the explorer render path — surface `wiring_status`/`notice`)
+- Test: add a small JS-logic test if the repo has a JS test harness; otherwise a Python smoke test asserting the served file no longer contains the hardcoded string.
+
+**Interfaces — Consumes:** the Task 9 payload (`wiring_status`, `notice`). **Produces:** the explorer renders metadata + the server `notice` for `wiring_status:"unavailable"`; no hardcoded remote-build text.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_explorer_no_hardcoded_remote_build.py
+from pathlib import Path
+def test_walkthrough_has_no_hardcoded_remote_build_message():
+    js = Path("vivarium_dashboard/static/walkthrough.js").read_text(encoding="utf-8")
+    assert "remote build cannot build generator composites" not in js
+```
+
+- [ ] **Step 2: Run → fail.** The string is present.
+
+- [ ] **Step 3: Implement** — in `_ceFetch`, replace the hardcoded fallback message with the server's real error, and render `wiring_status`/`notice`:
+
+```javascript
+var msg = (d && (d.error || d.detail || d.notice)) ? (d.error || d.detail || d.notice)
+  : ('HTTP ' + r.status + ' — could not resolve this composite.');
+return { error: msg };
+```
+
+  In the explorer render path, when a resolved payload has `wiring_status === 'unavailable'`,
+  show the config form + metadata and render `notice` as an inline info banner (not an error),
+  instead of treating the missing wiring as a hard failure.
+
+- [ ] **Step 4: Run → pass.** Plus a manual check: open the Explorer on a local generator with no artifact → metadata + honest notice, no "remote build" text.
+
+- [ ] **Step 5: Commit** `fix(dashboard): replace hardcoded remote-build explorer error with the server notice`.
+
+---
+
+### Task 11: Proof — migrate `baseline` (generator) + `growth-division` (static); generate baseline artifact
+
+**Worktrees:** v2ecoli (`/Users/eranagmon/code/v2e-main` or a fresh worktree off origin/main) + pbg-autopoiesis (fresh worktree off origin/main). The artifact-generation step needs a ParCa cache (run on the mini or a checkout with `out/cache`).
+
+**Files:**
+- Modify: `v2ecoli/v2ecoli/composites/baseline.py` — the `@composite_generator` decorator now flows through the shim (no source change required); ADD `default_state_ref="baseline.default-state.json"` once the decorator/shim supports passing it through (extend the generator shim decorator to accept + forward `default_state_ref` — a one-line addition in Task 7's `composite_generator`).
+- Create: `v2ecoli/.../composites/baseline.default-state.json` (generated artifact, committed)
+- Modify (if needed): `pbg-autopoiesis/.../growth-division.composite.yaml` — confirm it loads via `CompositeSpec.from_file` unchanged (it already has `schema: {population: tree}` + `parameters` + `state`).
+- Test: `v2ecoli` smoke test + autopoiesis smoke test.
+
+**Interfaces — Consumes:** the full stack (Tasks 1–10).
+
+- [ ] **Step 1: Static proof (headless).** In an autopoiesis worktree with process-bigraph + the shims installed, assert the YAML loads + resolves:
+
+```python
+def test_growth_division_loads_as_composite_spec():
+    from process_bigraph.composite_spec import CompositeSpec
+    p = "pbg_autopoiesis/composites/growth-division.composite.yaml"
+    s = CompositeSpec.from_file(p)
+    assert s.kind == "spec" and s.schema == {"population": "tree"}
+    assert s.default_state() == s.state  # static display state present, no build
+```
+
+Run → pass.
+
+- [ ] **Step 2: Generator metadata proof (headless).** Assert baseline registers with the new contract and exposes metadata WITHOUT a build:
+
+```python
+def test_baseline_registers_with_metadata():
+    import v2ecoli.composites.baseline  # triggers @composite_generator
+    from process_bigraph import composite_spec as cs
+    spec = cs.get("v2ecoli.composites.baseline.baseline")  # id = "<module>.<name>"
+    assert spec is not None and spec.kind == "generator"
+    assert spec.default_n_steps == 2700
+    assert all(p["type"] in cs.CANONICAL_TYPES for p in spec.parameters.values())  # normalized
+    assert spec.default_state_ref == "baseline.default-state.json"
+```
+
+Run → pass (after adding `default_state_ref` to the baseline decorator + the shim forward).
+
+- [ ] **Step 3: Generate the artifact (IN-THE-LOOP — needs a ParCa cache).** On the mini (or a checkout with `out/cache`):
+
+```bash
+cd <v2ecoli-with-cache>
+.venv/bin/python -c "import v2ecoli.composites.baseline; \
+from process_bigraph import composite_spec as cs, regenerate_default_state; \
+spec = cs.get('v2ecoli.composites.baseline.baseline'); \
+print(regenerate_default_state(spec, 'v2ecoli/composites'))"
+```
+
+Commit the generated `baseline.default-state.json`.
+
+- [ ] **Step 4: Dashboard display proof.** Start the dashboard on the v2ecoli workspace; open the Composite Explorer for `baseline` with NO ParCa cache on the dashboard host → it renders the config form + metadata + wiring from the artifact, no ParCa, no "remote build" error. Open `growth-division` → renders from inline state.
+
+- [ ] **Step 5: Commit** the artifact + any `default_state_ref` wiring + smoke tests: `feat(proof): baseline + growth-division on CompositeSpec; commit baseline default-state artifact`.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §2 architecture + §3 contract → Tasks 1–6 (dataclass, types, resolution, decorator, registry, discovery, regenerate, exports). ✓
+- §3 `schema` + `requires.{processes,types}` + whole-document passthrough + canonical types → Task 1 (validation/normalization) + Task 2 (`to_document` passthrough) + Task 4 (`from_file` carries schema/requires). ✓
+- §5 two front-ends + shim → Tasks 7 (generator) + 8 (static + discovery). ✓
+- §4 registry & discovery → Tasks 3 + 4. ✓
+- §6 dashboard resolve + display robustness + bug fix → Tasks 9 + 10. ✓
+- §3a/§4 saved default state → Task 5 (`regenerate_default_state` + artifact `default_state`) + Task 9 (display from it). ✓
+- §10 testing + §11 proof → Task 11 (static headless + generator metadata headless + the one in-the-loop artifact gen + display proof). ✓
+- §3a config_overrides convention → Task 2 note (`_merged_params` forwards a declared `config_overrides` param; no special logic). ✓
+
+**Placeholder scan:** Task 9's `_artifact_base_dir` and Task 11's `default_state_ref` decorator-forward are the two spots that defer a small decision to code review (artifact location, §13 OQ2) — both have a concrete default specified, not a TODO. No "add error handling"/"TBD" placeholders.
+
+**Type consistency:** `CompositeSpec` field names + method signatures are fixed in the Contract block and reused verbatim in Tasks 1–11. Registry fns named `register/get/all_specs/clear_registry` consistently (note: `all_specs`, not `all`, to avoid shadowing the builtin — used the same in tests). `discover_specs(workspace=...)`, `regenerate_default_state(spec, base_dir, core=None)`, `default_state(base_dir=None)`, `to_document(overrides=None, core=None)` consistent across the dashboard task and the proof task. The generator shim maps `CompositeSpec.builder → GeneratorEntry.func` consistently in `_entry_for`.
+
+## Execution Handoff
+
+Pre-flight conflict: Task 11 requires the generator shim decorator (Task 7) to accept + forward a `default_state_ref` kwarg — fold that one-line addition into Task 7 (note added there). No other cross-task contradictions found.

--- a/docs/superpowers/plans/2026-06-28-composite-spec-unified-declaration.md
+++ b/docs/superpowers/plans/2026-06-28-composite-spec-unified-declaration.md
@@ -1006,7 +1006,12 @@ def build_composite_from_spec(spec, overrides=None, core=None):
 - Modify: `vivarium_dashboard/lib/models.py` (`CompositeResolvePayload`: add optional `analyses`, `visualizations`, `emitters`, `schema`, `requires`, `tags`, `wiring_status`, `notice`)
 - Test: `tests/test_composite_resolve_dispatch.py` (or the existing composite-resolve test file)
 
-**Interfaces — Consumes:** `process_bigraph.composite_spec.{discover_specs,get}`, `CompositeSpec.default_state`. **Produces:** `resolve_composite(ws_root, spec_id, overrides=None) -> dict | None` returning `{id, name, description, parameters, state, schema, requires, tags, visualizations, analyses, emitters, kind, module, default_n_steps, wiring_status, notice}`. `wiring_status ∈ {"ready", "unavailable"}`.
+**Interfaces — Consumes:** `process_bigraph.composite_spec.{get, CompositeSpec}`, `CompositeSpec.default_state`, `vivarium_dashboard.lib.composite_lookup.find_composite_path`. **Produces:** `resolve_composite(ws_root, spec_id, overrides=None) -> dict | None` returning `{id, name, description, parameters, state, schema, requires, tags, visualizations, analyses, emitters, kind, module, default_n_steps, svg, wiring_status, notice}`. `wiring_status ∈ {"ready", "unavailable"}`.
+
+**CRITICAL — preserve the dashboard's id addressing (dual-branch resolve).** The dashboard LISTS composites via `composite_lookup.discover_all_composites` → `pbg_superpowers.composite_discovery.discover_all`, which addresses **generators by `"<module>.<name>"`** and **static specs by `"<pkg>.composites.<stem>"`** (the scheme `find_composite_path` decodes). These are TWO different id schemes, and `CompositeSpec.from_file`'s own default id (`"<stem>.<name>"`) matches NEITHER. So resolve MUST mirror the existing dual-branch lookup, NOT a single `registry.get(spec_id)`:
+1. **Generator branch:** prime the registry, then `spec = _get_spec(spec_id)` (process-bigraph registry; ids are `"<module>.<name>"`).
+2. **Static branch (spec is None):** `path = find_composite_path(ws_root, pkg, spec_id)`; if found, `spec = CompositeSpec.from_file(path)`. The payload's `id` is the REQUESTED `spec_id` (not `spec.id`), so it round-trips with what the dashboard listed.
+3. Neither → `None` (→ 404).
 
 **Constraint:** a generator whose default-state artifact is missing returns **200 + metadata + `wiring_status:"unavailable"` + honest `notice`**, NOT a swallowed None→404. A genuinely-unregistered id still returns None→404.
 
@@ -1020,60 +1025,93 @@ def test_resolve_generator_without_artifact_degrades(tmp_path, monkeypatch):
     cs.register(cs.CompositeSpec(id="m.g", name="g", builder=lambda core=None: {"state": {}},
                                  default_state_ref="m.g.default-state.json",
                                  parameters={"seed": {"type": "integer", "default": 0}}))
-    monkeypatch.setattr(cr, "discover_specs", lambda ws=None: cs.all_specs())
+    monkeypatch.setattr(cr, "_prime_registry", lambda: None)  # don't walk real distributions
     out = cr.resolve_composite(tmp_path, "m.g")
     assert out["wiring_status"] == "unavailable" and out["notice"]
     assert out["parameters"]["seed"]["type"] == "integer"   # metadata present without build
-    assert out["state"] is None
+    assert out["state"] is None and out["kind"] == "generator"
 
 
-def test_resolve_static_ready(tmp_path, monkeypatch):
-    from process_bigraph import composite_spec as cs
+def test_resolve_static_via_find_path(tmp_path, monkeypatch):
+    # A real static spec file resolved through the dashboard's id scheme
+    # "<pkg>.composites.<stem>" via find_composite_path.
     from vivarium_dashboard.lib import composite_resolve as cr
+    from process_bigraph import composite_spec as cs
     cs.clear_registry()
-    cs.register(cs.CompositeSpec(id="m.c", name="c", state={"v": 1}, schema={"v": "float"}))
-    monkeypatch.setattr(cr, "discover_specs", lambda ws=None: cs.all_specs())
-    out = cr.resolve_composite(tmp_path, "m.c")
+    (tmp_path / "workspace.yaml").write_text("name: demo-ws\npackage_path: pbg_demo\n", encoding="utf-8")
+    comp = tmp_path / "pbg_demo" / "composites"
+    comp.mkdir(parents=True)
+    (comp / "c.composite.yaml").write_text(
+        "name: c\nschema:\n  v: float\nstate:\n  v: 1\n", encoding="utf-8")
+    monkeypatch.setattr(cr, "_prime_registry", lambda: None)
+    out = cr.resolve_composite(tmp_path, "pbg_demo.composites.c")
+    assert out is not None and out["id"] == "pbg_demo.composites.c"  # requested id round-trips
     assert out["wiring_status"] == "ready" and out["state"] == {"v": 1}
+    assert out["schema"] == {"v": "float"} and out["kind"] == "spec"
 
 
 def test_resolve_unregistered_returns_none(tmp_path, monkeypatch):
     from process_bigraph import composite_spec as cs
     from vivarium_dashboard.lib import composite_resolve as cr
     cs.clear_registry()
-    monkeypatch.setattr(cr, "discover_specs", lambda ws=None: {})
-    assert cr.resolve_composite(tmp_path, "absent") is None
+    monkeypatch.setattr(cr, "_prime_registry", lambda: None)
+    assert cr.resolve_composite(tmp_path, "pbg_demo.composites.absent") is None
 ```
 
 - [ ] **Step 2: Run → fail.**
 
-- [ ] **Step 3: Implement** — rewrite `resolve_composite` in `composite_resolve.py` to use the unified registry (keep `resolve_composite_for_request` from SP-D1 wrapping it for remote builds):
+- [ ] **Step 3: Implement** — rewrite `resolve_composite` in `composite_resolve.py` (keep `resolve_composite_for_request` from SP-D1 wrapping it for remote builds). Mirror the EXISTING dual-branch structure; only the payload construction changes to use `CompositeSpec`:
 
 ```python
-from process_bigraph.composite_spec import discover_specs, get as _get_spec  # module-level for monkeypatch
+import yaml
+from process_bigraph.composite_spec import CompositeSpec, get as _get_spec  # module-level for monkeypatch
+
+
+def _prime_registry():
+    """Best-effort: import bigraph-schema packages so decorator-registered
+    generators populate the process-bigraph registry. Monkeypatched in tests."""
+    try:
+        from pbg_superpowers.composite_generator import discover_generators
+        discover_generators()
+    except Exception:
+        pass
+
+
+def _artifact_base_dir(ws_root, spec):
+    """Where a generator's default-state artifact lives. Reuses the dashboard's
+    existing snapshot dir if present, else the workspace root (§13 OQ2)."""
+    snap = Path(ws_root) / "api" / "composite-state"
+    return snap if snap.is_dir() else Path(ws_root)
+
 
 def resolve_composite(ws_root, spec_id, overrides=None):
     ws_root = Path(ws_root)
     _ws_add_to_sys_path(ws_root)
-    specs = discover_specs(workspace=ws_root)
-    spec = specs.get(spec_id)
-    if spec is None:
-        return None
-    base_dir = _artifact_base_dir(ws_root, spec)   # where default-state artifacts live
-    state = spec.default_state(base_dir=base_dir)
+    _prime_registry()
+    spec = _get_spec(spec_id)                       # generator branch: "<module>.<name>"
+    if spec is None:                                # static branch: "<pkg>.composites.<stem>"
+        from vivarium_dashboard.lib.composite_lookup import find_composite_path
+        ws_yaml = ws_root / "workspace.yaml"
+        ws_data = yaml.safe_load(ws_yaml.read_text(encoding="utf-8")) if ws_yaml.is_file() else {}
+        pkg = ws_data.get("package_path") or ("pbg_" + str(ws_data.get("name", "")).replace("-", "_"))
+        path = find_composite_path(ws_root, pkg, spec_id)
+        if path is None:
+            return None
+        spec = CompositeSpec.from_file(path)
+    state = spec.default_state(base_dir=_artifact_base_dir(ws_root, spec))
     wiring_status = "ready" if state is not None else "unavailable"
     notice = None
     if wiring_status == "unavailable":
         notice = (f"default state for generator '{spec.name}' is not generated yet — "
-                  f"run it, or regenerate its default-state artifact to see wiring.")
-    try:
-        from vivarium_dashboard.lib.process_docs import attach_process_docs
-        if state is not None:
+                  f"run it, or regenerate its default-state artifact to see the wiring.")
+    if state is not None:
+        try:
+            from vivarium_dashboard.lib.process_docs import attach_process_docs
             attach_process_docs(state)
-    except Exception:
-        pass
+        except Exception:
+            pass
     return {
-        "id": spec.id, "name": spec.name, "description": spec.description,
+        "id": spec_id, "name": spec.name, "description": spec.description,
         "parameters": spec.parameters, "state": state, "schema": spec.schema,
         "requires": spec.requires, "tags": spec.tags,
         "visualizations": spec.visualizations, "analyses": spec.analyses,
@@ -1083,12 +1121,18 @@ def resolve_composite(ws_root, spec_id, overrides=None):
     }
 ```
 
-  Add `_artifact_base_dir(ws_root, spec)` returning the dashboard's existing
-  `api/composite-state/` dir if present else `ws_root` (resolve in code review against
-  the §13 artifact-location decision). In `app.py`, the `/api/composite-resolve` handler
-  returns `CompositeResolvePayload.model_validate(result)` for a non-None result (200,
-  including `wiring_status:"unavailable"`), and only 404s when `result is None`. Add the
-  new optional fields to `CompositeResolvePayload` in `models.py`.
+  In `app.py`, the `/api/composite-resolve` handler returns
+  `CompositeResolvePayload.model_validate(result)` for a non-None result (200, including
+  `wiring_status:"unavailable"`), and only 404s when `result is None`. Add the new optional
+  fields to `CompositeResolvePayload` in `models.py` (`schema: dict = {}`, `requires: dict = {}`,
+  `tags: list = []`, `analyses: list = []`, `visualizations: list = []`, `emitters: list = []`,
+  `wiring_status: str | None = None`, `notice: str | None = None`) — all optional/defaulted so
+  existing callers/snapshots stay valid. **Type-string tolerance:** the dashboard's parameter
+  form/widget code must accept the canonical type vocabulary (`integer`/`boolean`/`float`/
+  `map`/`list`), since the unified path normalizes `int`/`bool`/etc. Grep the param-form code
+  (JS `configure-run.js`/`walkthrough.js` + any Python widget mapping) for exact-string matches
+  on `"int"`/`"bool"`/`"str"`/`"number"`; if found, map them through the canonical set (or accept
+  both). This closes the cross-task `int→integer` hazard flagged in Tasks 7-8.
 
 - [ ] **Step 4: Run → pass.** Test command: `cd /Users/eranagmon/code/vdash-composite-spec && PYTHONPATH=$PWD:/Users/eranagmon/code/investigation-contracts /Users/eranagmon/code/v2ecoli/.venv/bin/python -m pytest tests/test_composite_resolve_dispatch.py -v`.
 

--- a/docs/superpowers/plans/2026-06-28-composite-spec-unified-declaration.md
+++ b/docs/superpowers/plans/2026-06-28-composite-spec-unified-declaration.md
@@ -17,7 +17,7 @@
 - **A Composite DOCUMENT is `{schema, state, …}`** — generator builders may return extra exec keys (`skip_initial_steps`, `sequential_steps`, `flow_order`, `run_steps_on_init`); `to_document`/`to_composite` forward the WHOLE document verbatim, never narrowed to `{state, schema}`.
 - **`core_extensions` are load-bearing** — applied to the core BEFORE the builder runs.
 - **Worktrees:** process-bigraph work is in `/Users/eranagmon/code/pbg-composite-spec` (branch `feat/composite-spec`). Tasks 7–8 (pbg-superpowers) and 9–10 (vivarium-dashboard) each need their own worktree off `origin/main` — create at task start (see each task). Proof (Task 11) spans v2ecoli + autopoiesis worktrees.
-- **Test command (process-bigraph):** `cd /Users/eranagmon/code/pbg-composite-spec && .venv/bin/python -m pytest process_bigraph/tests/test_composite_spec.py -v`. Ruff: `.venv/bin/ruff check process_bigraph/composite_spec.py`.
+- **Test command (process-bigraph):** the worktree has no `.venv`; use the main checkout's interpreter, which imports the worktree's local `process_bigraph/` because CWD is on `sys.path`: `cd /Users/eranagmon/code/pbg-composite-spec && /Users/eranagmon/code/process-bigraph/.venv/bin/python -m pytest process_bigraph/tests/test_composite_spec.py -v`. Ruff: `/Users/eranagmon/code/process-bigraph/.venv/bin/ruff check process_bigraph/composite_spec.py` (or `python -m ruff` if the `ruff` entrypoint is absent).
 
 ## The Canonical Contract (every task depends on these exact signatures)
 

--- a/docs/superpowers/specs/2026-06-28-composite-spec-unified-declaration-design.md
+++ b/docs/superpowers/specs/2026-06-28-composite-spec-unified-declaration-design.md
@@ -1,0 +1,248 @@
+# CompositeSpec — Unified Composite Declaration — Design
+
+**Date:** 2026-06-28
+**Status:** Design (brainstormed + grounded in a process-bigraph / pbg-superpowers / vivarium-dashboard survey; approved section-by-section by user)
+**Author:** Eran Agmon (with Claude)
+**Repos touched:** `process-bigraph` (new abstraction — center of gravity), `pbg-superpowers` (back-compat shim), `vivarium-dashboard` (resolve against the new contract + display robustness + bug fix). Workspaces (`v2ecoli`, `pbg-autopoiesis`) provide the two proof composites.
+
+## 1. Context & goal
+
+Today a "composite" can be declared two incompatible ways, and a third object (the runtime
+`Composite`) knows about neither:
+
+- **`@composite_generator` decorator** (in `pbg-superpowers`) — Python code + a module-level
+  `_REGISTRY`. Rich metadata: `parameters`, `visualizations`, `emitters`, `default_n_steps`,
+  `core_extensions`. Runs a builder (`build_core`/ParCa) to *generate* state dynamically. This is what
+  v2ecoli's `baseline` uses.
+- **`*.composite.yaml` / `.json` spec files** — static data. Has `name`/`description`/`parameters`/
+  `state`/`emitters`/`tags`/`requires`, with `${param}` substitution. **No** visualizations, analyses,
+  or `default_n_steps`. Cannot run code.
+- **`process_bigraph.Composite`** — the runtime object. Consumes `{schema, state, interface, bridge,
+  …}`. Has `serialize_state()`/`serialize_schema()` but **zero** notion of parameters, runtime,
+  visualizations, analyses, or emitters. No registry, no decorator.
+
+The trigger: the dashboard's Composite Explorer cannot robustly display a generator composite. Opening
+v2ecoli `baseline` locally without a ParCa `out/cache` makes `build_generator` throw →
+`resolve_composite` swallows it to `None` → 404 → the client (`walkthrough.js:4186`) prints a
+hardcoded, **misleading** message ("a remote build cannot build generator composites (no local ParCa
+cache)") even though the workspace is local.
+
+**Goal:** one declarative descriptor — **`CompositeSpec`** — that lives in `process-bigraph` next to
+`Composite`, carries all authoring/UI metadata, knows how to produce a runtime `Composite`, and always
+resolves to a **default state** for display without running ParCa. Both existing front-ends (decorator,
+YAML file) reconcile onto this one contract and one registry. The dashboard reads exactly one contract.
+
+### Approved decisions (from brainstorming)
+1. **Descriptor wrapping `Composite`** — a new `CompositeSpec` class carries the metadata + a state
+   source; it *produces* a `Composite` document. `Composite`'s runtime `config_schema` is **not**
+   bloated with authoring fields. (Rejected: extending `Composite` itself; a frozen-JSON-only format.)
+2. **Two front-ends, one contract** — keep both authoring styles, both producing/registering a
+   `CompositeSpec` into one `process-bigraph` registry: a decorator (moved to `process-bigraph`) for
+   code/generator composites, and a YAML/JSON file for static ones. "Reconciled" = identical metadata
+   fields + one registry + one resolve contract, two ways to author.
+3. **Foundation + one proof each** — build the abstraction + a `pbg-superpowers` shim + the dashboard
+   resolve/display + the bug fix; prove on **one generator** (v2ecoli `baseline`) and **one static**
+   (autopoiesis `growth-division`). Migrating all other composites, an analyses **execution** runner,
+   and removing the shim are follow-ups.
+4. **Saved default state for display** (replaces a live "skeleton" build) — every `CompositeSpec`
+   resolves to a *default state* for display, regardless of kind: a static composite's inline `state`
+   *is* its default state; a generator ships a **saved, regenerable default-state artifact** (run the
+   builder once with default params, serialize, commit). Display reads that — **no ParCa at display
+   time, ever.** (Rejected: a `structure_only`/skeleton builder mode — risked entanglement with
+   ParCa-gated process assembly in `build_core`.)
+5. **Inline state for static + a sibling file for generators** — a static composite inlines its small
+   `state` in the descriptor; a generator references a sibling `<id>.default-state.json` (v2ecoli
+   baseline state is thousands of molecules — too big to inline). The descriptor stays small.
+
+## 2. Architecture
+
+```
+@composite_spec  ─┐
+                  ├─►  CompositeSpec  ──►  registry  ──►  dashboard / runners
+*.composite.yaml ─┘         │
+                            ├─ .to_composite(overrides, core) ─►  Composite   (full materialize)
+                            ├─ .default_state()               ─►  state dict  (display; NO ParCa)
+                            ├─ .to_document(overrides)        ─►  {schema, state}  (process-bigraph doc)
+                            └─ .to_dict() / .from_dict()       ─►  the portable composite JSON
+```
+
+`CompositeSpec` is a `@dataclass` in `process_bigraph` (new module `process_bigraph/composite_spec.py`).
+It aligns with `Composite` by **producing its document**, not by sharing its class.
+
+## 3. The `CompositeSpec` contract (the "composite JSON that captures what we need")
+
+```
+# identity
+id: str                       # canonical "<module>.<name>"
+name: str
+description: str = ""
+tags: list[str] = []
+
+# configuration surface
+parameters: dict[str, dict]   # {name: {type, default, description?, choices?}}
+default_n_steps: int | None = None
+
+# associated artifacts — DECLARATIVE this round (stored + surfaced; execution = follow-up)
+visualizations: list[dict] = []   # study-spec viz dicts
+analyses:       list[dict] = []   # NEW field, same {address, config?, …} declarative shape
+emitters:       list[dict] = []   # {address, config?, paths?}
+requires: dict = {}               # {processes: [...]} (carried from YAML)
+
+# the body — EXACTLY ONE state source (validated):
+state:   dict | None = None       # static composites inline this (also serves as default state)
+builder: Callable | str | None    # generator: a callable in code; a dotted "pkg.mod:fn" in JSON
+
+# generator-only: where the saved materialized default state lives
+default_state_ref: str | None = None   # e.g. "<id>.default-state.json" (sibling artifact)
+
+# code-only (not serialized)
+core_extensions: list[Callable] = []
+```
+
+**Methods**
+- `to_composite(overrides=None, core=None) -> Composite` — resolve `${param}` substitution (static) or
+  call the builder with merged defaults+overrides (generator); hand the document to `Composite(document, core)`.
+- `to_document(overrides=None) -> dict` — the resolved `{schema, state}` doc, without instantiating `Composite`.
+- `default_state(base_dir=None) -> dict | None` — the state used for **display**: inline `state` (static)
+  or the parsed `default_state_ref` artifact (generator). Returns `None` if a generator's artifact is
+  missing/not-yet-generated (→ dashboard shows the honest degrade notice). **Never runs the builder.**
+- `to_dict() / from_dict(d)` — round-trip the portable JSON. A code `builder` callable serializes to its
+  dotted `"pkg.mod:fn"` path; `from_dict` leaves it as a string (resolved lazily on `to_composite`).
+- **Validation:** exactly one of `state` / `builder` is set; a `builder` may additionally carry a
+  `default_state_ref`; `default_state_ref` without a `builder` is an error.
+
+**Regeneration (generator default-state artifact)**
+- `regenerate_default_state(spec, base_dir, core=None) -> Path` — run `spec.to_composite()` with default
+  params, serialize via `Composite.serialize_state()`, write `<base_dir>/<id>.default-state.json` with a
+  small provenance stamp (`{generated_from_commit, param_signature, generated_with}`). This mirrors the
+  existing dashboard `regenerate_composite_states.py` pattern. A CI/freshness check (compare stamp vs
+  current commit/param signature) is a **follow-up**, not in this spec.
+
+## 4. Registry & discovery
+
+- A module-level registry in `process_bigraph` (`composite_spec._REGISTRY: dict[str, CompositeSpec]`),
+  with `register(spec)`, `get(id)`, `all()`.
+- `@composite_spec(...)` registers on import (`builder=<the decorated fn>`).
+- `CompositeSpec.from_file(path)` parses a `*.composite.{yaml,json}` into a spec.
+- `discover_specs(workspace=None) -> dict[str, CompositeSpec]` — (a) imports installed packages that
+  depend on `bigraph-schema` (triggering decorators, same walk `discover_generators` does today) **and**
+  (b) scans a workspace's `composites/` directory for spec files, merging both into the one registry.
+  Idempotent; safe to call repeatedly.
+
+## 5. Authoring front-ends + the pbg-superpowers shim
+
+- **`@composite_spec(...)`** (in `process-bigraph`) — same kwargs the current `@composite_generator`
+  exposes (`name`, `description`, `parameters`, `visualizations`, `emitters`, `default_n_steps`,
+  `core_extensions`) **plus** `analyses` and `tags`. Builds + registers a `CompositeSpec` with
+  `builder=<fn>`.
+- **YAML/JSON loader** — `from_file` accepts the existing spec-file keys and the new `analyses`. A static
+  file's `state` becomes the spec's inline `state`. A file MAY instead declare `builder: "pkg.mod:fn"` +
+  `default_state_ref` for a generator authored as data (not required for this round).
+- **pbg-superpowers shim** — `@composite_generator`, `_REGISTRY`, `build_generator`,
+  `discover_generators` become **thin delegators** to the `process-bigraph` registry:
+  - `@composite_generator(**kw)` maps its kwargs onto `@composite_spec(**kw)` (no `analyses`/`tags` →
+    defaults) and registers the same `CompositeSpec`.
+  - `_REGISTRY` is a view/alias onto `process_bigraph.composite_spec._REGISTRY` keyed identically, with
+    a `GeneratorEntry`-compatible shim object (same attributes the dashboard reads today) so existing
+    imports keep working.
+  - `build_generator(entry, overrides)` delegates to the spec's `to_document(overrides)`.
+  - `discover_generators()` delegates to `discover_specs()`.
+  - **v2ecoli's existing `@composite_generator(...)` usage is unchanged.** Removing the shim is a
+    follow-up.
+
+## 6. Dashboard resolve + display robustness + the bug fix
+
+- **Resolve against the new contract** — `vivarium_dashboard/lib/composite_resolve.py::resolve_composite`
+  resolves through the `process-bigraph` registry (the shim keeps the current `pbg_superpowers` import
+  path working during transition). For the Explorer it returns:
+  - **metadata** (name, description, parameters, default_n_steps, visualizations, analyses, emitters) —
+    straight from the descriptor, **zero build**;
+  - **wiring state** from `spec.default_state(base_dir)` — the inline state (static) or the saved
+    artifact (generator), **no ParCa**.
+- **Structured payload** — distinguish *not-found* (404, `unresolved`) from *found-but-no-default-state*
+  (200 + metadata + `wiring_status: "ready" | "unavailable"` + an honest `notice` when a generator's
+  artifact hasn't been generated). Display always shows the config form + metadata even when wiring is
+  unavailable.
+- **Bug fix** — delete the hardcoded "a remote build cannot build generator composites (no local ParCa
+  cache)" string at `walkthrough.js:~4186`; render the server's actual `error`/`notice`/`wiring_status`
+  instead. The misleading remote-build framing is removed for both local and remote workspaces.
+
+## 7. Components (each independently testable)
+
+- **process-bigraph:** `CompositeSpec` dataclass + validation; `to_composite` / `to_document` /
+  `default_state`; `to_dict`/`from_dict` round-trip; `@composite_spec` decorator + registry +
+  `discover_specs`; `regenerate_default_state`. Unit-tested with a **fake builder** (no ParCa).
+- **pbg-superpowers:** the shim — old `@composite_generator` still registers; `_REGISTRY` view exposes
+  the dashboard-read attributes; `build_generator` / `discover_generators` delegate.
+- **vivarium-dashboard:** `resolve_composite` returns metadata + default-state wiring + `wiring_status`;
+  the structured 404-vs-200 payload; the `walkthrough.js` bug fix.
+
+## 8. Data flow / shape
+
+The dashboard's resolve payload stays **shape-compatible** with today's `CompositeResolvePayload`
+(`{id, name, description, parameters, state, svg, kind, module, default_n_steps}`), **plus** new
+optional `analyses`, `visualizations`, `emitters`, `wiring_status`, and `notice` fields. SP-C's config
+form and the Explorer keep working; the new fields are additive.
+
+## 9. Error handling
+
+| Case | Behavior |
+|---|---|
+| Composite id not registered | 404 `{error, unresolved:true, ref}` (unchanged) |
+| Generator, default-state artifact missing | 200 metadata + `wiring_status:"unavailable"` + honest `notice` ("default state not generated — run regenerate or run the composite"); config form still renders |
+| Static spec / generator with artifact present | 200 full payload incl. wiring `state` |
+| Spec file malformed | `from_file` raises a typed error; loader skips it with a logged warning (discovery stays robust) |
+| `to_composite` builder raises at RUN time | propagates to the run path (not the display path) — display never builds |
+
+## 10. Testing
+
+- **process-bigraph (headless, no ParCa):** construct/validate (exactly-one-of `state`/`builder`;
+  `default_state_ref` requires `builder`); `to_dict`/`from_dict` round-trip incl. dotted-builder
+  serialization; `to_document`/`to_composite` produce a runnable `Composite` (fake builder returning a
+  small doc); `default_state` reads inline state and a sibling artifact, and returns `None` when the
+  artifact is absent; decorator registers into the registry; `discover_specs` merges decorator + file
+  specs; `regenerate_default_state` writes the artifact + stamp.
+- **pbg-superpowers (headless):** old `@composite_generator` registers a `CompositeSpec`; `_REGISTRY`
+  view exposes the attributes the dashboard reads; `build_generator` delegates to `to_document`;
+  `discover_generators` delegates.
+- **vivarium-dashboard (headless, fakes only):** generator-without-cache resolves to metadata +
+  `wiring_status:"unavailable"` + notice (no ParCa); generator-with-artifact resolves full wiring;
+  static composite resolves from inline state; the client renders the server notice (no hardcoded
+  remote-build string).
+- **Proof (in-the-loop where ParCa is needed):** v2ecoli `baseline` — `regenerate_default_state`
+  produces + commits `baseline.default-state.json` **once** (needs a ParCa cache, on the machine that
+  has it); thereafter the dashboard displays baseline with **no ParCa**. autopoiesis `growth-division`
+  — static, resolves from inline `state`. The artifact generation for baseline is the one step that
+  needs a real environment; everything else is headless.
+
+## 11. Scope boundaries
+
+**In:** the `process-bigraph` `CompositeSpec` abstraction (class, validation, `to_composite`/
+`to_document`/`default_state`/`to_dict`/`from_dict`, decorator, registry, `discover_specs`,
+`regenerate_default_state`); the `pbg-superpowers` shim; the dashboard resolve-against-new-contract +
+saved-default-state display + the `walkthrough.js` bug fix; proof on `baseline` (generator) +
+`growth-division` (static).
+
+**Out (follow-ups):** migrating all other composites onto the contract; an **analyses execution**
+runner (analyses are declarative-only this round); a CI **freshness check** for generator default-state
+artifacts; **removing** the pbg-superpowers shim; the deployment/sms-api default-state path (ties into
+SP-D — a remote build could ship its default-state artifact in the workspace tarball).
+
+## 12. Realism / build split (READ FIRST)
+
+- **Headless-doable now:** the entire `process-bigraph` abstraction + shim + dashboard wiring + bug
+  fix + all unit tests (fake builders, no ParCa). The static proof (`growth-division`) is headless.
+- **One in-the-loop step:** generating `baseline.default-state.json` requires a real ParCa cache (run
+  `regenerate_default_state` on the machine/worktree that has `out/cache`, e.g. the mini). After that
+  one-time artifact commit, the dashboard proof is headless.
+
+## 13. Open questions (resolve in planning)
+
+1. **`_REGISTRY` view shape** — exact `GeneratorEntry`-compatible shim object the dashboard reads
+   (`.name`, `.description`, `.parameters`, `.module`, `.default_n_steps`, `.visualizations`,
+   `.emitters`). Enumerate every attribute the current dashboard touches and mirror it.
+2. **Artifact location convention** — `<id>.default-state.json` beside the spec module vs a workspace
+   `composites/_state/` dir vs the dashboard's existing `api/composite-state/<id>.json`. Pick one in
+   planning; prefer reusing the dashboard snapshot convention if it fits.
+3. **`from_file` builder authoring** — confirm the data-authored-generator path (`builder:` +
+   `default_state_ref` in YAML) is specified but un-proven this round (no proof composite uses it).

--- a/docs/superpowers/specs/2026-06-28-composite-spec-unified-declaration-design.md
+++ b/docs/superpowers/specs/2026-06-28-composite-spec-unified-declaration-design.md
@@ -1,7 +1,7 @@
 # CompositeSpec — Unified Composite Declaration — Design
 
 **Date:** 2026-06-28
-**Status:** Design (brainstormed + grounded in a process-bigraph / pbg-superpowers / vivarium-dashboard survey; approved section-by-section by user)
+**Status:** Design (brainstormed + grounded in a process-bigraph / pbg-superpowers / vivarium-dashboard survey; **contract validated against the full ecosystem** — all 13 v2ecoli generators, 93 YAML composites across ~20 pbg-* repos, and ~12 study specs — see §3a; approved section-by-section by user)
 **Author:** Eran Agmon (with Claude)
 **Repos touched:** `process-bigraph` (new abstraction — center of gravity), `pbg-superpowers` (back-compat shim), `vivarium-dashboard` (resolve against the new contract + display robustness + bug fix). Workspaces (`v2ecoli`, `pbg-autopoiesis`) provide the two proof composites.
 
@@ -80,36 +80,75 @@ tags: list[str] = []
 
 # configuration surface
 parameters: dict[str, dict]   # {name: {type, default, description?, choices?}}
-default_n_steps: int | None = None
+                              # `type` ∈ a CANONICAL vocabulary (see "Parameter types" below);
+                              # aliases (bool/boolean, float/number, int/integer) normalized on load.
+default_n_steps: int | None = None   # a DEFAULT/fallback, NOT a hard bound — studies override per run/variant
 
-# associated artifacts — DECLARATIVE this round (stored + surfaced; execution = follow-up)
+# associated artifacts — DECLARATIVE this round (stored + surfaced; execution = follow-up).
+# These are an OPEN menu: studies extend freely and are not constrained to these lists.
+# `state` may ALSO contain inline emitter/viz/analysis STEPS; these fields are the
+# declarative, dashboard-facing surface, not a closed set.
 visualizations: list[dict] = []   # study-spec viz dicts
 analyses:       list[dict] = []   # NEW field, same {address, config?, …} declarative shape
 emitters:       list[dict] = []   # {address, config?, paths?}
-requires: dict = {}               # {processes: [...]} (carried from YAML)
+
+requires: dict = {}               # {processes: [...], types: [...]} — process AND external-type deps
+schema:  dict = {}                # bigraph-schema type declarations for stores (e.g. {population: tree});
+                                  # the static counterpart of a generator document's "schema" envelope key.
+                                  # A Composite DOCUMENT is {schema, state, …} — the spec carries both.
 
 # the body — EXACTLY ONE state source (validated):
-state:   dict | None = None       # static composites inline this (also serves as default state)
-builder: Callable | str | None    # generator: a callable in code; a dotted "pkg.mod:fn" in JSON
+state:   dict | None = None       # static composites inline this (paired with optional `schema`);
+                                  # also serves as the default state for display
+builder: Callable | str | None    # generator: a callable in code; a dotted "pkg.mod:fn" in JSON.
+                                  # Returns a process-bigraph DOCUMENT dict — {state, schema?, and
+                                  # composite-exec keys: skip_initial_steps?, sequential_steps?,
+                                  # flow_order?, run_steps_on_init?}. `to_composite`/`to_document`
+                                  # forward the WHOLE document to Composite(); `default_state` reads
+                                  # only its `state` (from the saved artifact).
 
 # generator-only: where the saved materialized default state lives
 default_state_ref: str | None = None   # e.g. "<id>.default-state.json" (sibling artifact)
 
-# code-only (not serialized)
+# code-only (not serialized) — register types/processes on the core (e.g. map[pymunk_agent],
+# parca core, millard links). LOAD-BEARING and applied to the core BEFORE the builder runs;
+# required for builds in sandboxed/subprocess environments (and for regenerate_default_state).
 core_extensions: list[Callable] = []
 ```
 
+**Parameter types (canonical vocabulary + alias normalization).** The audit found the same
+semantic type spelled inconsistently across composites (`bool`/`boolean`, `float`/`number`,
+`int`/`integer`). The contract defines a canonical set — `integer`, `float`, `string`, `boolean`,
+`list`, `map`/`object` — and the decorator + `from_file` loader **normalize known aliases** to it
+(`bool→boolean`, `number→float`, `int→integer`). Unknown types load as-is with a logged warning.
+This is part of "make it robust": the dashboard config form keys rendering off a single vocabulary.
+
+**Deep-path overrides convention.** Two override styles exist in studies: flat
+`parameter_overrides` (validated against `parameters`) and deep-path `config_overrides` like
+`ecoli-polypeptide-elongation.basal_elongation_rate: 28` (targets `<process>.<config-key>`). The
+latter is NOT a separate contract mechanism — it is a **builder-provided escape hatch**: a generator
+declares a `config_overrides` parameter (type `map`) and applies the patches to its built document
+itself (as v2ecoli `baseline()` does, baseline.py:696). `to_composite(overrides)` forwards all
+overrides to the builder; flat `parameters` are the validated knobs, `config_overrides` is the typed,
+declared escape hatch. No deep-path-aware logic lives in `CompositeSpec`.
+
 **Methods**
-- `to_composite(overrides=None, core=None) -> Composite` — resolve `${param}` substitution (static) or
-  call the builder with merged defaults+overrides (generator); hand the document to `Composite(document, core)`.
-- `to_document(overrides=None) -> dict` — the resolved `{schema, state}` doc, without instantiating `Composite`.
-- `default_state(base_dir=None) -> dict | None` — the state used for **display**: inline `state` (static)
-  or the parsed `default_state_ref` artifact (generator). Returns `None` if a generator's artifact is
-  missing/not-yet-generated (→ dashboard shows the honest degrade notice). **Never runs the builder.**
+- `to_composite(overrides=None, core=None) -> Composite` — apply `core_extensions` to the core FIRST, then
+  resolve `${param}` substitution over `{schema, state}` (static) or call the builder with merged
+  defaults+overrides (generator); hand the **whole** resolved document to `Composite(document, core)`.
+- `to_document(overrides=None) -> dict` — the resolved process-bigraph document, WITHOUT instantiating
+  `Composite`. For a static spec: `{schema, state}` after substitution. For a generator: the entire dict
+  the builder returns (`state`, optional `schema`, plus any composite-exec keys like `skip_initial_steps`,
+  `sequential_steps`, `flow_order`) — passed through verbatim, never narrowed to just state+schema.
+- `default_state(base_dir=None) -> dict | None` — the **state** used for display: inline `state` (static)
+  or the `state` of the parsed `default_state_ref` artifact (generator). Returns `None` if a generator's
+  artifact is missing/not-yet-generated (→ dashboard shows the honest degrade notice). **Never runs the
+  builder; needs no core_extensions** (the artifact is already materialized).
 - `to_dict() / from_dict(d)` — round-trip the portable JSON. A code `builder` callable serializes to its
   dotted `"pkg.mod:fn"` path; `from_dict` leaves it as a string (resolved lazily on `to_composite`).
-- **Validation:** exactly one of `state` / `builder` is set; a `builder` may additionally carry a
-  `default_state_ref`; `default_state_ref` without a `builder` is an error.
+- **Validation:** exactly one of `state` / `builder` is set; `schema` may accompany `state` (static) and
+  defaults to `{}`; a `builder` may additionally carry a `default_state_ref`; `default_state_ref` without
+  a `builder` is an error; parameter `type`s are normalized to the canonical vocabulary on construction.
 
 **Regeneration (generator default-state artifact)**
 - `regenerate_default_state(spec, base_dir, core=None) -> Path` — run `spec.to_composite()` with default
@@ -117,6 +156,40 @@ core_extensions: list[Callable] = []
   small provenance stamp (`{generated_from_commit, param_signature, generated_with}`). This mirrors the
   existing dashboard `regenerate_composite_states.py` pattern. A CI/freshness check (compare stamp vs
   current commit/param signature) is a **follow-up**, not in this spec.
+
+## 3a. Coverage — validated against the ecosystem
+
+The contract was audited against real usage: **all 13 `@composite_generator` generators in v2ecoli**,
+**93 `*.composite.{yaml,json}` files across ~20 pbg-* repos** (autopoiesis, bioreactordesign,
+membrane-actin, tyssue, copasi, tellurium, smoldyn, martini, comets, mem3dg, cellpack, yalla, biomodels,
+nfsim, readdy, medyan, lammps, compucell3d, parsimony, caspule), and **the study→composite interface
+across ~12 `study.yaml` files** (v2ecoli, v2e-invest, autopoiesis, viva-munk, sms-ecoli, bioreactordesign).
+
+| Capability seen in practice | Source | Covered by |
+|---|---|---|
+| name / description / tags | all | `name`/`description`/`tags` |
+| flat config knobs | all generators + most YAML | `parameters` (canonical types) |
+| string enums | baseline `emitter` | `parameters[].choices` |
+| default run length | v2ecoli `default_n_steps`, incl. dynamic (`len(STEP_ORDER)`) | `default_n_steps` (fallback) |
+| declarative viz / emitters / analyses | v2ecoli decorator; tyssue top-level `emitters` | `visualizations`/`emitters`/`analyses` (open menu) |
+| inline emitter/viz STEPS in state | membrane-actin (8 viz steps) | `state` (steps live in state; the fields above are the declarative surface) |
+| process deps | most YAML `requires.processes` | `requires.processes` |
+| **external type deps** | tyssue `requires.types` | **`requires.types` (added)** |
+| **store type declarations** | autopoiesis `schema: {population: tree}`; builder `{state, schema}` envelope | **`schema` (added)** |
+| **composite-exec doc keys** | v2ecoli builders return `skip_initial_steps`/`sequential_steps`/`flow_order` | **whole-document passthrough (added)** |
+| core/type registration | 5 v2ecoli composites (`core_extensions`) | `core_extensions` (load-bearing, pre-builder) |
+| flat parameter_overrides | v4 studies | `parameters` (validated) |
+| deep-path `config_overrides` | param-uq studies; `baseline(config_overrides=…)` | builder escape-hatch param of type `map` (documented convention) |
+| static (data) composite | autopoiesis, all pbg-* wrappers | `state` (+ `schema`) inline |
+| generator (code) composite | v2ecoli | `builder` + saved `default_state_ref` |
+
+**Study-level, NOT composite gaps (out of scope by design):** variant/condition declaration,
+`parameter_overrides`/`config_overrides` *values*, per-variant seeds/durations, `default_emitter` choice
+at run time, `observables`/`readouts`/`behavior_tests`, `pipeline_gate`/`prerequisites`,
+`enforced_params` (critical-param locking). The composite exposes the parameter/emitter/analysis
+**surface**; the study OWNS which variants to run and what to measure. An optional future
+`parameters[].enforced: <reason>` flag (to let a composite mark a knob whose change invalidates the
+model, e.g. v2ecoli `mode: full`) is noted but **deferred** — YAGNI for this round.
 
 ## 4. Registry & discovery
 
@@ -135,9 +208,12 @@ core_extensions: list[Callable] = []
   exposes (`name`, `description`, `parameters`, `visualizations`, `emitters`, `default_n_steps`,
   `core_extensions`) **plus** `analyses` and `tags`. Builds + registers a `CompositeSpec` with
   `builder=<fn>`.
-- **YAML/JSON loader** — `from_file` accepts the existing spec-file keys and the new `analyses`. A static
-  file's `state` becomes the spec's inline `state`. A file MAY instead declare `builder: "pkg.mod:fn"` +
-  `default_state_ref` for a generator authored as data (not required for this round).
+- **YAML/JSON loader** — `from_file` accepts the existing spec-file keys (`name`, `description`, `tags`,
+  `parameters`, `state`, `emitters`, `requires.processes`) plus the keys the audit surfaced: `analyses`,
+  `visualizations`, `default_n_steps`, top-level `schema`, and `requires.types`. A static file's `state`
+  (+ optional `schema`) becomes the spec's inline body; parameter `type`s are alias-normalized. A file MAY
+  instead declare `builder: "pkg.mod:fn"` + `default_state_ref` for a generator authored as data (specified
+  but un-proven this round — no proof composite uses it).
 - **pbg-superpowers shim** — `@composite_generator`, `_REGISTRY`, `build_generator`,
   `discover_generators` become **thin delegators** to the `process-bigraph` registry:
   - `@composite_generator(**kw)` maps its kwargs onto `@composite_spec(**kw)` (no `analyses`/`tags` →
@@ -181,8 +257,8 @@ core_extensions: list[Callable] = []
 
 The dashboard's resolve payload stays **shape-compatible** with today's `CompositeResolvePayload`
 (`{id, name, description, parameters, state, svg, kind, module, default_n_steps}`), **plus** new
-optional `analyses`, `visualizations`, `emitters`, `wiring_status`, and `notice` fields. SP-C's config
-form and the Explorer keep working; the new fields are additive.
+optional `analyses`, `visualizations`, `emitters`, `schema`, `requires`, `tags`, `wiring_status`, and
+`notice` fields. SP-C's config form and the Explorer keep working; the new fields are additive.
 
 ## 9. Error handling
 
@@ -197,11 +273,14 @@ form and the Explorer keep working; the new fields are additive.
 ## 10. Testing
 
 - **process-bigraph (headless, no ParCa):** construct/validate (exactly-one-of `state`/`builder`;
-  `default_state_ref` requires `builder`); `to_dict`/`from_dict` round-trip incl. dotted-builder
-  serialization; `to_document`/`to_composite` produce a runnable `Composite` (fake builder returning a
-  small doc); `default_state` reads inline state and a sibling artifact, and returns `None` when the
-  artifact is absent; decorator registers into the registry; `discover_specs` merges decorator + file
-  specs; `regenerate_default_state` writes the artifact + stamp.
+  `schema` pairs with `state`; `default_state_ref` requires `builder`); parameter-`type` alias
+  normalization (`bool→boolean`, `number→float`, `int→integer`); `to_dict`/`from_dict` round-trip incl.
+  dotted-builder serialization, `schema`, and `requires.{processes,types}`; `to_document` forwards a
+  generator's WHOLE document (extra keys like `skip_initial_steps`/`flow_order` preserved);
+  `to_composite` applies `core_extensions` before building and produces a runnable `Composite` (fake
+  builder returning a small doc); `default_state` reads inline state and the `state` of a sibling
+  artifact, and returns `None` when the artifact is absent; decorator registers into the registry;
+  `discover_specs` merges decorator + file specs; `regenerate_default_state` writes the artifact + stamp.
 - **pbg-superpowers (headless):** old `@composite_generator` registers a `CompositeSpec`; `_REGISTRY`
   view exposes the attributes the dashboard reads; `build_generator` delegates to `to_document`;
   `discover_generators` delegates.
@@ -217,8 +296,9 @@ form and the Explorer keep working; the new fields are additive.
 
 ## 11. Scope boundaries
 
-**In:** the `process-bigraph` `CompositeSpec` abstraction (class, validation, `to_composite`/
-`to_document`/`default_state`/`to_dict`/`from_dict`, decorator, registry, `discover_specs`,
+**In:** the `process-bigraph` `CompositeSpec` abstraction (class with `schema` + `requires.{processes,
+types}` + canonical parameter-type normalization, validation, `to_composite`/`to_document` [whole-document
+passthrough]/`default_state`/`to_dict`/`from_dict`, decorator, registry, `discover_specs`,
 `regenerate_default_state`); the `pbg-superpowers` shim; the dashboard resolve-against-new-contract +
 saved-default-state display + the `walkthrough.js` bug fix; proof on `baseline` (generator) +
 `growth-division` (static).
@@ -244,5 +324,6 @@ SP-D — a remote build could ship its default-state artifact in the workspace t
 2. **Artifact location convention** — `<id>.default-state.json` beside the spec module vs a workspace
    `composites/_state/` dir vs the dashboard's existing `api/composite-state/<id>.json`. Pick one in
    planning; prefer reusing the dashboard snapshot convention if it fits.
-3. **`from_file` builder authoring** — confirm the data-authored-generator path (`builder:` +
-   `default_state_ref` in YAML) is specified but un-proven this round (no proof composite uses it).
+3. **Canonical type vocabulary final list** — confirm the exact set + alias map (the audit found
+   `bool`/`boolean`, `float`/`number`, `int`/`integer`, plus `object`/`map`); decide whether `map` or
+   `object` is canonical. Normalize the existing v2ecoli composites' types as part of the proof.

--- a/process_bigraph/__init__.py
+++ b/process_bigraph/__init__.py
@@ -1,15 +1,15 @@
-from bigraph_schema import allocate_core
+from bigraph_schema import allocate_core  # noqa: F401
 
-from process_bigraph.composite import (
+from process_bigraph.composite import (  # noqa: F401
     Process, Step, Composite, TimingSummary, interval_time_precision, wire_step_layers,
 )
-from process_bigraph.composite_spec import (
+from process_bigraph.composite_spec import (  # noqa: F401
     CompositeSpec, discover_specs, regenerate_default_state,
     normalize_type, CANONICAL_TYPES,
 )
-from process_bigraph.bundle import load_bundle
-from process_bigraph.emitter import Emitter, gather_emitter_results, generate_emitter_state
-from process_bigraph.types import StepLink, ProcessLink, CompositeLink
+from process_bigraph.bundle import load_bundle  # noqa: F401
+from process_bigraph.emitter import Emitter, gather_emitter_results, generate_emitter_state  # noqa: F401
+from process_bigraph.types import StepLink, ProcessLink, CompositeLink  # noqa: F401
 
 
 import pprint

--- a/process_bigraph/__init__.py
+++ b/process_bigraph/__init__.py
@@ -3,6 +3,10 @@ from bigraph_schema import allocate_core
 from process_bigraph.composite import (
     Process, Step, Composite, TimingSummary, interval_time_precision, wire_step_layers,
 )
+from process_bigraph.composite_spec import (
+    CompositeSpec, discover_specs, regenerate_default_state,
+    normalize_type, CANONICAL_TYPES,
+)
 from process_bigraph.bundle import load_bundle
 from process_bigraph.emitter import Emitter, gather_emitter_results, generate_emitter_state
 from process_bigraph.types import StepLink, ProcessLink, CompositeLink

--- a/process_bigraph/composite_spec.py
+++ b/process_bigraph/composite_spec.py
@@ -192,3 +192,51 @@ class CompositeSpec:
         if self.state is not None:
             return self.state
         return None  # generator artifact path implemented in Task 5
+
+
+_REGISTRY: "dict[str, CompositeSpec]" = {}
+
+
+def register(spec: CompositeSpec) -> None:
+    _REGISTRY[spec.id] = spec
+
+
+def get(spec_id: str) -> "CompositeSpec | None":
+    return _REGISTRY.get(spec_id)
+
+
+def all_specs() -> "dict[str, CompositeSpec]":
+    return dict(_REGISTRY)
+
+
+def clear_registry() -> None:
+    _REGISTRY.clear()
+
+
+def composite_spec(*, name, description="", parameters=None, visualizations=None,
+                   emitters=None, analyses=None, tags=None, default_n_steps=None,
+                   core_extensions=None, default_state_ref=None):
+    """Decorator: register a generator function as a CompositeSpec.
+
+    The wrapped fn becomes the spec's ``builder``; its id is
+    ``"<fn.__module__>.<name>"``. Returns the original fn unchanged.
+    """
+    def decorate(fn):
+        spec = CompositeSpec(
+            id=f"{fn.__module__}.{name}",
+            name=name,
+            description=description or (fn.__doc__ or "").strip().split("\n")[0],
+            tags=list(tags or []),
+            parameters=dict(parameters or {}),
+            default_n_steps=default_n_steps,
+            visualizations=list(visualizations or []),
+            analyses=list(analyses or []),
+            emitters=list(emitters or []),
+            builder=fn,
+            module=fn.__module__,
+            default_state_ref=default_state_ref,
+            core_extensions=list(core_extensions or []),
+        )
+        register(spec)
+        return fn
+    return decorate

--- a/process_bigraph/composite_spec.py
+++ b/process_bigraph/composite_spec.py
@@ -138,10 +138,12 @@ class CompositeSpec:
                              "from the builder document")
         if self.default_state_ref is not None and not has_builder:
             raise ValueError("`default_state_ref` requires a `builder`")
-        # normalize parameter types in place
-        for pdef in self.parameters.values():
-            if isinstance(pdef, dict) and "type" in pdef:
-                pdef["type"] = normalize_type(pdef["type"])
+        # normalize parameter types (non-mutating rebuild)
+        self.parameters = {
+            k: ({**v, "type": normalize_type(v["type"])}
+                if isinstance(v, dict) and "type" in v else v)
+            for k, v in self.parameters.items()
+        }
 
     @property
     def kind(self) -> str:

--- a/process_bigraph/composite_spec.py
+++ b/process_bigraph/composite_spec.py
@@ -1,0 +1,91 @@
+"""Unified composite declaration for process-bigraph.
+
+A CompositeSpec is the declarative descriptor a composite is authored as —
+either inline data (``state`` + optional ``schema``) for a static composite, or
+a ``builder`` callable for a generator composite. It carries the dashboard/UI
+metadata (parameters, default_n_steps, visualizations, analyses, emitters,
+requires) and produces a runtime ``process_bigraph.Composite``.
+
+This unifies (and is the new home of) the two front-ends that previously lived
+separately in pbg-superpowers: the static ``composite_spec`` spec-file format
+and the ``composite_generator`` decorator. Those become thin shims over this.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+from typing import Callable
+
+CANONICAL_TYPES = {"integer", "float", "string", "boolean", "list", "map"}
+
+_TYPE_ALIASES = {
+    "integer": "integer", "int": "integer",
+    "float": "float", "number": "float", "double": "float",
+    "string": "string", "str": "string",
+    "boolean": "boolean", "bool": "boolean",
+    "list": "list", "array": "list",
+    "map": "map", "object": "map", "dict": "map",
+}
+
+
+def normalize_type(t: str) -> str:
+    """Map a parameter ``type`` string onto the canonical vocabulary.
+
+    Known aliases collapse (int→integer, number→float, bool→boolean,
+    object→map, array→list); an unknown type passes through unchanged.
+    """
+    return _TYPE_ALIASES.get(t, t)
+
+
+@dataclass
+class CompositeSpec:
+    id: str
+    name: str
+    description: str = ""
+    tags: list = field(default_factory=list)
+    parameters: dict = field(default_factory=dict)
+    default_n_steps: "int | None" = None
+    visualizations: list = field(default_factory=list)
+    analyses: list = field(default_factory=list)
+    emitters: list = field(default_factory=list)
+    requires: dict = field(default_factory=dict)
+    schema: dict = field(default_factory=dict)
+    state: "dict | None" = None
+    builder: "Callable | str | None" = None
+    default_state_ref: "str | None" = None
+    module: str = ""
+    core_extensions: list = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.name, str) or not self.name:
+            raise ValueError("CompositeSpec.name is required (non-empty string)")
+        has_state = self.state is not None
+        has_builder = self.builder is not None
+        if has_state == has_builder:
+            raise ValueError("CompositeSpec needs exactly one of `state` or `builder`")
+        if has_builder and self.schema:
+            raise ValueError("`schema` is for static specs; a generator's schema comes "
+                             "from the builder document")
+        if self.default_state_ref is not None and not has_builder:
+            raise ValueError("`default_state_ref` requires a `builder`")
+        # normalize parameter types in place
+        for pdef in self.parameters.values():
+            if isinstance(pdef, dict) and "type" in pdef:
+                pdef["type"] = normalize_type(pdef["type"])
+
+    @property
+    def kind(self) -> str:
+        return "generator" if self.builder is not None else "spec"
+
+    def to_dict(self) -> dict:
+        d = asdict(self)
+        d.pop("core_extensions", None)  # callables are not serializable
+        if callable(self.builder):
+            module = self.module if self.module else getattr(self.builder, '__module__', '')
+            d["builder"] = f"{module}:{self.builder.__name__}"
+        return d
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "CompositeSpec":
+        d = dict(d)
+        d.pop("core_extensions", None)
+        return cls(**d)

--- a/process_bigraph/composite_spec.py
+++ b/process_bigraph/composite_spec.py
@@ -12,8 +12,10 @@ and the ``composite_generator`` decorator. Those become thin shims over this.
 """
 from __future__ import annotations
 
+import re
+import importlib
 from dataclasses import dataclass, field, asdict
-from typing import Callable
+from typing import Callable, Any
 
 CANONICAL_TYPES = {"integer", "float", "string", "boolean", "list", "map"}
 
@@ -34,6 +36,73 @@ def normalize_type(t: str) -> str:
     object→map, array→list); an unknown type passes through unchanged.
     """
     return _TYPE_ALIASES.get(t, t)
+
+
+_FULL_PLACEHOLDER = re.compile(r"^\$\{([a-zA-Z_][a-zA-Z0-9_]*)\}$")
+_INLINE_PLACEHOLDER = re.compile(r"\$\{([a-zA-Z_][a-zA-Z0-9_]*)\}")
+
+
+def _cast(value: Any, declared_type: "str | None") -> Any:
+    if declared_type is None:
+        return value
+    t = normalize_type(declared_type)
+    if t == "float":
+        return float(value)
+    if t == "integer":
+        return int(value)
+    if t == "string":
+        return str(value)
+    if t == "boolean":
+        if isinstance(value, str):
+            return value.strip().lower() in ("true", "1", "yes")
+        return bool(value)
+    return value
+
+
+def _resolve_value(value, params, overrides):
+    if not isinstance(value, str):
+        return value
+    m = _FULL_PLACEHOLDER.match(value)
+    if m:
+        pname = m.group(1)
+        if pname not in params:
+            raise KeyError(f"parameter '{pname}' referenced in state but not declared")
+        pdef = params[pname]
+        raw = overrides.get(pname, pdef.get("default"))
+        if raw is None and "default" not in pdef:
+            raise KeyError(f"parameter '{pname}' has no default and no override")
+        return _cast(raw, pdef.get("type"))
+    if _INLINE_PLACEHOLDER.search(value):
+        def repl(match):
+            pname = match.group(1)
+            if pname not in params:
+                raise KeyError(f"parameter '{pname}' referenced in state but not declared")
+            raw = overrides.get(pname, params[pname].get("default"))
+            return str(raw)
+        return _INLINE_PLACEHOLDER.sub(repl, value)
+    return value
+
+
+def substitute_parameters(state, params, overrides=None):
+    """Recursively substitute ``${name}`` placeholders. Returns a new structure."""
+    overrides = overrides or {}
+    if isinstance(state, dict):
+        return {k: substitute_parameters(v, params, overrides) for k, v in state.items()}
+    if isinstance(state, list):
+        return [substitute_parameters(v, params, overrides) for v in state]
+    return _resolve_value(state, params, overrides)
+
+
+def _resolve_builder(builder, module):
+    """Resolve a builder callable; a dotted ``pkg.mod:fn`` string is imported."""
+    if callable(builder):
+        return builder
+    mod_name, _, qual = str(builder).partition(":")
+    mod = importlib.import_module(mod_name or module)
+    obj = mod
+    for part in qual.split("."):
+        obj = getattr(obj, part)
+    return obj
 
 
 @dataclass
@@ -89,3 +158,37 @@ class CompositeSpec:
         d = dict(d)
         d.pop("core_extensions", None)
         return cls(**d)
+
+    def _merged_params(self, overrides):
+        overrides = overrides or {}
+        unknown = set(overrides) - set(self.parameters)
+        if unknown:
+            raise KeyError(f"unknown override(s): {sorted(unknown)}")
+        merged = {k: v.get("default") for k, v in self.parameters.items()}
+        merged.update(overrides)
+        return merged
+
+    def to_document(self, overrides=None, core=None) -> dict:
+        # Validate overrides for both static and generator specs
+        self._merged_params(overrides)
+        if self.kind == "spec":
+            return {
+                "schema": substitute_parameters(self.schema, self.parameters, overrides),
+                "state": substitute_parameters(self.state, self.parameters, overrides),
+            }
+        fn = _resolve_builder(self.builder, self.module)
+        return fn(core=core, **self._merged_params(overrides))
+
+    def to_composite(self, overrides=None, core=None):
+        from process_bigraph import Composite, allocate_core
+        if core is None:
+            core = allocate_core()
+        for ext in self.core_extensions:
+            ext(core)
+        doc = self.to_document(overrides, core=core)
+        return Composite(doc, core=core)
+
+    def default_state(self, base_dir=None) -> "dict | None":
+        if self.state is not None:
+            return self.state
+        return None  # generator artifact path implemented in Task 5

--- a/process_bigraph/composite_spec.py
+++ b/process_bigraph/composite_spec.py
@@ -13,9 +13,13 @@ and the ``composite_generator`` decorator. Those become thin shims over this.
 from __future__ import annotations
 
 import re
+import json
 import importlib
+from pathlib import Path
 from dataclasses import dataclass, field, asdict
 from typing import Callable, Any
+
+import yaml
 
 CANONICAL_TYPES = {"integer", "float", "string", "boolean", "list", "map"}
 
@@ -159,6 +163,34 @@ class CompositeSpec:
         d.pop("core_extensions", None)
         return cls(**d)
 
+    @classmethod
+    def from_file(cls, path) -> "CompositeSpec":
+        path = Path(path)
+        text = path.read_text(encoding="utf-8")
+        raw = json.loads(text) if path.suffix.lower() == ".json" else yaml.safe_load(text)
+        if not isinstance(raw, dict):
+            raise ValueError(f"composite spec {path} must parse to a dict")
+        name = raw.get("name")
+        # id: prefer an explicit id, else "<file-stem-stripped>.<name>"; keep stable + simple
+        stem = path.name.replace(".composite.yaml", "").replace(".composite.json", "")
+        spec_id = raw.get("id") or f"{stem}.{name}"
+        builder = raw.get("builder")
+        return cls(
+            id=spec_id, name=name, description=raw.get("description", ""),
+            tags=list(raw.get("tags") or []),
+            parameters=dict(raw.get("parameters") or {}),
+            default_n_steps=raw.get("default_n_steps"),
+            visualizations=list(raw.get("visualizations") or []),
+            analyses=list(raw.get("analyses") or []),
+            emitters=list(raw.get("emitters") or []),
+            requires=dict(raw.get("requires") or {}),
+            schema=dict(raw.get("schema") or {}) if builder is None else {},
+            state=raw.get("state") if builder is None else None,
+            builder=builder,
+            default_state_ref=raw.get("default_state_ref"),
+            module=raw.get("module", ""),
+        )
+
     def _merged_params(self, overrides):
         overrides = overrides or {}
         unknown = set(overrides) - set(self.parameters)
@@ -240,3 +272,21 @@ def composite_spec(*, name, description="", parameters=None, visualizations=None
         register(spec)
         return fn
     return decorate
+
+
+def discover_specs(workspace=None) -> "dict[str, CompositeSpec]":
+    """Populate + return the registry: import decorator-registered generators
+    AND scan a workspace for ``*.composite.{yaml,json}`` files."""
+    try:
+        from pbg_superpowers.composite_generator import discover_generators
+        discover_generators()  # fires @composite_spec / @composite_generator on import
+    except Exception:
+        pass  # discovery of code generators is best-effort
+    if workspace is not None:
+        for pat in ("*.composite.yaml", "*.composite.json"):
+            for fp in Path(workspace).rglob(pat):
+                try:
+                    register(CompositeSpec.from_file(fp))
+                except Exception:
+                    continue  # a malformed file must not break discovery
+    return all_specs()

--- a/process_bigraph/composite_spec.py
+++ b/process_bigraph/composite_spec.py
@@ -19,8 +19,6 @@ from pathlib import Path
 from dataclasses import dataclass, field, asdict
 from typing import Callable, Any
 
-import yaml
-
 CANONICAL_TYPES = {"integer", "float", "string", "boolean", "list", "map"}
 
 _TYPE_ALIASES = {
@@ -167,7 +165,11 @@ class CompositeSpec:
     def from_file(cls, path) -> "CompositeSpec":
         path = Path(path)
         text = path.read_text(encoding="utf-8")
-        raw = json.loads(text) if path.suffix.lower() == ".json" else yaml.safe_load(text)
+        if path.suffix.lower() == ".json":
+            raw = json.loads(text)
+        else:
+            import yaml
+            raw = yaml.safe_load(text)
         if not isinstance(raw, dict):
             raise ValueError(f"composite spec {path} must parse to a dict")
         name = raw.get("name")

--- a/process_bigraph/composite_spec.py
+++ b/process_bigraph/composite_spec.py
@@ -225,7 +225,31 @@ class CompositeSpec:
     def default_state(self, base_dir=None) -> "dict | None":
         if self.state is not None:
             return self.state
-        return None  # generator artifact path implemented in Task 5
+        if self.default_state_ref and base_dir is not None:
+            artifact = Path(base_dir) / self.default_state_ref
+            if artifact.is_file():
+                data = json.loads(artifact.read_text(encoding="utf-8"))
+                return data.get("state", data)
+        return None
+
+
+def regenerate_default_state(spec: CompositeSpec, base_dir, core=None) -> "Path":
+    """Run a generator's builder with default params, serialize the materialized
+    state, and write the ``default_state_ref`` artifact (+ a provenance stamp).
+
+    This is the one step that needs the heavy build environment (e.g. a ParCa
+    cache for v2ecoli baseline). Display thereafter reads the artifact, no build.
+    """
+    if spec.kind != "generator" or not spec.default_state_ref:
+        raise ValueError("regenerate_default_state requires a generator with default_state_ref")
+    comp = spec.to_composite(core=core)
+    state = comp.serialize_state()
+    param_sig = {k: v.get("default") for k, v in spec.parameters.items()}
+    out = Path(base_dir) / spec.default_state_ref
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps({"state": state, "_provenance": {"param_signature": param_sig}},
+                              indent=2), encoding="utf-8")
+    return out
 
 
 _REGISTRY: "dict[str, CompositeSpec]" = {}

--- a/process_bigraph/tests/test_composite_spec.py
+++ b/process_bigraph/tests/test_composite_spec.py
@@ -193,3 +193,10 @@ def test_discover_specs_scans_workspace_files(tmp_path):
     (comp / "x.composite.yaml").write_text("name: xc\nstate: {a: 1}\n", encoding="utf-8")
     found = cs.discover_specs(workspace=tmp_path)
     assert any(s.name == "xc" for s in found.values())
+
+
+def test_composite_spec_module_has_no_module_level_yaml_import():
+    # yaml must be a lazy/optional import (PyYAML is not a process-bigraph dep);
+    # importing the module must not require it, only from_file on a .yaml does.
+    import process_bigraph.composite_spec as m
+    assert not hasattr(m, "yaml"), "yaml must not be imported at module level"

--- a/process_bigraph/tests/test_composite_spec.py
+++ b/process_bigraph/tests/test_composite_spec.py
@@ -118,3 +118,32 @@ def test_to_composite_applies_core_extensions_before_build():
 def test_default_state_inline():
     s = CompositeSpec(id="m.c", name="c", state={"v": 1})
     assert s.default_state() == {"v": 1}
+
+
+def test_decorator_registers_generator():
+    from process_bigraph import composite_spec as cs
+    cs.clear_registry()
+
+    @cs.composite_spec(name="demo", description="d",
+                       parameters={"seed": {"type": "int", "default": 0}},
+                       emitters=[{"address": "local:RAMEmitter"}], default_n_steps=5)
+    def demo(core=None, *, seed=0):
+        return {"state": {"s": seed}}
+
+    spec_id = f"{demo.__module__}.demo"
+    spec = cs.get(spec_id)
+    assert spec is not None and spec.kind == "generator"
+    assert spec.parameters["seed"]["type"] == "integer"  # normalized
+    assert spec.default_n_steps == 5 and spec.builder is demo
+    assert demo(seed=2) == {"state": {"s": 2}}  # decorator returns the original fn
+
+
+def test_register_get_all_clear():
+    from process_bigraph import composite_spec as cs
+    cs.clear_registry()
+    s = CompositeSpec(id="m.c", name="c", state={})
+    cs.register(s)
+    assert cs.get("m.c") is s
+    assert "m.c" in cs.all_specs()
+    cs.clear_registry()
+    assert cs.get("m.c") is None

--- a/process_bigraph/tests/test_composite_spec.py
+++ b/process_bigraph/tests/test_composite_spec.py
@@ -1,5 +1,8 @@
 import pytest
+import json
+import textwrap
 from process_bigraph.composite_spec import CompositeSpec, normalize_type, CANONICAL_TYPES, substitute_parameters
+import process_bigraph.composite_spec as cs
 
 
 def test_normalize_type_aliases():
@@ -139,11 +142,54 @@ def test_decorator_registers_generator():
 
 
 def test_register_get_all_clear():
-    from process_bigraph import composite_spec as cs
-    cs.clear_registry()
+    from process_bigraph import composite_spec as cs_mod
+    cs_mod.clear_registry()
     s = CompositeSpec(id="m.c", name="c", state={})
-    cs.register(s)
-    assert cs.get("m.c") is s
-    assert "m.c" in cs.all_specs()
+    cs_mod.register(s)
+    assert cs_mod.get("m.c") is s
+    assert "m.c" in cs_mod.all_specs()
+    cs_mod.clear_registry()
+    assert cs_mod.get("m.c") is None
+
+
+def test_from_file_static_yaml(tmp_path):
+    p = tmp_path / "g.composite.yaml"
+    p.write_text(textwrap.dedent("""
+        name: growth
+        description: demo
+        tags: [a]
+        requires:
+          processes: [P]
+          types: [ty]
+        schema:
+          population: tree
+        parameters:
+          seed: {type: int, default: 0}
+        state:
+          v: "${seed}"
+    """), encoding="utf-8")
+    s = CompositeSpec.from_file(p)
+    assert s.kind == "spec" and s.name == "growth"
+    assert s.schema == {"population": "tree"}
+    assert s.requires == {"processes": ["P"], "types": ["ty"]}
+    assert s.parameters["seed"]["type"] == "integer"  # normalized
+    assert s.id.endswith(".growth")
+
+
+def test_from_file_generator_with_builder_ref(tmp_path):
+    p = tmp_path / "b.composite.json"
+    p.write_text(json.dumps({
+        "name": "bgen", "builder": "process_bigraph.composite_spec:normalize_type",
+        "default_state_ref": "bgen.default-state.json",
+        "parameters": {}}), encoding="utf-8")
+    s = CompositeSpec.from_file(p)
+    assert s.kind == "generator" and s.default_state_ref == "bgen.default-state.json"
+
+
+def test_discover_specs_scans_workspace_files(tmp_path):
     cs.clear_registry()
-    assert cs.get("m.c") is None
+    comp = tmp_path / "composites"
+    comp.mkdir()
+    (comp / "x.composite.yaml").write_text("name: xc\nstate: {a: 1}\n", encoding="utf-8")
+    found = cs.discover_specs(workspace=tmp_path)
+    assert any(s.name == "xc" for s in found.values())

--- a/process_bigraph/tests/test_composite_spec.py
+++ b/process_bigraph/tests/test_composite_spec.py
@@ -1,0 +1,66 @@
+import pytest
+from process_bigraph.composite_spec import CompositeSpec, normalize_type, CANONICAL_TYPES
+
+
+def test_normalize_type_aliases():
+    assert normalize_type("int") == "integer"
+    assert normalize_type("number") == "float"
+    assert normalize_type("bool") == "boolean"
+    assert normalize_type("object") == "map"
+    assert normalize_type("array") == "list"
+    assert normalize_type("string") == "string"
+    assert normalize_type("unknownX") == "unknownX"  # pass-through
+
+
+def test_static_spec_normalizes_param_types():
+    s = CompositeSpec(id="m.c", name="c", state={"x": 1},
+                      parameters={"seed": {"type": "int", "default": 0},
+                                  "rate": {"type": "number", "default": 1.0}})
+    assert s.parameters["seed"]["type"] == "integer"
+    assert s.parameters["rate"]["type"] == "float"
+    assert s.kind == "spec"
+
+
+def test_generator_spec_kind():
+    s = CompositeSpec(id="m.g", name="g", builder="m:g")
+    assert s.kind == "generator"
+
+
+def test_exactly_one_of_state_or_builder():
+    with pytest.raises(ValueError, match="exactly one"):
+        CompositeSpec(id="m.x", name="x")  # neither
+    with pytest.raises(ValueError, match="exactly one"):
+        CompositeSpec(id="m.x", name="x", state={}, builder="m:x")  # both
+
+
+def test_schema_only_with_state():
+    with pytest.raises(ValueError, match="schema"):
+        CompositeSpec(id="m.g", name="g", builder="m:g", schema={"pop": "tree"})
+
+
+def test_default_state_ref_requires_builder():
+    with pytest.raises(ValueError, match="default_state_ref"):
+        CompositeSpec(id="m.c", name="c", state={"x": 1}, default_state_ref="x.json")
+
+
+def test_to_dict_from_dict_round_trip_static():
+    s = CompositeSpec(id="m.c", name="c", description="d", tags=["t"],
+                      state={"x": "${seed}"}, schema={"pop": "tree"},
+                      parameters={"seed": {"type": "integer", "default": 0}},
+                      requires={"processes": ["P"], "types": ["ty"]},
+                      emitters=[{"address": "local:RAMEmitter"}], default_n_steps=10)
+    d = s.to_dict()
+    assert d["state"] == {"x": "${seed}"} and d["schema"] == {"pop": "tree"}
+    assert d["requires"] == {"processes": ["P"], "types": ["ty"]}
+    s2 = CompositeSpec.from_dict(d)
+    assert s2 == s
+
+
+def test_to_dict_serializes_builder_callable_to_dotted():
+    def fn(core=None):
+        return {"state": {}}
+    s = CompositeSpec(id="m.g", name="g", builder=fn, module="m")
+    d = s.to_dict()
+    # a callable serializes to "<module>:<qualname>"; core_extensions are dropped
+    assert isinstance(d["builder"], str) and d["builder"].endswith(":fn")
+    assert "core_extensions" not in d

--- a/process_bigraph/tests/test_composite_spec.py
+++ b/process_bigraph/tests/test_composite_spec.py
@@ -1,5 +1,5 @@
 import pytest
-from process_bigraph.composite_spec import CompositeSpec, normalize_type, CANONICAL_TYPES
+from process_bigraph.composite_spec import CompositeSpec, normalize_type, CANONICAL_TYPES, substitute_parameters
 
 
 def test_normalize_type_aliases():
@@ -64,3 +64,57 @@ def test_to_dict_serializes_builder_callable_to_dotted():
     # a callable serializes to "<module>:<qualname>"; core_extensions are dropped
     assert isinstance(d["builder"], str) and d["builder"].endswith(":fn")
     assert "core_extensions" not in d
+
+
+def test_substitute_full_and_inline():
+    params = {"seed": {"type": "integer", "default": 0}, "tag": {"type": "string", "default": "x"}}
+    state = {"a": "${seed}", "b": "v-${tag}", "c": 5}
+    out = substitute_parameters(state, params, {"seed": 7, "tag": "z"})
+    assert out == {"a": 7, "b": "v-z", "c": 5}  # full placeholder typed; inline stringified
+
+
+def test_to_document_static_substitutes_schema_and_state():
+    s = CompositeSpec(id="m.c", name="c", state={"x": "${seed}"}, schema={"pop": "tree"},
+                      parameters={"seed": {"type": "integer", "default": 3}})
+    doc = s.to_document()
+    assert doc == {"schema": {"pop": "tree"}, "state": {"x": 3}}
+
+
+def test_to_document_generator_passes_whole_document():
+    def build(core=None, *, seed=0):
+        return {"state": {"s": seed}, "skip_initial_steps": True, "flow_order": ["a"]}
+    s = CompositeSpec(id="m.g", name="g", builder=build,
+                      parameters={"seed": {"type": "integer", "default": 0}})
+    doc = s.to_document({"seed": 9})
+    assert doc == {"state": {"s": 9}, "skip_initial_steps": True, "flow_order": ["a"]}
+
+
+def test_to_document_rejects_unknown_override():
+    s = CompositeSpec(id="m.c", name="c", state={}, parameters={"seed": {"type": "integer", "default": 0}})
+    with pytest.raises(KeyError):
+        s.to_document({"nope": 1})
+
+
+def test_to_composite_static_returns_runnable_composite():
+    s = CompositeSpec(id="m.c", name="c", state={"v": 1.0})
+    comp = s.to_composite()
+    from process_bigraph import Composite
+    assert isinstance(comp, Composite)
+
+
+def test_to_composite_applies_core_extensions_before_build():
+    seen = {}
+    def ext(core):
+        seen["ran"] = True
+        return core
+    def build(core=None):
+        seen["built_after_ext"] = seen.get("ran", False)
+        return {"state": {}}
+    s = CompositeSpec(id="m.g", name="g", builder=build, core_extensions=[ext])
+    s.to_composite()
+    assert seen["ran"] and seen["built_after_ext"]
+
+
+def test_default_state_inline():
+    s = CompositeSpec(id="m.c", name="c", state={"v": 1})
+    assert s.default_state() == {"v": 1}

--- a/process_bigraph/tests/test_composite_spec.py
+++ b/process_bigraph/tests/test_composite_spec.py
@@ -221,3 +221,10 @@ def test_default_state_missing_artifact_returns_none(tmp_path):
     s = CompositeSpec(id="m.g", name="g", builder=lambda core=None: {"state": {}},
                       default_state_ref="absent.json")
     assert s.default_state(base_dir=tmp_path) is None
+
+
+def test_top_level_exports():
+    import process_bigraph as pbg
+    assert hasattr(pbg, "CompositeSpec")
+    assert hasattr(pbg, "composite_spec")      # the decorator
+    assert hasattr(pbg, "discover_specs")

--- a/process_bigraph/tests/test_composite_spec.py
+++ b/process_bigraph/tests/test_composite_spec.py
@@ -200,3 +200,24 @@ def test_composite_spec_module_has_no_module_level_yaml_import():
     # importing the module must not require it, only from_file on a .yaml does.
     import process_bigraph.composite_spec as m
     assert not hasattr(m, "yaml"), "yaml must not be imported at module level"
+
+
+def test_regenerate_and_read_default_state(tmp_path):
+    def build(core=None, *, seed=0):
+        return {"state": {"count": seed + 1}}
+    s = CompositeSpec(id="m.g", name="g", builder=build,
+                      parameters={"seed": {"type": "integer", "default": 4}},
+                      default_state_ref="g.default-state.json")
+    from process_bigraph.composite_spec import regenerate_default_state
+    out = regenerate_default_state(s, tmp_path)
+    assert out.exists()
+    # display reads the saved state, no rebuild
+    state = s.default_state(base_dir=tmp_path)
+    assert state is not None
+    assert state["count"] == 5
+
+
+def test_default_state_missing_artifact_returns_none(tmp_path):
+    s = CompositeSpec(id="m.g", name="g", builder=lambda core=None: {"state": {}},
+                      default_state_ref="absent.json")
+    assert s.default_state(base_dir=tmp_path) is None


### PR DESCRIPTION
Unifies the two pbg composite front-ends (the `@composite_generator` decorator + `*.composite.yaml` spec files) onto **one declarative `CompositeSpec` descriptor in process-bigraph**, aligned with the `Composite` class. Foundation of a 3-repo change (see cross-repo note).

## What this adds
`process_bigraph/composite_spec.py`:
- `CompositeSpec` dataclass — metadata (`parameters`, `default_n_steps`, `visualizations`, `analyses`, `emitters`, `requires.{processes,types}`, `tags`, `schema`) + a body that is **exactly one of** inline `state` (static) or a `builder` (generator).
- Canonical parameter-type vocabulary + alias normalization (`int→integer`, `bool→boolean`, `number→float`, `object→map`, …) — the audit found these spelled inconsistently across the ecosystem.
- `to_document` (whole-document passthrough — generator exec keys like `skip_initial_steps`/`flow_order` survive), `to_composite` (applies `core_extensions` before building), `default_state` (display state from inline state or a **saved artifact** — never builds, so the dashboard renders without ParCa).
- `@composite_spec` decorator + registry, `from_file` + `discover_specs`, `regenerate_default_state`, `to_dict`/`from_dict`.
- Narrow `__init__` export (the decorator/registry stay on the module to avoid shadowing the `composite_spec` module attribute).

Contract validated against the real ecosystem: all 13 v2ecoli generators, 93 YAML composites across ~20 pbg-* repos, ~12 study specs. Design + plan in `docs/superpowers/`. 24 unit tests, full suite green.

## Cross-repo merge order (this is #1 of 3)
1. **this PR** (process-bigraph) — the foundation.
2. pbg-superpowers — shims `@composite_generator` + the static spec loader onto this.
3. vivarium-dashboard — resolves composites via this + ParCa-free display + the Composite Explorer bug fix.

PRs #2/#3 depend on this being released; their CI stays red until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)