### PR TITLE
docs(spec): study & investigation templates (site-based, Layer 3)

### DIFF
--- a/docs/superpowers/specs/2026-07-31-git-remote-protocol-design.md
+++ b/docs/superpowers/specs/2026-07-31-git-remote-protocol-design.md
@@ -1,0 +1,71 @@
+# The `git:` / remote protocol — resolving a repo address to a runnable process
+
+**Status:** Design (Layer 3 capability — decisions-forward)
+**Date:** 2026-07-31
+**Repo:** process-bigraph (a new `Protocol`, alongside `local:`)
+**Companion:** `2026-07-31-study-investigation-templates-design.md` (§5.1 — the comparison-harness needs this)
+**Why:** an **address site** (Layer-1 §4.6) can be filled with a *repo* address — the vEcoli case: `fill(vecoli.address, 'git:CovertLab/vEcoli@<ref>')`. That address must resolve to a runnable `Edge` whose face is checked. This is the one genuinely new capability behind "compare against a different implementation."
+
+---
+
+## 1. What it does
+
+`git:<owner>/<repo>@<ref>#<entry>` resolves to an `Edge`:
+
+1. **Fetch + pin** the repo at `<ref>` (branch/tag/commit) into a content-addressed cache; record the resolved **commit SHA** (a moving `<ref>` re-resolves; a SHA is frozen — the reproducibility unit).
+2. **Materialize an environment** for that checkout (its deps).
+3. **Expose `<entry>`** (a designated process/composite entrypoint) as an `Edge` whose `interface()` is the face the address site checks (`admits`).
+
+Filling the site is one call; the *heavy* work (fetch/install) is cached and happens once per SHA, **not** at document build. Conformance is checked **before a run**, not at every fill.
+
+---
+
+## 2. The decisions (each needs a call — recommendation given)
+
+### D1. Environment isolation — *the load-bearing decision*
+Running fetched code (vEcoli pulls a large scientific stack) must not pollute or break the host env.
+- **(a) Subprocess + per-SHA venv** — `uv venv` per commit SHA, install the repo, run the entrypoint out-of-process, talk over a small RPC/stdio boundary. Portable, no daemon, matches process-bigraph's existing detached-run model. **Recommended.**
+- (b) Container (Docker) per repo — strongest isolation + reproducibility, but a hard host dependency (not everywhere) and heavier.
+- (c) In-process import — cheapest, but foreign deps collide with the host (numpy pins, etc.) and one bad import can crash the server. **Rejected** for anything but trusted, pip-clean repos.
+
+*Recommendation: (a). The edge is a thin RPC proxy over a subprocess running in the repo's own venv; the `interface()` it advertises is the face.*
+
+### D2. Trust & security — *running foreign code*
+`git:` executes code from a URL.
+- **Allow-list of orgs/repos** in `workspace.yaml` (default: `CovertLab/vEcoli` + explicitly added forks); a `git:` address outside the list is refused, not run.
+- **Pin-to-SHA for runs**: a bare branch is resolved-and-recorded; the *run* uses the recorded SHA, and a changed SHA is surfaced (never silently re-run).
+- No credentials in the address; private repos use the host's existing git auth.
+- *Recommendation: allow-list + SHA-pinning are mandatory; sandboxing beyond the venv/subprocess is out of scope v1 (documented as "runs code you allow-listed").* **This is a real user decision — confirm the allow-list model.**
+
+### D3. Caching & reproducibility
+- Cache key = `(repo, commit-SHA)`; the built venv is cached too (keyed by SHA + a lockfile hash). A pinned SHA is reproducible; a comparison investigation records the SHA in its artifacts.
+- GC/eviction of old checkouts is a workspace maintenance concern (out of scope v1; just don't unbounded-grow silently — log sizes).
+
+### D4. The entrypoint contract
+How does `git:` know *what* in the repo to run?
+- **(a) `#<entry>`** in the address names a module:callable the repo exposes (e.g. `#vecoli.workflow:make_process`). Explicit, no convention needed. **Recommended.**
+- (b) A repo-root manifest (`.pbg-entry.yaml`) the protocol reads. Cleaner addresses, but requires the repo to adopt a convention (vEcoli is CovertLab's, not ours).
+- *Recommendation: (a), with (b) as an optional convenience later. For vEcoli we point `#` at a thin adapter we maintain in v2ecoli that wraps CovertLab's entrypoint to the study's face.*
+
+### D5. Conformance timing
+- `admits` at **fill** time checks the *declared* face if the address is already resolved-and-cached; otherwise it's deferred to **pre-run** (resolve → introspect `interface()` → conform). A run never starts against a non-conforming address.
+- *Recommendation: cheap declared-face check at fill when available; authoritative check pre-run.*
+
+---
+
+## 3. Contracts
+
+1. **Resolution is a pure function of `(repo, SHA, entry)`** → the same `Edge` face; recorded SHA is the reproducibility unit.
+2. **`admits` holds against the resolved `interface()`** — a non-conforming vEcoli entrypoint is rejected before a run, naming the face mismatch.
+3. **Isolation** — foreign deps never enter the host process/env (D1(a)); a fetched-code failure degrades to a clear error, not a host crash.
+4. **Allow-list** — an un-allow-listed `git:` address is refused (D2).
+
+---
+
+## 4. Sequencing & out of scope
+
+**Sequence:** (1) the protocol skeleton + cache/pin + allow-list (no real repo); (2) subprocess+venv materialization + RPC edge on a *lightweight* test repo; (3) a v2ecoli-side vEcoli adapter (`#` entry) so the comparison-harness (companion spec §5) runs against `CovertLab/vEcoli@<ref>`; (4) SHA recording in comparison artifacts.
+
+**Out of scope v1:** container isolation (D1(b)); full sandboxing beyond venv/subprocess; private-repo credential management beyond host git auth; cache GC policy.
+
+**Open for the user:** confirm the **allow-list trust model** (D2) and the **subprocess+venv isolation** (D1) before build — these define how the workbench runs foreign code.

--- a/docs/superpowers/specs/2026-07-31-git-remote-protocol-design.md
+++ b/docs/superpowers/specs/2026-07-31-git-remote-protocol-design.md
@@ -22,6 +22,11 @@ Filling the site is one call; the *heavy* work (fetch/install) is cached and hap
 
 ## 2. The decisions (each needs a call — recommendation given)
 
+> **RESOLVED 2026-07-31 (user).** **D1 = (a)** subprocess + per-SHA `uv venv`. **D2 = allow-list
+> + mandatory SHA-pinning**, sandboxing beyond venv/subprocess out of scope v1. Build proceeds on
+> these. Container isolation (D1(b)) deferred; the allow-list defaults to `CovertLab/vEcoli` plus
+> explicitly-added forks, refusing any `git:` address outside it.
+
 ### D1. Environment isolation — *the load-bearing decision*
 Running fetched code (vEcoli pulls a large scientific stack) must not pollute or break the host env.
 - **(a) Subprocess + per-SHA venv** — `uv venv` per commit SHA, install the repo, run the entrypoint out-of-process, talk over a small RPC/stdio boundary. Portable, no daemon, matches process-bigraph's existing detached-run model. **Recommended.**

--- a/docs/superpowers/specs/2026-07-31-study-investigation-templates-design.md
+++ b/docs/superpowers/specs/2026-07-31-study-investigation-templates-design.md
@@ -163,6 +163,34 @@ before a run, not at document build). This is the one genuinely new capability.
 - The workbench's ProcessCard viewer already renders open sites as the "unbound"
   state (presentation side) — a template study/investigation renders for free.
 
+### 6.1 The Layer-4 authoring & fill loop (workbench)
+
+A template is authored and run entirely through the ProcessCard viewer — no code —
+because a template *is* a document and the viewer already renders documents:
+
+1. **Author** a study/investigation template: drop a composite into the study's
+   **model** face-site, mark the emitter / viz / analysis / report-card holes as
+   **sites** (the viewer's config/inputs/outputs regions gain an "open site" affordance
+   — a hole with its sort/contract shown, not a value). Saved as `*.template.yaml`
+   (sites round-trip via Layer 1).
+2. **Fill** it: the viewer's config panel binds each site — a **value** site is a
+   typed field; a **face** site (model / viz / report-card) offers the *conforming*
+   registry entries (`admits` filters the picker); an **address** site (the vEcoli
+   repo) is a text/ref field the `git:` protocol resolves; a **cardinality** site is
+   a count. **Apply** = `fill_sites` + re-render (the same Apply already in the card).
+3. **Run** it: a fully-filled (ground) template's Run is live; an unfilled required
+   site keeps the card in the **unbound** state and disables Run — the *same*
+   `is_ground` predicate that gates the engine gates the button. One predicate, one
+   picture (viewer handoff §D4).
+4. **A gated investigation** renders its blocked members as *pruned/absent* (staged
+   filling, §4) — the DAG the viewer draws is the ground remainder, so "what didn't
+   fill isn't shown" matches "what didn't fill didn't run."
+
+So the viewer's four regions (config · inputs · contract · outputs) + the pull-down
+loom render a *template* as naturally as a composite: a site is just a region whose
+value is a **hole with a contract** instead of a value. No new UI concept — the
+"unbound" state + `admits`-filtered pickers are the whole Layer-4 surface.
+
 ---
 
 ## 7. Contracts

--- a/docs/superpowers/specs/2026-07-31-study-investigation-templates-design.md
+++ b/docs/superpowers/specs/2026-07-31-study-investigation-templates-design.md
@@ -1,0 +1,156 @@
+# Study & investigation templates — the site-based format (Option 3)
+
+**Status:** Design (Layer 3 of the framework-unification stack)
+**Date:** 2026-07-31
+**Repos:** process-bigraph (study/investigation documents), bigraph-schema (the site primitive — shipped in 1.4.4), vivarium-workbench (authoring), v2ecoli (the comparison-harness proof)
+**Umbrella:** `vivarium-workbench/docs/superpowers/specs/2026-07-29-framework-unification-design.md`
+
+---
+
+## 1. Why this exists (and what it is *not*)
+
+The corpus disproved "make `CompositeSpec` a template by lowering `${name}` onto
+sites" (Layer-2a Part B, superseded): a **site** fills a place-graph position *in a
+schema*; `${name}` fills a value *inside opaque config blobs and edge fields in a
+state document* — different things, and `fill_sites → core.fill` realizes every edge.
+So the legacy `${name}` `CompositeSpec` is **kept** (with typed validation, Part B′).
+
+**This spec is the real thing the user asked for: templates for studies and
+investigations** — a **new, first-class, site-based format** where a parameter *is* a
+schema **site**, built directly on the Layer-1 primitive (all shipped in
+bigraph-schema 1.4.4): `fill_sites`, `is_ground`, `admits`, `contract`/`amend`, and
+**address injection**. No `${name}`. It coexists with legacy specs.
+
+---
+
+## 2. The building blocks (Layer 1, already shipped)
+
+A template is **a document that is not ground** (has open sites). Its site kinds:
+
+- **value site** — a sorted `Site` of a value type (`float`/`string`/`enum[...]`);
+  `admits` = `core.check`. This is a configurable config knob.
+- **model / process site** — a `Site` whose sort is a **face** (`link[in,out]`);
+  `admits` = the filler's `interface()` conforms. Drop in a conforming composite.
+- **address site** — a process edge with a **fixed face** and its **`address` open**
+  (Layer-1 §4.6, *a process definition without an implementation*). `fill` injects the
+  address; `admits` checks the named process's face conforms.
+- **cardinality site** — an `int` driving a `ReactionRule` replication (Layer-1 §4.5),
+  e.g. `n_seeds`.
+
+`fill(template, bindings)` → `build` returns a ground `(schema, state)`; `is_ground`
+is the runnable predicate; a partially-filled template is still a template.
+
+---
+
+## 3. A study is a template with a model site
+
+A **study template** fixes the analysis-flush sub-network (viz / analyses / report
+cards, wired to the emitter's `results` port — umbrella Layer 1) and leaves the
+**model** as a site:
+
+```
+study.template:
+  model:        <site: face = the study's expected model interface>   # fill with a composite
+  n_seeds:      <site: int>                                           # cardinality
+  media:        <site: enum[...]>                                     # value
+  flush:        [ viz_* , analysis_* , report_card_* ]               # fixed
+  emitter:      <declared, results port>                             # fixed
+```
+
+`fill({model: ecoli_baseline, n_seeds: 8, media: minimal})` → a ground, runnable study
+document. Any conforming registered composite drops into `model`.
+
+## 4. An investigation is a template with a site per study; gating = filling
+
+An **investigation template** has one **study site per member**, plus value/address
+sites for what's configurable, and **gate edges** that fill downstream sites at
+runtime (umbrella Layer 2 — gating is conditional filling): a gate emits `study_B`'s
+filler on the upstream `pass`, leaves the site open on `fail`; an open site ⇒
+non-ground ⇒ never built.
+
+## 5. Flagship — the comparison-harness investigation template
+
+The v2ecoli ↔ vEcoli comparison, as one document:
+
+```
+comparison.template:
+  compared:                        # value sites — sweep these
+    media:        <site: enum[...]>
+    n_seeds:      <site: int>
+    timepoints:   <site: list[float]>
+    tolerances:   <site: map[float]>
+  vecoli:                          # an ADDRESS site (abstract process)
+    _type: process
+    _inputs / _outputs: <fixed face — vEcoli's I/O contract>
+    address:  <site: sort = "a whole-cell model process">    # default: git:CovertLab/vEcoli@main
+  v2ecoli: <model site>            # the in-tree model
+  compare: <fixed step: matched-timepoint nRMSE, report cards>
+```
+
+- **Compare against a different implementation:** `fill(vecoli.address,
+  'git:CovertLab/vEcoli@<ref>')` — a fork, a branch, a pinned commit.
+- **Sweep the compared configs:** `fill` the value sites.
+- One document, no code. This proves **address injection end-to-end on a real
+  cross-model harness** — the flagship the umbrella names.
+
+### 5.1 New piece required — a git/remote protocol
+
+The vEcoli `address` names an implementation fetched from a **repo**. Add a
+**protocol** `git:<owner>/<repo>@<ref>` (alongside `local:`) that resolves a repo
+address to a runnable process: clone/pin the ref, install into an isolated env,
+expose vEcoli's entrypoint as an `Edge` whose `interface()` matches the site's face.
+`admits` runs against that resolved face (fetch is cached; conformance is checked
+before a run, not at document build). This is the one genuinely new capability.
+
+---
+
+## 6. Authoring format & coexistence
+
+- A study/investigation template is a **document with sites** on disk
+  (`*.template.{yaml,json}`), authored/rendered via the workbench. A site is written
+  as `{_type: site, _sort: <value type | face | address-sort>, _default?: …}` at its
+  position — `render`/`access` round-trip it (Layer-1 fixed the `_sort` round-trip).
+- **Coexistence:** legacy `${name}` `CompositeSpec` is untouched and keeps working;
+  the site format is **opt-in** for new studies/investigations. No mass migration is
+  forced — a study authored the new way is a template, an old one stays a spec.
+- The workbench's ProcessCard viewer already renders open sites as the "unbound"
+  state (presentation side) — a template study/investigation renders for free.
+
+---
+
+## 7. Contracts
+
+1. **A template is `not is_ground`.** `build(template, bindings)` → ground `(schema,
+   state)`; the study/investigation runs iff ground.
+2. **`admits` per site kind** — value (`core.check`), model/address (face
+   conformance via the resolved `interface()`), cardinality (int/range).
+3. **Address protocol contract** — `git:` resolves a `(repo, ref)` to an `Edge` whose
+   face is checked before run; resolution is cached and pinnable for reproducibility.
+4. **Gating = filling** — a failed prerequisite leaves a study site open; the region
+   is non-ground and never built.
+5. **No `${name}`** — this format never touches the legacy substitution engine.
+
+---
+
+## 8. Tests
+
+- A study template with a model site + value + cardinality sites builds to a runnable
+  study when filled with a conforming composite; a non-conforming model → fill error.
+- The comparison-harness template: `fill` the vEcoli address with two refs → two
+  distinct resolved faces both conform; a non-whole-cell address → rejected.
+- Gating: an investigation template where an upstream `fail` leaves the dependent
+  study site open → the dependent is not built (asserted via A0's open-site check).
+- `git:` protocol: resolves a pinned ref deterministically; caches; a moved ref is
+  re-resolved; conformance checked before run.
+
+---
+
+## 9. Sequencing & out of scope
+
+**Sequencing:** (1) the `git:`/remote **protocol** (the new capability); (2) the
+study & investigation template **format** + `build`; (3) the **comparison-harness**
+template as the proof; (4) workbench authoring UI. Depends on: bigraph-schema ≥1.4.4
+(shipped), process-bigraph Part A (A0 open-sites, merged path).
+
+**Out of scope:** migrating the ~250 legacy studies (they stay `${name}` specs; new
+ones opt in); rewriting `CompositeSpec`; the read-side renderers.

--- a/docs/superpowers/specs/2026-07-31-study-investigation-templates-design.md
+++ b/docs/superpowers/specs/2026-07-31-study-investigation-templates-design.md
@@ -42,23 +42,39 @@ is the runnable predicate; a partially-filled template is still a template.
 
 ---
 
-## 3. A study is a template with a model site
+## 3. A study is a template — model, emitter, AND flush entities are all sites
 
-A **study template** fixes the analysis-flush sub-network (viz / analyses / report
-cards, wired to the emitter's `results` port — umbrella Layer 1) and leaves the
-**model** as a site:
+Everything configurable about a study is a **site**; only the *wiring* (each flush
+edge reads the emitter's `results` port — umbrella Layer 1) is fixed. A study
+template's holes:
 
 ```
 study.template:
-  model:        <site: face = the study's expected model interface>   # fill with a composite
-  n_seeds:      <site: int>                                           # cardinality
-  media:        <site: enum[...]>                                     # value
-  flush:        [ viz_* , analysis_* , report_card_* ]               # fixed
-  emitter:      <declared, results port>                             # fixed
+  model:          <site: face = the study's expected model interface>   # fill with a composite
+  # config (value / cardinality sites)
+  n_seeds:        <site: int>                                           # cardinality
+  media:          <site: enum[...]>                                     # value
+  # the sink — an interchangeable-face site
+  emitter:        <site: face = Emitter(results)>                       # RAM | Parquet | XArray-zarr
+  # the flush entities — CARDINALITY REGIONS of face-sorted sites (0+ each),
+  # every one wired to `results`:
+  visualizations: [ <site: face = Visualization(results→figure)> … ]
+  analyses:       [ <site: face = Analysis(results→analysis)>     … ]
+  report_cards:   [ <site: face = ReportCard(results→verdict)>    … ]
 ```
 
-`fill({model: ecoli_baseline, n_seeds: 8, media: minimal})` → a ground, runnable study
-document. Any conforming registered composite drops into `model`.
+- **Emitter site.** Filling it chooses the sink (RAM / Parquet / XArray-zarr) —
+  interchangeable because they share the `results` face; `admits` checks conformance.
+- **Flush-entity site-regions.** `visualizations`/`analyses`/`report_cards` are
+  cardinality regions (Layer-1 §4.5): fill with 0+ conforming Steps, each auto-wired
+  to `results`. A report-card site accepts only a Step whose face reads `results` and
+  writes a verdict — so you can't wire a viz where a card belongs.
+
+`fill({model: ecoli_baseline, emitter: XArrayEmitter, media: minimal, n_seeds: 8,
+visualizations: [mass_trace, growth_curve], analyses: [doubling_time],
+report_cards: [mass_conservation, division_timing]})` → a **fully-specified, ground,
+runnable study**, no code. Every knob — the model, the sink, and *which* figures /
+analyses / verdicts run — is a `fill`.
 
 ## 4. An investigation is a template with a site per study; gating = filling
 

--- a/docs/superpowers/specs/2026-07-31-study-investigation-templates-design.md
+++ b/docs/superpowers/specs/2026-07-31-study-investigation-templates-design.md
@@ -54,31 +54,61 @@ predicate; a partially-filled template is still a template.
 
 ## 3. A study is a template — model, emitter, AND flush entities are all sites
 
-Everything configurable about a study is a **site**; only the *wiring* (each flush
-edge reads the emitter's `results` port — umbrella Layer 1) is fixed. A study
-template's holes:
+A study is a **higher-order DAG**. The simulation is *one node*
+(`local:SimulationStep`, process-bigraph ≥ the #160 merge) and the flush entities are
+ordinary steps downstream of that node's **`results`** output — the emitter's durable
+handle (`EmitterResults`: a reference, resolved on demand, never the bulk).
+
+That shape is what makes a flush entity fire **exactly once**. Its `results` input is
+unsatisfied until the simulation node's update returns, and the simulation's per-tick
+stepping happens *inside* the node rather than beside it — so the flush steps are
+never siblings of the simulation's own steps. Ordinary producer/consumer ordering does
+all of it: no completion phase, no marker, no scheduler special case.
+
+Everything configurable is a **site**; only the wiring is fixed. A study template's
+holes:
 
 ```
 study.template:
-  model:          <site: face = the study's expected model interface>   # fill with a composite
-  # config (value / cardinality sites)
-  n_seeds:        <site: int>                                           # cardinality
-  media:          <site: enum[...]>                                     # value
-  # the sink — an interchangeable-face site
-  emitter:        <site: face = Emitter(results)>                       # RAM | Parquet | XArray-zarr
+  threshold/media/n_seeds: <value & cardinality sites>     # study-level config
+  sim:                                                     # the simulation, ONE node
+    _type: step
+    address: local:SimulationStep
+    config:
+      runtime: <float>
+      state:                                               # the simulation it runs
+        model:   <site: face = the study's expected model interface>
+        emitter:                                           # the sink
+          address: <site: sort = "an emitter">             # RAM | Parquet | XArray-zarr
+          outputs: {results: [results]}                    # fixed — the handle leaves here
+    outputs: {results: [results]}                          # fixed — and leaves the node
   # the flush entities — CARDINALITY REGIONS of face-sorted sites (0+ each),
-  # every one wired to `results`:
+  # every one wired to `results` via an ascending wire:
   visualizations: [ <site: face = Visualization(results→figure)> … ]
   analyses:       [ <site: face = Analysis(results→analysis)>     … ]
   report_cards:   [ <site: face = ReportCard(results→verdict)>    … ]
 ```
 
-- **Emitter site.** Filling it chooses the sink (RAM / Parquet / XArray-zarr) —
-  interchangeable because they share the `results` face; `admits` checks conformance.
+- **Model & emitter sites live inside the simulation node's inner state.** Filling
+  them configures *the simulation the study runs*. Sites nested in a node's `config`
+  are discoverable and fillable like any other (addressed by path, e.g.
+  `study/sim/config/state/model`).
+- **Emitter site.** Filling it chooses the sink. Interchangeability is expressed by a
+  **registered sort** (`core.register_sort`), not by face conformance: every emitter
+  exposes the same `results` port and nothing else, so a face check cannot tell an
+  emitter from anything else that happens to expose `results`. The sort states the
+  constraint directly — *the address must name a registered `Emitter`* — and refuses
+  e.g. `local:IncreaseProcess`.
 - **Flush-entity site-regions.** `visualizations`/`analyses`/`report_cards` are
-  cardinality regions (Layer-1 §4.5): fill with 0+ conforming Steps, each auto-wired
-  to `results`. A report-card site accepts only a Step whose face reads `results` and
-  writes a verdict — so you can't wire a viz where a card belongs.
+  cardinality regions (Layer-1 §4.5): fill with 0+ conforming Steps. Each sits inside
+  its own instance region, so it reaches the shared handle with an **ascending wire**
+  (`['..', 'results']`). A report-card site accepts only a Step whose face reads
+  `results` and writes a verdict — so you can't wire a viz where a card belongs. Zero
+  entities is valid: a study that reports nothing is still a study.
+- **What a flush entity observes.** The *resolved trajectory* of a finished run, not
+  an instantaneous store value. A report card wired to `results` judges the run's
+  final state — something no per-tick step could do — and its firing count is
+  independent of how long the simulation ran.
 
 `fill({model: ecoli_baseline, emitter: XArrayEmitter, media: minimal, n_seeds: 8,
 visualizations: [mass_trace, growth_curve], analyses: [doubling_time],

--- a/docs/superpowers/specs/2026-07-31-study-investigation-templates-design.md
+++ b/docs/superpowers/specs/2026-07-31-study-investigation-templates-design.md
@@ -37,8 +37,18 @@ A template is **a document that is not ground** (has open sites). Its site kinds
 - **cardinality site** — an `int` driving a `ReactionRule` replication (Layer-1 §4.5),
   e.g. `n_seeds`.
 
-`fill(template, bindings)` → `build` returns a ground `(schema, state)`; `is_ground`
-is the runnable predicate; a partially-filled template is still a template.
+`fill(template, bindings)` → a ground document; `is_ground` is the runnable
+predicate; a partially-filled template is still a template.
+
+> **Use `fill_sites → render → Composite`, not `assembly.build`.** The PoC found
+> `build()` finishes with `core.fill`, which realizes every edge and **crashes on a
+> process's `config`** (`default(0.5)` — a raw value where `default` expects a
+> schema; `default_link` still does `default(schema.config)`). This is the same
+> materialization gap 1.4.4 closed for `address`/`inputs`/`outputs` but **not**
+> `config`, so `build()` is unusable for any realistic pbg document. `Composite`
+> realizes the document itself, so the native path skips the broken step. **A
+> one-line bigraph-schema fix to `default_link` should make `build()` usable** — a
+> worthwhile upstream follow-up.
 
 ---
 
@@ -76,13 +86,34 @@ report_cards: [mass_conservation, division_timing]})` → a **fully-specified, g
 runnable study**, no code. Every knob — the model, the sink, and *which* figures /
 analyses / verdicts run — is a `fill`.
 
-## 4. An investigation is a template with a site per study; gating = filling
+## 4. An investigation is a template with a site per study; gating = *staged* filling
 
-An **investigation template** has one **study site per member**, plus value/address
-sites for what's configurable, and **gate edges** that fill downstream sites at
-runtime (umbrella Layer 2 — gating is conditional filling): a gate emits `study_B`'s
-filler on the upstream `pass`, leaves the site open on `fail`; an open site ⇒
-non-ground ⇒ never built.
+An **investigation template** has one **study site per member** + value/address
+sites. Gating is **conditional filling, staged** (validated in the PoC, `f908bae`):
+a gate is a **real edge** (a report-card step) whose verdict decides the **bindings
+of the next stage** — on `pass` it emits the downstream study's filler; on `fail` it
+does not. An unfilled member is then **pruned** (`prune_open_regions`) and is
+**absent** from the constructed document — the strongest form of "never run": the
+engine never *decides* not to run something, because what wasn't filled isn't there.
+
+| upstream verdict | blocked | built & run |
+|---|---|---|
+| `pass` | — | `study_A`, `study_B` |
+| `fail` | `study_B` | `study_A` |
+
+**Why staged, not single-run (a real finding, not a compromise).** A site is a hole
+in a *schema*, and schemas are consumed at **construction**; the step network runs
+**after**. And an open site is **not local** — A0 rejects the *whole* document if any
+required site is open (`'investigation/study_B/model' unfilled` → nothing builds). So
+a gate edge *cannot* fill a site inside a composite that could never be constructed.
+The gate therefore runs **between builds** (verdict → next-stage bindings → build the
+now-ground remainder), and unfilled members are pruned before construction. This
+preserves contract #4 exactly, with **one** filling mechanism.
+
+*Literal single-run gating (insert a subtree mid-`run()`) is a different operation —
+process-bigraph's runtime **structural updates** (`_add`/`_remove`/`_divide`, used for
+cell division), not sites. If ever wanted, spec it as that; do **not** conflate it
+with filling (the same trap the `${name}`-lowering attempt fell into).*
 
 ## 5. Flagship — the comparison-harness investigation template
 


### PR DESCRIPTION
The real answer to *'templates for studies and investigations'* — a **new site-based format** (a parameter *is* a schema **site**) built on Layer 1 (`fill`/`is_ground`/`admits`/address-injection, shipped in bigraph-schema 1.4.4). **Not** a `CompositeSpec`/`${name}` refactor (the corpus disproved that — see Layer-2a spec).

- **Study template** = a document with a **model site** (+ value/cardinality sites); the analysis-flush is fixed.
- **Investigation template** = a **site per member study** + value/address sites; **gating = filling** (a failed prerequisite leaves a study site open → non-ground → not built).
- **Flagship — the comparison-harness:** value sites for the compared configs + a **`git:CovertLab/vEcoli` address site** (inject a fork/branch/commit = compare a different implementation). Proves address injection end-to-end.
- **New capability:** a `git:`/remote **protocol** resolving a repo address to a runnable process (the implementation the address names).
- **Coexists** with legacy `${name}` specs — opt-in, no forced migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)