### PR TITLE
fix(composite): kill the Composite.run zero-interval hang (two causes)

### DIFF
--- a/process_bigraph/composite.py
+++ b/process_bigraph/composite.py
@@ -2488,6 +2488,47 @@ class Composite(Process):
             per_process=dict(self._per_process_time),
         )
 
+    def _require_advancing_interval(
+            self,
+            path: Union[str, Tuple[str, ...]],
+            process_interval: Any,
+    ) -> None:
+        """Reject a process step that would not advance simulation time.
+
+        The scheduler takes the smallest process interval as the step it
+        advances ``global_time`` by. A non-positive interval therefore makes
+        that step zero or negative, ``global_time`` never reaches
+        ``end_time``, and ``run`` spins forever — a hang with no diagnostic.
+
+        A ``Process`` must advance time, so this is always an error: fail
+        loudly, naming the process and the offending value. Note an *omitted*
+        interval is not affected — it takes the ``process`` schema default
+        (1.0); only an explicit non-positive value (or a
+        ``calculate_timestep`` that returns one) lands here.
+        """
+        readable = '/'.join(path) if isinstance(path, (tuple, list)) else path
+
+        if process_interval is None:
+            detail = 'None'
+        elif not isinstance(process_interval, (int, float)) or isinstance(
+                process_interval, bool):
+            detail = f'{process_interval!r} (not a number)'
+        elif process_interval != process_interval:      # NaN
+            detail = 'NaN'
+        elif process_interval > 0:
+            return
+        else:
+            detail = repr(process_interval)
+
+        raise ValueError(
+            f"process {readable!r} has a non-advancing interval: {detail}. "
+            f"A Process must advance time — the scheduler steps by the "
+            f"smallest process interval, so a non-positive one would leave "
+            f"global_time unchanged and run() would never terminate. Give "
+            f"the process a positive 'interval' (omit it to take the "
+            f"default of 1.0), or return a positive value from "
+            f"calculate_timestep().")
+
     def run_process(
             self,
             path: Union[str, Tuple[str, ...]],
@@ -2530,6 +2571,8 @@ class Composite(Process):
                 state_interval = process['interval']
                 process_interval = process['instance'].calculate_timestep(state_interval, state)
                 process['interval'] = process_interval
+
+            self._require_advancing_interval(path, process_interval)
 
             # Determine the target time for the next update
             future = (
@@ -2618,6 +2661,8 @@ class Composite(Process):
                     process_interval = process['instance'].calculate_timestep(
                         state_interval, state)
                     process['interval'] = process_interval
+
+                self._require_advancing_interval(path, process_interval)
 
                 future = (
                     min(process_time + process_interval, end_time)

--- a/process_bigraph/types/process.py
+++ b/process_bigraph/types/process.py
@@ -16,6 +16,8 @@ from dataclasses import dataclass, is_dataclass, field
 from bigraph_schema import capture_object_state, restore_object_value
 from bigraph_schema.schema import Node, Empty, Float, Wires, Link, Schema, is_schema_field
 from bigraph_schema.methods import resolve, realize, realize_link, default, default_link, render, wrap_default
+from bigraph_schema.methods import reify_schema
+from bigraph_schema.methods.handle_parameters import reify_schema_link
 from bigraph_schema.methods import serialize, divide, bundle, apply
 from bigraph_schema.methods.bundle import BundleContext
 
@@ -92,6 +94,28 @@ def default(schema: StepLink):
     link['priority'] = default(schema.priority)
 
     return link
+
+
+@reify_schema.dispatch
+def reify_schema(core, schema: ProcessLink, parameters):
+    """Compile a process declaration, keeping its declared ``interval``.
+
+    ``reify_schema_link`` knows only the base ``Link`` fields, so a declared
+    ``interval`` was silently dropped — an accessed process kept the schema
+    default and the authored value was gone. Carry it on the ``Float``'s
+    ``_default``, the way every other declared value rides its schema node.
+
+    Only a number is carried: re-accessing a document whose ``interval`` was
+    rendered as the bare type ``'float'`` leaves the default in place rather
+    than stamping a string that would later realize to 0.
+    """
+    schema = reify_schema_link(core, schema, parameters)
+
+    declared = parameters.get('interval')
+    if isinstance(declared, (int, float)) and not isinstance(declared, bool):
+        schema.interval = Float(_default=declared)
+
+    return schema
 
 
 @default.dispatch
@@ -173,6 +197,15 @@ def render(schema: ProcessLink, defaults=False):
             continue
         value = getattr(schema, field_name)
         result[field_name] = render(value, defaults=defaults)
+
+    # ``interval`` is a *value*, not a type. Rendering the Float node emits
+    # the bare type name ``'float'``, which loses the interval — and the
+    # re-accessed document then realizes with interval 0, a process that
+    # cannot advance time.
+    carried = getattr(schema.interval, '_default', None)
+    if carried is not None:
+        result['interval'] = carried
+
     return wrap_default(schema, result) if defaults else result
 
 

--- a/tests.py
+++ b/tests.py
@@ -2962,3 +2962,150 @@ def test_tick_lifecycle_dispatches_managed_processes(core):
     # Updates applied: a += 1 each tick, b += 10 each tick.
     assert sim.state['counters']['a'] == 3
     assert sim.state['counters']['b'] == 30
+
+
+# ==========================================
+# A Process must advance time (no run() hang)
+# ==========================================
+
+def _increaser(interval=None, rate=0.1):
+    """An `IncreaseProcess` node, optionally with an explicit interval."""
+    node = {
+        '_type': 'process',
+        'address': 'local:IncreaseProcess',
+        'config': {'rate': rate},
+        'inputs': {'level': ['level']},
+        'outputs': {'level': ['level']},
+    }
+    if interval is not None:
+        node['interval'] = interval
+    return {'proc': node, 'level': 1.0}
+
+
+@pytest.mark.parametrize('interval', [0, 0.0, -1.0])
+def test_non_advancing_interval_raises_instead_of_hanging(interval):
+    """A non-positive interval used to spin `run()` forever.
+
+    The scheduler advances `global_time` by the smallest process interval, so
+    a zero or negative one leaves time unchanged and the run loop never
+    reaches `end_time`. It must fail loudly instead.
+    """
+    core = allocate_core()
+    sim = Composite({'state': _increaser(interval)}, core=core)
+
+    with pytest.raises(ValueError, match='non-advancing interval') as raised:
+        sim.run(3.0)
+
+    message = str(raised.value)
+    assert "'proc'" in message              # names the offending process
+    assert 'must advance time' in message
+
+
+def test_non_advancing_interval_raises_in_the_parallel_path():
+    """The parallel scheduler shares the hazard, so it shares the guard."""
+    core = allocate_core()
+    good = _increaser(1.0)['proc']
+    bad = _increaser(0.0, rate=0.2)['proc']
+    state = {'a': good, 'b': bad, 'level': 1.0}
+
+    sim = Composite(
+        {'state': state, 'parallel_processes': True}, core=core)
+    assert sim._parallel_processes and len(sim.process_paths) > 1
+
+    with pytest.raises(ValueError, match='non-advancing interval') as raised:
+        sim.run(3.0)
+
+    assert "'b'" in str(raised.value)       # the bad one, not its neighbour
+
+
+def test_calculate_timestep_returning_zero_raises():
+    """The guard sits after `calculate_timestep`, so a process that computes
+    a non-advancing step is caught too — not only a declared one."""
+    core = allocate_core()
+
+    class StalledProcess(Process):
+        config_schema = {}
+
+        def inputs(self):
+            return {'level': 'float'}
+
+        def outputs(self):
+            return {'level': 'float'}
+
+        def calculate_timestep(self, interval, state):
+            return 0.0
+
+        def update(self, state, interval):
+            return {'level': 1.0}
+
+    core.register_link('StalledProcess', StalledProcess)
+    state = {
+        'proc': {
+            '_type': 'process',
+            'address': 'local:StalledProcess',
+            'inputs': {'level': ['level']},
+            'outputs': {'level': ['level']},
+            'interval': 1.0},
+        'level': 1.0}
+
+    sim = Composite({'state': state}, core=core)
+    with pytest.raises(ValueError, match='non-advancing interval'):
+        sim.run(3.0)
+
+
+def test_omitted_interval_takes_the_schema_default():
+    """An omitted interval is not an error — it takes the `process` schema
+    default of 1.0 and runs."""
+    core = allocate_core()
+    sim = Composite({'state': _increaser()}, core=core)
+
+    assert sim.state['proc']['interval'] == 1.0
+    sim.run(3.0)
+    assert sim.state['global_time'] == 3.0
+
+
+def test_positive_interval_still_runs():
+    core = allocate_core()
+    sim = Composite({'state': _increaser(0.5)}, core=core)
+
+    sim.run(2.0)
+    assert sim.state['global_time'] == 2.0
+    assert sim.state['level'] > 1.0
+
+
+# ==========================================
+# A declared interval survives access/render
+# ==========================================
+
+@pytest.mark.parametrize('declared,expected', [(1.0, 1.0), (0.5, 0.5), (None, 1.0)])
+def test_declared_interval_survives_access_and_render(declared, expected):
+    """`access` used to drop a declared `interval` (keeping the schema
+    default) and `render` emitted the bare type `'float'`, so a document that
+    round-tripped through the schema layer came back with interval 0 — a
+    process that could not advance time.
+    """
+    core = allocate_core()
+    node = {'_type': 'process', 'address': 'local:IncreaseProcess'}
+    if declared is not None:
+        node['interval'] = declared
+
+    schema = core.access(node)
+    assert schema.interval._default == expected
+
+    rendered = core.render(schema)
+    assert rendered['interval'] == expected
+    assert core.access(rendered).interval._default == expected
+
+
+def test_round_tripped_document_still_runs():
+    """The end-to-end form: a document that goes through `access`/`render`
+    must still advance time when handed back to a Composite."""
+    core = allocate_core()
+    document = _increaser(1.0)
+
+    rendered = core.render(core.access(document))
+    assert rendered['proc']['interval'] == 1.0
+
+    sim = Composite({'state': rendered}, core=allocate_core())
+    sim.run(2.0)
+    assert sim.state['global_time'] == 2.0


### PR DESCRIPTION
`Composite.run()` hung on any process whose effective interval was non-positive. Two causes, both had to land together:

**Cause 1 — the run loop spins on a 0 step.** `run_process` reads `process['interval']`, `calculate_timestep` returns it unchanged, and a non-positive value makes `full_step` 0 → `global_time += 0` → `_run_inner`'s `while global_time < end_time` never advances. (Negative intervals hang too; explicit `None` coerces to 0.0.)

**Cause 2 — a declared interval never survived the schema layer.** `reify_schema_link` knows only base `Link` fields, so `access` silently dropped a declared `interval` (even `0.5` came back as `Float(_default=1.0)`) and `render` emitted the bare type `'float'`. A document round-tripped through access/render realized with interval **0** — which is why a composite *declaring* `interval: 1.0` still hung. Shipping only the guard would have turned that hang into a *spurious error*, so both fixes land together.

## Fix
- `composite.py` — `_require_advancing_interval(path, interval)` rejects non-positive/None/NaN/non-numeric, naming the process path + value; called in **both** the serial (`run_process`) and parallel (`_run_processes_layer_parallel`) paths, *after* `calculate_timestep` (so a computed non-advancing step is caught too). Validates the process interval, not `full_step` (which is legitimately 0 at the `force_complete` boundary).
- `types/process.py` — `ProcessLink` gets its own `reify_schema` (carries a declared interval on the `Float._default`) and `render` emits the value; only numbers are carried, so a re-accessed damaged document falls back to the default.

| interval | before | after |
|---|---|---|
| `1.0` / omitted | ran | ran |
| `0` / `0.0` / `None` / `-1.0` | **hang** | `ValueError` naming the process |

## Tests
**90 passed, 7 skipped, 0 failures** (baseline 79). The original failing scenario — `fill_sites` → `render` → `Composite` with two nested processes — now runs to completion instead of hanging. Green against both released bigraph-schema and the Layer-1 tree.

**Latent, not fixed here (folded into Layer 2a):** `StepLink.priority` is dropped by `reify_schema_link` the same way as cause 2 — can't hang, so out of a hang-focused diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)