### PR TITLE
feat: composite hardening Part A — A0 groundness, A1 emitters, StepLink.priority

### DIFF
--- a/process_bigraph/composite.py
+++ b/process_bigraph/composite.py
@@ -1121,6 +1121,8 @@ class Composite(Process):
         except Exception:
             pass
 
+        self._require_ground_document()
+
         # Load the bridge configuration, which defines how inputs/outputs connect to the world.
         self.bridge = self.config.get('bridge', {})
 
@@ -2487,6 +2489,38 @@ class Composite(Process):
             framework_time=self.framework_time,
             per_process=dict(self._per_process_time),
         )
+
+    def _require_ground_document(self) -> None:
+        """Reject a document that still has unfilled template holes.
+
+        A composite is runnable only once every required site is filled: an
+        open site is a hole where a process or a value should be, and nothing
+        downstream — wiring, scheduling, emitters — can be built over it.
+        Checking here turns what would be a confusing failure deep in the run
+        into a clear one at construction.
+
+        Deliberately checked over **sites**, not ``is_ground``: any composite
+        containing a process has unwired ports by construction, so
+        ``is_ground`` is never true for a real composite and would reject
+        everything. A site carrying a ``_default`` is optional — it can supply
+        its own filler — so it does not block.
+        """
+        from bigraph_schema.assembly import collect_sites
+
+        # ``collect_sites`` addresses each site twice (bare key and path);
+        # collapse to unique paths.
+        unfilled = sorted({
+            tuple(path)
+            for path, site in collect_sites(self.schema).values()
+            if getattr(site, '_default', None) is None})
+
+        if unfilled:
+            named = ', '.join(repr('/'.join(path)) for path in unfilled)
+            raise ValueError(
+                f'composite document is not ground — required site(s) left '
+                f'unfilled: {named}. An open site is a hole where a process '
+                f'or value should be; fill it before constructing the '
+                f'composite (bigraph_schema `fill_sites` / `build`).')
 
     def _require_advancing_interval(
             self,

--- a/process_bigraph/composite_spec.py
+++ b/process_bigraph/composite_spec.py
@@ -204,24 +204,54 @@ class CompositeSpec:
         merged.update(overrides)
         return merged
 
-    def to_document(self, overrides=None, core=None) -> dict:
+    def to_document(self, overrides=None, core=None, emit=True) -> dict:
+        """Build the composite document.
+
+        ``emitters`` is a first-class field of a spec, so the document it
+        produces carries the declared sinks — otherwise a composite built
+        through this API observes nothing. Pass ``emit=False`` for the bare
+        document (e.g. to inspect or re-emit it under different sinks).
+        """
         # Validate overrides for both static and generator specs
         self._merged_params(overrides)
         if self.kind == "spec":
-            return {
+            doc = {
                 "schema": substitute_parameters(self.schema, self.parameters, overrides),
                 "state": substitute_parameters(self.state, self.parameters, overrides),
             }
-        fn = _resolve_builder(self.builder, self.module)
-        return fn(core=core, **self._merged_params(overrides))
+        else:
+            fn = _resolve_builder(self.builder, self.module)
+            doc = fn(core=core, **self._merged_params(overrides))
 
-    def to_composite(self, overrides=None, core=None):
+        return self._with_emitters(doc, core) if emit else doc
+
+    def _with_emitters(self, doc, core=None):
+        """Install this spec's declared emitters into a built document.
+
+        Installing is idempotent — the sinks land at fixed ``emitter`` /
+        ``emitter_<i>`` keys — so a caller that also installs (the
+        ``viva_superpowers`` shim, the dashboard's observable injection)
+        rewrites the same slots rather than giving the composite two sinks.
+        """
+        from process_bigraph.emitter import install_emitters
+
+        if not self.emitters or not isinstance(doc, dict):
+            return doc
+
+        if "state" in doc:
+            return {**doc, "state": install_emitters(
+                doc["state"] or {}, self.emitters, core=core)}
+
+        # A builder that returned a bare state tree.
+        return install_emitters(doc, self.emitters, core=core)
+
+    def to_composite(self, overrides=None, core=None, emit=True):
         from process_bigraph import Composite, allocate_core
         if core is None:
             core = allocate_core()
         for ext in self.core_extensions:
             ext(core)
-        doc = self.to_document(overrides, core=core)
+        doc = self.to_document(overrides, core=core, emit=emit)
         return Composite(doc, core=core)
 
     def default_state(self, base_dir=None) -> "dict | None":

--- a/process_bigraph/emitter.py
+++ b/process_bigraph/emitter.py
@@ -81,8 +81,10 @@ def generate_emitter_state(composite, emitter_mode='all', address='local:ram-emi
         - "all": observe all valid inputs
         - "none": observe nothing
         - {"paths": [...]}: custom paths to observe
+
+    The node comes from :func:`emitter_from_wires` so a generated sink and a
+    declared one are built by the same constructor.
     '''
-    config = {}
     input_ports = {}
 
     if emitter_mode == 'all':
@@ -101,15 +103,84 @@ def generate_emitter_state(composite, emitter_mode='all', address='local:ram-emi
     if 'global_time' not in input_ports:
         input_ports['global_time'] = ['global_time']
 
-    if 'emit' not in config:
-        config['emit'] = {port: 'node' for port in input_ports}
+    return emitter_from_wires(input_ports, address=address)
 
-    return {
-        '_type': 'step',
-        'address': address,
-        'config': config,
-        'inputs': input_ports
-    }
+
+def emitter_node_from_declaration(
+        decl,
+        run_id=None,
+        out_dir=None,
+        core=None,
+        fallback='local:RAMEmitter'):
+    '''Materialize one declared emitter (``{address, config?, paths?}``) into
+    a step node.
+
+    A declaration names *what to observe*; the emit schema and topology depend
+    on the composite's shape, so they are computed here. Each ``paths`` entry
+    (slash- or dot-joined) becomes one wired column; ``global_time`` is always
+    emitted so trajectories have a time axis and the step re-fires every tick.
+
+    The node itself comes from :func:`emitter_from_wires` — the one emitter
+    constructor — so a declared sink and a generated one are the same shape.
+    An address the core does not know degrades to ``fallback`` so the
+    composite still builds.
+    '''
+    address = decl.get('address') or fallback
+    name = address.split(':', 1)[-1]
+    registered = getattr(core, 'link_registry', None) if core is not None else None
+    if registered is not None and name not in registered:
+        address = fallback
+        name = address.split(':', 1)[-1]
+
+    wires = {}
+    for path in decl.get('paths') or []:
+        parts = [part for part in str(path).replace('.', '/').split('/') if part]
+        if not parts:
+            continue
+        wires['_'.join(parts)] = parts
+    wires.setdefault('global_time', ['global_time'])
+
+    node = emitter_from_wires(wires, address=address)
+
+    # Declared config layers *under* the computed emit schema.
+    declared_config = dict(decl.get('config') or {})
+    node['config'] = {**declared_config, **node['config']}
+
+    # Run-specific partitioning for hive-partitioned parquet sinks; other
+    # sinks keep their declared config untouched.
+    if name.endswith('ParquetEmitter'):
+        if out_dir is not None:
+            node['config']['out_dir'] = str(out_dir)
+        if run_id is not None:
+            node['config'].setdefault('partitioning_keys', ['experiment_id'])
+            metadata = dict(node['config'].get('metadata') or {})
+            metadata.setdefault('experiment_id', run_id)
+            node['config']['metadata'] = metadata
+
+    return node
+
+
+def install_emitters(state, declarations, run_id=None, out_dir=None, core=None):
+    '''Return a copy of ``state`` with the declared emitter(s) installed.
+
+    Emitters land at the conventional ``emitter`` / ``emitter_<i>`` keys.
+    Because those keys are deterministic, installing twice rewrites the same
+    slots rather than adding a second sink — so a caller may invoke this
+    unconditionally without risking a composite that emits everything twice.
+
+    Returns ``state`` unchanged when nothing is declared.
+    '''
+    declarations = [decl for decl in (declarations or []) if isinstance(decl, dict)]
+    if not declarations:
+        return dict(state)
+
+    installed = dict(state)
+    for index, decl in enumerate(declarations):
+        key = 'emitter' if index == 0 else f'emitter_{index}'
+        installed[key] = emitter_node_from_declaration(
+            decl, run_id=run_id, out_dir=out_dir, core=core)
+
+    return installed
 
 def gather_emitter_results(composite, queries=None):
     '''Retrieve query results from all emitter steps in a composite.'''

--- a/process_bigraph/types/process.py
+++ b/process_bigraph/types/process.py
@@ -97,6 +97,34 @@ def default(schema: StepLink):
 
 
 @reify_schema.dispatch
+def reify_schema(core, schema: StepLink, parameters):
+    """Compile a step declaration, keeping its declared ``priority``.
+
+    The same gap the process ``interval`` had: ``reify_schema_link`` knows
+    only the base ``Link`` fields, so a declared ``priority`` (and the
+    ``_triggers`` port set) was silently dropped. A document round-tripped
+    through access/render came back with the schema defaults — a step that
+    lost its scheduling order, which decides which step runs first when the
+    network has a cycle.
+
+    Only a number is carried, so re-accessing a document whose ``priority``
+    was rendered as the bare type ``'float'`` keeps the default rather than
+    stamping a string.
+    """
+    schema = reify_schema_link(core, schema, parameters)
+
+    declared = parameters.get('priority')
+    if isinstance(declared, (int, float)) and not isinstance(declared, bool):
+        schema.priority = Float(_default=declared)
+
+    triggers = parameters.get('_triggers')
+    if isinstance(triggers, dict) and triggers:
+        schema._triggers = dict(triggers)
+
+    return schema
+
+
+@reify_schema.dispatch
 def reify_schema(core, schema: ProcessLink, parameters):
     """Compile a process declaration, keeping its declared ``interval``.
 
@@ -186,6 +214,18 @@ def render(schema: StepLink, defaults=False):
             continue
         value = getattr(schema, field_name)
         result[field_name] = render(value, defaults=defaults)
+
+    # ``priority`` and ``_triggers`` are *values*, not types. Rendering their
+    # schema nodes emits ``'float'`` / ``'node'`` and loses them, so the
+    # re-accessed step falls back to the defaults and forgets its scheduling
+    # order.
+    carried = getattr(schema.priority, '_default', None)
+    if carried is not None:
+        result['priority'] = carried
+
+    if schema._triggers:
+        result['_triggers'] = dict(schema._triggers)
+
     return wrap_default(schema, result) if defaults else result
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     # 1.4.2 first moved the bundle Parquet writer (_save_array_parquet) into
     # bigraph-schema (layer inversion); process-bigraph no longer ships it,
     # so save_bundle needs a schema that owns it.
-    "bigraph-schema>=1.4.3",
+    "bigraph-schema>=1.4.4",
     "matplotlib",
     "pint>=0.24.4",
     "scipy>=1.8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,13 @@ description = "protocol and execution for compositional systems biology"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    # >=1.4.2 required: the bundle Parquet writer (_save_array_parquet) moved
-    # into bigraph-schema in 1.4.2 (layer inversion); process-bigraph no longer
-    # ships it, so save_bundle needs a schema that owns it.
-    "bigraph-schema>=1.4.2",
+    # >=1.4.3 required: `assembly.collect_sites` (the site/fill primitive)
+    # backs the groundness check in `Composite.__init__` — a document with
+    # unfilled template holes must be rejected at construction.
+    # 1.4.2 first moved the bundle Parquet writer (_save_array_parquet) into
+    # bigraph-schema (layer inversion); process-bigraph no longer ships it,
+    # so save_bundle needs a schema that owns it.
+    "bigraph-schema>=1.4.3",
     "matplotlib",
     "pint>=0.24.4",
     "scipy>=1.8",

--- a/tests.py
+++ b/tests.py
@@ -3771,3 +3771,80 @@ def test_declared_emitter_config_is_preserved():
 
     assert node['config']['subsample'] == 5
     assert 'emit' in node['config']
+
+
+# ==========================================
+# StepLink.priority survives access/render
+# ==========================================
+
+@pytest.mark.parametrize('declared,expected', [(5.0, 5.0), (2.5, 2.5), (None, 0.0)])
+def test_declared_step_priority_survives_access_and_render(declared, expected):
+    """`reify_schema_link` knows only the base `Link` fields, so a declared
+    step `priority` was dropped exactly the way a process `interval` was: the
+    schema kept its default and `render` emitted the bare type `'float'`, so
+    a round-tripped step forgot its scheduling order.
+    """
+    core = allocate_core()
+    node = {'_type': 'step', 'address': 'local:Collect'}
+    if declared is not None:
+        node['priority'] = declared
+
+    schema = core.access(node)
+    assert schema.priority._default == expected
+
+    rendered = core.render(schema)
+    assert rendered['priority'] == expected
+    assert core.access(rendered).priority._default == expected
+
+
+def test_declared_step_triggers_survive_access_and_render():
+    core = allocate_core()
+    schema = core.access({
+        '_type': 'step',
+        'address': 'local:Collect',
+        '_triggers': {'a': ['a']}})
+
+    assert schema._triggers == {'a': ['a']}
+    assert core.render(schema)['_triggers'] == {'a': ['a']}
+
+
+def test_the_scheduler_sees_a_round_tripped_priority():
+    """The payoff: priority decides which step runs first when the network
+    has a cycle, so it must survive the schema layer."""
+    core = allocate_core()
+
+    class Marker(Step):
+        config_schema = {'name': 'string'}
+
+        def inputs(self):
+            return {'seen': 'list'}
+
+        def outputs(self):
+            return {'seen': 'list'}
+
+        def update(self, state):
+            return {'seen': state['seen'] + [self.config['name']]}
+
+    core.register_link('Marker', Marker)
+
+    document = {
+        'low': {
+            '_type': 'step', 'address': 'local:Marker',
+            'config': {'name': 'low'}, 'priority': 1.0,
+            'inputs': {'seen': ['seen']}, 'outputs': {'seen': ['seen']}},
+        'high': {
+            '_type': 'step', 'address': 'local:Marker',
+            'config': {'name': 'high'}, 'priority': 9.0,
+            'inputs': {'seen': ['seen']}, 'outputs': {'seen': ['seen']}},
+        'seen': []}
+
+    round_tripped = core.render(core.access(document))
+    assert round_tripped['low']['priority'] == 1.0
+    assert round_tripped['high']['priority'] == 9.0
+
+    sim = Composite({'state': round_tripped}, core=core)
+    priorities = {
+        path[-1]: meta['priority']
+        for path, meta in sim.step_dependencies.items()}
+    assert priorities['high'] == 9.0
+    assert priorities['low'] == 1.0

--- a/tests.py
+++ b/tests.py
@@ -3640,3 +3640,134 @@ def test_a_filled_template_constructs():
     assert list(sim.process_paths) == [('proc',)]
     sim.run(2.0)
     assert sim.state['global_time'] == 2.0
+
+
+# ==========================================
+# A1 — declared emitters are actually installed
+# ==========================================
+
+def _emitting_spec(emitters):
+    from process_bigraph.composite_spec import CompositeSpec
+    return CompositeSpec(
+        id='emitting', name='emitting',
+        emitters=emitters,
+        state={
+            'proc': {
+                '_type': 'process',
+                'address': 'local:IncreaseProcess',
+                'config': {'rate': 0.1},
+                'inputs': {'level': ['level']},
+                'outputs': {'level': ['level']},
+                'interval': 1.0},
+            'level': 1.0})
+
+
+def test_declared_emitter_is_installed_and_gathers():
+    """`CompositeSpec.emitters` is a first-class field, but `to_composite`
+    never installed it — a composite built through the pure process-bigraph
+    API had no observation sink at all."""
+    spec = _emitting_spec([{'address': 'local:RAMEmitter', 'paths': ['level']}])
+
+    sim = spec.to_composite()
+    assert list(sim.step_paths) == [('emitter',)]
+
+    sim.run(3.0)
+    results = gather_emitter_results(sim)
+    rows = results[('emitter',)]
+
+    assert len(rows) > 1
+    assert 'level' in rows[0] and 'global_time' in rows[0]
+
+
+def test_emit_false_returns_the_bare_document():
+    spec = _emitting_spec([{'address': 'local:RAMEmitter', 'paths': ['level']}])
+
+    assert 'emitter' in spec.to_document()['state']
+    assert 'emitter' not in spec.to_document(emit=False)['state']
+
+
+def test_a_spec_with_no_emitters_installs_none():
+    spec = _emitting_spec([])
+    assert spec.to_document()['state'].keys() == {'proc', 'level'}
+    assert list(_emitting_spec([]).to_composite().step_paths) == []
+
+
+def test_installing_emitters_twice_yields_one_sink():
+    """The shim and the dashboard also install; fixed keys mean a second
+    install rewrites the same slot instead of adding a second sink."""
+    from process_bigraph.emitter import install_emitters
+
+    declarations = [{'address': 'local:RAMEmitter', 'paths': ['level']}]
+    state = _emitting_spec(declarations).to_document()['state']
+
+    once = install_emitters(state, declarations)
+    twice = install_emitters(once, declarations)
+
+    assert sorted(k for k in twice if k.startswith('emitter')) == ['emitter']
+    assert twice['emitter'] == once['emitter']
+
+    sim = Composite({'state': twice}, core=allocate_core())
+    assert list(sim.step_paths) == [('emitter',)]
+
+
+def test_multiple_declared_emitters_get_distinct_slots():
+    from process_bigraph.emitter import install_emitters
+
+    state = install_emitters({'level': 1.0}, [
+        {'address': 'local:RAMEmitter', 'paths': ['level']},
+        {'address': 'local:ConsoleEmitter', 'paths': ['level']}])
+
+    assert sorted(k for k in state if k.startswith('emitter')) == [
+        'emitter', 'emitter_1']
+
+
+def test_declaration_paths_become_wires():
+    """A declaration names what to observe; the wiring is computed. Slash-
+    and dot-joined paths both address a nested store."""
+    from process_bigraph.emitter import emitter_node_from_declaration
+
+    node = emitter_node_from_declaration(
+        {'address': 'local:RAMEmitter', 'paths': ['cell/mass', 'cell.volume']})
+
+    assert node['inputs']['cell_mass'] == ['cell', 'mass']
+    assert node['inputs']['cell_volume'] == ['cell', 'volume']
+    # global_time is always emitted so trajectories carry a time axis.
+    assert node['inputs']['global_time'] == ['global_time']
+    assert node['config']['emit']['cell_mass'] == 'node'
+
+
+def test_declaration_uses_the_one_emitter_constructor():
+    """A declared sink and a generated one are the same node shape, because
+    both come from `emitter_from_wires`."""
+    from process_bigraph.emitter import (
+        emitter_node_from_declaration, emitter_from_wires)
+
+    declared = emitter_node_from_declaration(
+        {'address': 'local:RAMEmitter', 'paths': ['level']})
+    generated = emitter_from_wires(
+        {'level': ['level'], 'global_time': ['global_time']},
+        address='local:RAMEmitter')
+
+    assert declared == generated
+
+
+def test_unregistered_emitter_address_degrades_to_ram():
+    from process_bigraph.emitter import emitter_node_from_declaration
+
+    node = emitter_node_from_declaration(
+        {'address': 'local:NoSuchEmitter', 'paths': ['level']},
+        core=allocate_core())
+
+    assert node['address'] == 'local:RAMEmitter'
+
+
+def test_declared_emitter_config_is_preserved():
+    from process_bigraph.emitter import emitter_node_from_declaration
+
+    node = emitter_node_from_declaration({
+        'address': 'local:RAMEmitter',
+        'config': {'subsample': 5},
+        'paths': ['level']})
+
+    assert node['config']['subsample'] == 5
+    assert 'emit' in node['config']

--- a/tests.py
+++ b/tests.py
@@ -3542,3 +3542,101 @@ def test_a_nested_flush_step_waits_for_the_simulation():
 
     assert FLUSH_FIRINGS == ['EmitterResults']
     assert study.state['cards_0']['rows'] > 1
+
+
+# ==========================================
+# A0 — groundness at the Composite boundary
+# ==========================================
+
+MODEL_FACE = {
+    '_type': 'link',
+    '_inputs': {'level': 'float'},
+    '_outputs': {'level': 'float'}}
+
+
+def test_unfilled_required_site_is_rejected():
+    """A document with an open template hole is not runnable.
+
+    Nothing downstream — wiring, scheduling, emitters — can be built over a
+    site, so the composite must say so at construction rather than fail
+    obscurely mid-run.
+    """
+    core = allocate_core()
+    document = {'study': {
+        'model': {'_type': 'site', '_sort': MODEL_FACE},
+        'level': 1.0}}
+
+    with pytest.raises(ValueError, match='not ground') as raised:
+        Composite({'state': document}, core=core)
+
+    assert "'study/model'" in str(raised.value)
+
+
+def test_every_unfilled_site_is_named():
+    core = allocate_core()
+    document = {'study': {
+        'model': {'_type': 'site', '_sort': MODEL_FACE},
+        'reference': {'_type': 'site', '_sort': MODEL_FACE}}}
+
+    with pytest.raises(ValueError, match='not ground') as raised:
+        Composite({'state': document}, core=core)
+
+    message = str(raised.value)
+    assert "'study/model'" in message
+    assert "'study/reference'" in message
+
+
+def test_optional_site_does_not_block_construction():
+    """A site carrying a `_default` can supply its own filler, so it is not
+    a required hole."""
+    core = allocate_core()
+    document = {'study': {
+        'rate': {'_type': 'site', '_sort': 'float', '_default': 0.5},
+        'level': 1.0}}
+
+    sim = Composite({'state': document}, core=core)
+    assert sim.state['study']['level'] == 1.0
+
+
+def test_a_normal_composite_is_still_ground():
+    """The check is over *sites*, not `is_ground`: a composite containing a
+    process has unwired ports by construction, so `is_ground` would reject
+    every real composite. It must not."""
+    core = allocate_core()
+    document = {
+        'proc': {
+            '_type': 'process',
+            'address': 'local:IncreaseProcess',
+            'config': {'rate': 0.1},
+            'inputs': {'level': ['level']},
+            'outputs': {'level': ['level']},
+            'interval': 1.0},
+        'level': 1.0}
+
+    sim = Composite({'state': document}, core=core)
+    sim.run(2.0)
+    assert sim.state['global_time'] == 2.0
+
+
+def test_a_filled_template_constructs():
+    """The end-to-end shape: fill the hole, then the composite builds."""
+    from bigraph_schema.assembly import fill_sites
+
+    core = allocate_core()
+    template = core.access({
+        'proc': {'_type': 'site', '_sort': MODEL_FACE},
+        'level': 'float'})
+    filler = core.access({
+        '_type': 'process',
+        'address': 'local:IncreaseProcess',
+        'config': {'rate': 0.1},
+        'inputs': {'level': ['level']},
+        'outputs': {'level': ['level']},
+        'interval': 1.0})
+
+    filled = fill_sites(core, template, {'proc': filler})
+
+    sim = Composite({'state': core.render(filled)}, core=allocate_core())
+    assert list(sim.process_paths) == [('proc',)]
+    sim.run(2.0)
+    assert sim.state['global_time'] == 2.0


### PR DESCRIPTION
**Layer 2a Part A** of framework-unification (spec PR #154). Harden the composite concept; Part B (`${name}`→site lowering) is a later task.

## A0 — enforce groundness at the boundary
`Composite._require_ground_document()` in `__init__`, after `core.realize(...)` (the earliest point a site is a real `Site` node). Uses `collect_sites` filtered to sites with **no `_default`** — deliberately **not** `is_ground` (a real composite with a process has unwired ports by construction, so `is_ground` would reject every composite). An unfilled required site raises naming its path; optional/defaulted sites and normal wired composites construct fine.

## A1 — install a spec's declared emitters (real bug)
`CompositeSpec.to_composite()` never installed declared emitters → a composite built via the pure API had no sink. Fixed by **collapsing constructors, not adding one**: `generate_emitter_state` now delegates to `emitter_from_wires` (the node shapes were byte-identical); `emitter_node_from_declaration` turns `paths`→wires through the same constructor; `install_emitters` places them; `to_document`/`to_composite` install (with `emit=False` for the bare document). Idempotency is structural (fixed keys). *Note:* `add_emitter_to_composite` installs into a **live** Composite (state merge + step-network rebuild) and can't place a node into a document, so it stays the live-composite path; both now route through one constructor.

## StepLink.priority (+ _triggers)
`reify_schema_link` dropped a declared step `priority` (and `_triggers`) exactly like the interval bug. `StepLink` gets its own `reify_schema`/`render`; the scheduler now sees round-tripped priorities.

## Tests
**109 passed, 7 skipped, 0 failures** (baseline 90).

## ⚠️ Dependency: bigraph-schema 1.4.3
A0 depends on the Layer-1 site primitive; the floor is bumped to `bigraph-schema>=1.4.3`. **1.4.3 must be released** (Layer 1 is merged to bigraph-schema main but not yet published) before this PR's CI can install it.

## Part-B blockers found (for the next task)
1. `substitute_parameters` runs on `state` before emitters install — when `${name}` becomes a site, filling must happen **before** emitter install (order matters).
2. Inline interpolation (`"pre_${n}_post"`) is string concat, no site equivalent — the golden corpus must report its usage first.
3. Builder-kind specs return an opaque document — no `${name}`/site, so subsumption covers `spec`-kind only.
4. A0 rejects open-site documents, so the lowering must **fill before constructing**, never during.

## Follow-up (different repo)
pbg-superpowers' `install_default_emitters` becomes a 3-line re-export of `process_bigraph.emitter.install_emitters` (patch provided by the build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)