### PR TITLE
Add git: remote protocol — resolve a repo address to a runnable Edge

### DIFF
--- a/process_bigraph/protocols/__init__.py
+++ b/process_bigraph/protocols/__init__.py
@@ -8,12 +8,14 @@ Protocols for retrieving processes from address
 from process_bigraph.protocols.parallel import ParallelProtocol, load_protocol as load_parallel_protocol
 from process_bigraph.protocols.rest import RestProtocol
 from process_bigraph.protocols.ray import RayProtocol
+from process_bigraph.protocols.git import GitProtocol
 
 
 PROCESS_PROTOCOLS = {
     'parallel': ParallelProtocol,
     'rest': RestProtocol,
-    'ray': RayProtocol}
+    'ray': RayProtocol,
+    'git': GitProtocol}
 
 
 def register_types(core):

--- a/process_bigraph/protocols/_git_worker.py
+++ b/process_bigraph/protocols/_git_worker.py
@@ -1,0 +1,164 @@
+"""
+Standalone stdio worker for the ``git:`` protocol.
+
+This script runs **inside the fetched repo's own venv** (``<sha>/venv``), where
+process-bigraph is deliberately *not* installed. It therefore imports only the
+Python standard library, so it can be launched by any interpreter regardless of
+what scientific stack the foreign repo pulls in. The host talks to it over a
+small newline-delimited-JSON RPC on stdin/stdout — this is the isolation
+boundary: foreign code (and foreign dependencies) live entirely in this
+subprocess and never enter the host interpreter (spec contract 3, D1(a)).
+
+Wire protocol (one JSON object per line):
+
+    host -> worker : {"cmd": "init", "config": {...}}
+    worker -> host : {"ok": true, "interface": {"inputs": {...}, "outputs": {...}}}
+
+    host -> worker : {"cmd": "update", "state": {...}, "interval": 1.0}
+    worker -> host : {"ok": true, "update": {...}}
+
+    host -> worker : {"cmd": "interface"}
+    worker -> host : {"ok": true, "interface": {...}}
+
+    host -> worker : {"cmd": "end"}
+    (worker exits)
+
+Any failure resolving/instantiating the entrypoint, or in an update, is
+reported as ``{"ok": false, "error": "..."}`` — a clear error the host raises,
+never a host crash.
+
+Invocation::
+
+    <venv-python> _git_worker.py <module> <callable>
+
+``<callable>`` is invoked with the init ``config`` if it accepts an argument,
+else with no arguments. Its return value must be an edge-like object exposing
+``inputs()``, ``outputs()`` and ``update(state, interval)``.
+"""
+
+import sys
+import json
+import inspect
+import importlib
+import traceback
+
+
+def _load_entry(module_name, callable_name):
+    module = importlib.import_module(module_name)
+    entry = module
+    for attr in callable_name.split('.'):
+        entry = getattr(entry, attr)
+    return entry
+
+
+def _instantiate(entry, config):
+    """Call the entrypoint. If it takes at least one parameter, pass the
+    config; otherwise call it with no arguments. Keeps the entrypoint
+    contract minimal (spec D4): ``module:callable`` returning an edge."""
+    if not callable(entry):
+        # The fragment named a value that is already an edge-like object.
+        return entry
+    try:
+        sig = inspect.signature(entry)
+        takes_arg = any(
+            p.kind in (
+                inspect.Parameter.POSITIONAL_ONLY,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                inspect.Parameter.VAR_POSITIONAL,
+            )
+            for p in sig.parameters.values()
+        )
+    except (ValueError, TypeError):
+        takes_arg = True
+    if takes_arg:
+        return entry(config)
+    return entry()
+
+
+def _interface(edge):
+    face = getattr(edge, 'interface', None)
+    if callable(face):
+        result = face() or {}
+        return {
+            'inputs': dict(result.get('inputs') or {}),
+            'outputs': dict(result.get('outputs') or {}),
+        }
+    return {
+        'inputs': dict(edge.inputs() or {}),
+        'outputs': dict(edge.outputs() or {}),
+    }
+
+
+def _send(obj):
+    sys.stdout.write(json.dumps(obj) + '\n')
+    sys.stdout.flush()
+
+
+def main(argv):
+    if len(argv) != 3:
+        _send({'ok': False,
+               'error': f'usage: _git_worker.py <module> <callable> '
+                        f'(got {argv!r})'})
+        return 2
+
+    module_name, callable_name = argv[1], argv[2]
+
+    # --- init handshake -------------------------------------------------
+    first = sys.stdin.readline()
+    if not first:
+        return 0
+    try:
+        request = json.loads(first)
+    except json.JSONDecodeError as error:
+        _send({'ok': False, 'error': f'bad init request: {error}'})
+        return 2
+
+    config = request.get('config') or {}
+    try:
+        entry = _load_entry(module_name, callable_name)
+        edge = _instantiate(entry, config)
+        interface = _interface(edge)
+    except Exception:
+        _send({'ok': False,
+               'error': f'failed to load entrypoint '
+                        f'{module_name}:{callable_name}: '
+                        f'{traceback.format_exc()}'})
+        return 1
+
+    _send({'ok': True, 'interface': interface})
+
+    # --- command loop ---------------------------------------------------
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            command = json.loads(line)
+        except json.JSONDecodeError as error:
+            _send({'ok': False, 'error': f'bad request: {error}'})
+            continue
+
+        cmd = command.get('cmd')
+        if cmd == 'end':
+            break
+        elif cmd == 'interface':
+            try:
+                _send({'ok': True, 'interface': _interface(edge)})
+            except Exception:
+                _send({'ok': False, 'error': traceback.format_exc()})
+        elif cmd == 'update':
+            try:
+                update = edge.update(
+                    command.get('state') or {},
+                    command.get('interval'))
+                _send({'ok': True, 'update': update})
+            except Exception:
+                _send({'ok': False, 'error': traceback.format_exc()})
+        else:
+            _send({'ok': False, 'error': f'unknown command: {cmd!r}'})
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/process_bigraph/protocols/git.py
+++ b/process_bigraph/protocols/git.py
@@ -1,0 +1,577 @@
+"""
+===============================================================
+The ``git:`` / remote protocol — resolve a repo address to an Edge
+===============================================================
+
+A ``git:`` address resolves a *repository* to a runnable process ``Edge``:
+
+    git:<owner>/<repo>@<ref>#<module>:<callable>
+
+e.g. ``git:CovertLab/vEcoli@main#vecoli.workflow:make_process``. ``@<ref>`` is
+optional (defaults to the repo's default branch); ``#<module>:<callable>`` is
+required and names the entrypoint the repo exposes.
+
+Resolution (spec §1):
+
+  1. **Fetch + pin** the repo at ``<ref>`` into a content-addressed cache and
+     record the resolved **commit SHA** — a moving ref re-resolves; a SHA is
+     frozen (the reproducibility unit).
+  2. **Materialize a venv** for that checkout (``uv venv`` + install the repo),
+     keyed by SHA. The foreign stack lives only in that venv.
+  3. **Expose ``<module>:<callable>``** as an ``Edge`` whose ``update()`` proxies
+     over a small stdio-RPC boundary to a subprocess running the entrypoint in
+     the repo's own venv (``_git_worker.py``). No foreign code is imported into
+     the host interpreter (D1(a) = subprocess + per-SHA venv).
+
+Trust (D2): a ``git:`` address whose ``owner/repo`` is not on the **allow-list**
+is refused, not run. The allow-list defaults to ``CovertLab/vEcoli`` and is
+supplied by the caller (``set_allow_list`` / ``add_allowed_repo``) — pbg stays
+workspace-agnostic and never reads ``workspace.yaml`` itself.
+
+Conformance (D5): :func:`check_conformance` verifies the resolved
+``interface()`` admits a declared face and *names* any mismatch. A run never
+starts against a non-conforming address (contract 2).
+"""
+
+from __future__ import annotations
+
+import os
+import io
+import re
+import json
+import time
+import shutil
+import hashlib
+import pathlib
+import subprocess
+from dataclasses import dataclass, field, asdict
+from typing import Any, Dict, Optional, Callable
+
+from bigraph_schema.schema import Protocol, String
+from bigraph_schema.methods import load_protocol
+
+from process_bigraph.composite import Process
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+class GitProtocolError(Exception):
+    """Any failure resolving or running a ``git:`` address. Raised as a clear
+    error (contract 3: a fetched-code failure degrades to an error, not a
+    host crash)."""
+
+
+class AllowListError(GitProtocolError):
+    """An ``owner/repo`` outside the allow-list was addressed (D2, contract 4)."""
+
+
+class ConformanceError(GitProtocolError):
+    """The resolved ``interface()`` does not admit the declared face
+    (D5, contract 2)."""
+
+
+# ---------------------------------------------------------------------------
+# Address grammar
+# ---------------------------------------------------------------------------
+_ADDRESS_RE = re.compile(
+    r'^(?P<owner>[^/@#]+)/(?P<repo>[^/@#]+)'
+    r'(?:@(?P<ref>[^#]+))?'
+    r'#(?P<module>[A-Za-z_][\w.]*):(?P<callable>[A-Za-z_][\w.]*)$'
+)
+
+# The default branch sentinel — resolved against the remote's HEAD when no
+# ``@ref`` is given.
+DEFAULT_REF = 'HEAD'
+
+
+@dataclass(frozen=True)
+class GitAddress:
+    """Parsed ``git:`` address. ``repo_slug`` is the allow-list key."""
+    owner: str
+    repo: str
+    ref: str
+    module: str
+    entry: str
+
+    @property
+    def repo_slug(self) -> str:
+        return f'{self.owner}/{self.repo}'
+
+    def __str__(self) -> str:
+        return (f'git:{self.owner}/{self.repo}@{self.ref}'
+                f'#{self.module}:{self.entry}')
+
+
+def parse_git_address(data: str) -> GitAddress:
+    """Parse the ``data`` half of a ``git:`` address (everything after
+    ``git:``) into a :class:`GitAddress`. ``normalize_address`` splits on the
+    first ``:`` only, so the ``module:callable`` colon survives inside
+    ``data``."""
+    if not isinstance(data, str):
+        raise GitProtocolError(f'git address must be a string, not {data!r}')
+    match = _ADDRESS_RE.match(data.strip())
+    if match is None:
+        raise GitProtocolError(
+            f'malformed git address {data!r}. Expected '
+            f'"<owner>/<repo>[@<ref>]#<module>:<callable>", e.g. '
+            f'"CovertLab/vEcoli@main#vecoli.workflow:make_process".')
+    groups = match.groupdict()
+    return GitAddress(
+        owner=groups['owner'],
+        repo=groups['repo'],
+        ref=groups['ref'] or DEFAULT_REF,
+        module=groups['module'],
+        entry=groups['callable'])
+
+
+# ---------------------------------------------------------------------------
+# Allow-list (D2) — caller-supplied, pbg stays workspace-agnostic
+# ---------------------------------------------------------------------------
+_DEFAULT_ALLOW_LIST = frozenset({'CovertLab/vEcoli'})
+_ALLOW_LIST: set = set(_DEFAULT_ALLOW_LIST)
+
+
+def set_allow_list(repos) -> None:
+    """Replace the allow-list. The caller (e.g. the workbench, reading
+    ``workspace.yaml``) supplies the set of ``owner/repo`` slugs it trusts."""
+    global _ALLOW_LIST
+    _ALLOW_LIST = set(repos)
+
+
+def add_allowed_repo(repo_slug: str) -> None:
+    """Add one ``owner/repo`` to the allow-list (an explicitly-trusted fork)."""
+    _ALLOW_LIST.add(repo_slug)
+
+
+def get_allow_list() -> set:
+    """Return a copy of the current allow-list."""
+    return set(_ALLOW_LIST)
+
+
+def reset_allow_list() -> None:
+    """Restore the default allow-list (``CovertLab/vEcoli``). For tests."""
+    global _ALLOW_LIST
+    _ALLOW_LIST = set(_DEFAULT_ALLOW_LIST)
+
+
+def check_allow_list(address: GitAddress) -> None:
+    if address.repo_slug not in _ALLOW_LIST:
+        raise AllowListError(
+            f'git address {address.repo_slug!r} is not on the allow-list '
+            f'{sorted(_ALLOW_LIST)!r}. Add it explicitly with '
+            f'add_allowed_repo({address.repo_slug!r}) — git: refuses to run '
+            f'code from un-allow-listed repositories.')
+
+
+# ---------------------------------------------------------------------------
+# Repo URL resolution — a hook so forks / private mirrors / test fixtures can
+# override the clone URL for an ``owner/repo`` (default: github.com).
+# ---------------------------------------------------------------------------
+_URL_OVERRIDES: Dict[str, str] = {}
+
+
+def set_repo_url(repo_slug: str, url: str) -> None:
+    """Point ``owner/repo`` at an explicit git URL (a fork, a local mirror, or
+    a ``file://`` fixture in tests). Does *not* implicitly allow-list it."""
+    _URL_OVERRIDES[repo_slug] = url
+
+
+def clear_repo_url(repo_slug: str) -> None:
+    _URL_OVERRIDES.pop(repo_slug, None)
+
+
+def repo_url(address: GitAddress) -> str:
+    override = _URL_OVERRIDES.get(address.repo_slug)
+    if override:
+        return override
+    return f'https://github.com/{address.owner}/{address.repo}'
+
+
+# ---------------------------------------------------------------------------
+# Cache / pin (D3)
+# ---------------------------------------------------------------------------
+def cache_root() -> pathlib.Path:
+    root = os.environ.get('PBG_GIT_CACHE') or os.path.join(
+        os.path.expanduser('~'), '.process_bigraph', 'git_cache')
+    path = pathlib.Path(root)
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _slug_dir(address: GitAddress) -> pathlib.Path:
+    return cache_root() / f'{address.owner}__{address.repo}'
+
+
+def _run_git(args, cwd=None) -> str:
+    result = subprocess.run(
+        ['git', *args],
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True)
+    if result.returncode != 0:
+        raise GitProtocolError(
+            f'git {" ".join(args)} failed (exit {result.returncode}): '
+            f'{result.stderr.strip()}')
+    return result.stdout
+
+
+def resolve_sha(address: GitAddress) -> str:
+    """Resolve ``address.ref`` to a concrete commit SHA against the remote,
+    without cloning (``git ls-remote``). A ref that is already a full 40-hex
+    SHA is returned as-is (frozen)."""
+    ref = address.ref
+    if re.fullmatch(r'[0-9a-f]{40}', ref or ''):
+        return ref
+
+    url = repo_url(address)
+    if ref == DEFAULT_REF:
+        out = _run_git(['ls-remote', '--symref', url, 'HEAD'])
+        for line in out.splitlines():
+            parts = line.split()
+            if len(parts) == 2 and parts[1] == 'HEAD':
+                return parts[0]
+        raise GitProtocolError(
+            f'could not resolve default branch (HEAD) of {url}')
+
+    out = _run_git(['ls-remote', url, ref])
+    lines = [ln for ln in out.splitlines() if ln.strip()]
+    if not lines:
+        # Might already be a short/long SHA the remote accepts on fetch.
+        if re.fullmatch(r'[0-9a-f]{7,40}', ref):
+            return ref
+        raise GitProtocolError(
+            f'ref {ref!r} not found in {url}')
+    # Prefer an exact refs/heads or refs/tags match; else first line.
+    for line in lines:
+        sha, name = line.split('\t', 1) if '\t' in line else line.split()
+        if name in (f'refs/heads/{ref}', f'refs/tags/{ref}', ref):
+            return sha
+    return lines[0].split()[0]
+
+
+@dataclass
+class Pin:
+    """A recorded resolution — the reproducibility unit (D3)."""
+    repo_slug: str
+    url: str
+    ref: str
+    sha: str
+    resolved_at: float
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def _sha_dir(address: GitAddress, sha: str) -> pathlib.Path:
+    return _slug_dir(address) / sha
+
+
+def read_pin(address: GitAddress, sha: str) -> Optional[Pin]:
+    pin_path = _sha_dir(address, sha) / 'pin.json'
+    if pin_path.exists():
+        return Pin(**json.loads(pin_path.read_text()))
+    return None
+
+
+def resolve_and_pin(address: GitAddress) -> Pin:
+    """Resolve ``ref`` -> SHA and record the pin under the cache. Records the
+    SHA; the run uses the recorded SHA (a later ref move re-resolves to a new
+    SHA and is surfaced, never silently re-run)."""
+    check_allow_list(address)
+    sha = resolve_sha(address)
+    sha_dir = _sha_dir(address, sha)
+    sha_dir.mkdir(parents=True, exist_ok=True)
+    pin = read_pin(address, sha)
+    if pin is None:
+        pin = Pin(
+            repo_slug=address.repo_slug,
+            url=repo_url(address),
+            ref=address.ref,
+            sha=sha,
+            resolved_at=time.time())
+        (sha_dir / 'pin.json').write_text(json.dumps(pin.to_dict(), indent=2))
+    return pin
+
+
+# ---------------------------------------------------------------------------
+# Materialization — checkout + per-SHA venv
+# ---------------------------------------------------------------------------
+@dataclass
+class Materialized:
+    address: GitAddress
+    pin: Pin
+    repo_dir: pathlib.Path
+    venv_python: pathlib.Path
+
+
+def _uv() -> str:
+    uv = shutil.which('uv')
+    if uv is None:
+        raise GitProtocolError(
+            'the git: protocol needs `uv` to materialize per-SHA venvs; '
+            'install it (https://docs.astral.sh/uv/) or add it to PATH.')
+    return uv
+
+
+def _checkout(address: GitAddress, pin: Pin, repo_dir: pathlib.Path) -> None:
+    if (repo_dir / '.git').exists():
+        return
+    repo_dir.parent.mkdir(parents=True, exist_ok=True)
+    # Full clone then checkout the pinned SHA — robust across servers that
+    # don't allow fetching arbitrary SHAs directly. Repos are cached per-SHA
+    # so this is paid once.
+    _run_git(['clone', '--quiet', pin.url, str(repo_dir)])
+    _run_git(['checkout', '--quiet', pin.sha], cwd=str(repo_dir))
+
+
+def _build_venv(repo_dir: pathlib.Path, venv_dir: pathlib.Path) -> pathlib.Path:
+    """``uv venv`` + install the repo into it. Returns the venv python path."""
+    python = venv_dir / 'bin' / 'python'
+    stamp = venv_dir / '.pbg-installed'
+    if stamp.exists() and python.exists():
+        return python
+
+    uv = _uv()
+    if not python.exists():
+        subprocess.run([uv, 'venv', '--quiet', str(venv_dir)],
+                       check=True,
+                       stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    # Install the repo into its venv. ``uv pip install .`` builds the repo's
+    # own dependency closure inside the venv — never touching the host env.
+    result = subprocess.run(
+        [uv, 'pip', 'install', '--python', str(python), '--quiet', '.'],
+        cwd=str(repo_dir),
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    if result.returncode != 0:
+        raise GitProtocolError(
+            f'failed to install repo into venv (uv pip install .): '
+            f'{result.stderr.strip()}')
+    stamp.write_text('ok')
+    return python
+
+
+def materialize(address: GitAddress) -> Materialized:
+    """Full resolve -> pin -> checkout -> venv path. Cheap on a warm cache."""
+    pin = resolve_and_pin(address)
+    sha_dir = _sha_dir(address, pin.sha)
+    repo_dir = sha_dir / 'repo'
+    venv_dir = sha_dir / 'venv'
+    _checkout(address, pin, repo_dir)
+    venv_python = _build_venv(repo_dir, venv_dir)
+    return Materialized(
+        address=address,
+        pin=pin,
+        repo_dir=repo_dir,
+        venv_python=venv_python)
+
+
+# ---------------------------------------------------------------------------
+# The remote edge — a thin stdio-RPC proxy over the venv subprocess
+# ---------------------------------------------------------------------------
+_WORKER_PATH = str(pathlib.Path(__file__).with_name('_git_worker.py'))
+
+
+class GitRemoteProcess(Process):
+    """A ``Process`` whose ``update()`` proxies over stdio to a subprocess
+    running the repo's entrypoint in the repo's *own* venv.
+
+    Bound per-address by :func:`load_protocol` (subclasses carry the
+    materialization as class attributes, mirroring the ray protocol)."""
+
+    # Populated on the per-address bound subclass.
+    _materialized: Optional[Materialized] = None
+
+    config_schema: Any = {}
+
+    def initialize(self, config):
+        mat = self._materialized
+        if mat is None:
+            raise GitProtocolError(
+                'GitRemoteProcess used without a bound address; go through '
+                'the git: protocol (load_protocol).')
+        self._ended = False
+        self._proc = subprocess.Popen(
+            [str(mat.venv_python), _WORKER_PATH, mat.address.module,
+             mat.address.entry],
+            cwd=str(mat.repo_dir),
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1)
+        # Init handshake — send config, receive the interface.
+        reply = self._rpc({'cmd': 'init', 'config': config or {}})
+        interface = reply.get('interface') or {}
+        self._interface_inputs = dict(interface.get('inputs') or {})
+        self._interface_outputs = dict(interface.get('outputs') or {})
+
+    # -- RPC ---------------------------------------------------------------
+    def _rpc(self, request: dict) -> dict:
+        proc = self._proc
+        if proc is None or proc.poll() is not None:
+            raise GitProtocolError(
+                f'git: worker for {self._materialized.address} is not running '
+                f'(exited {proc.returncode if proc else "n/a"}).')
+        try:
+            proc.stdin.write(json.dumps(request) + '\n')
+            proc.stdin.flush()
+            line = proc.stdout.readline()
+        except (BrokenPipeError, OSError) as error:
+            raise GitProtocolError(
+                f'git: worker communication failed: {error}') from error
+        if not line:
+            stderr = proc.stderr.read() if proc.stderr else ''
+            raise GitProtocolError(
+                f'git: worker for {self._materialized.address} closed the '
+                f'connection unexpectedly. stderr:\n{stderr.strip()}')
+        reply = json.loads(line)
+        if not reply.get('ok', False):
+            raise GitProtocolError(
+                f'git: worker error for {self._materialized.address}:\n'
+                f'{reply.get("error", "unknown error")}')
+        return reply
+
+    # -- Edge interface ----------------------------------------------------
+    def inputs(self):
+        return self._interface_inputs
+
+    def outputs(self):
+        return self._interface_outputs
+
+    def update(self, state, interval):
+        reply = self._rpc({
+            'cmd': 'update',
+            'state': state,
+            'interval': interval})
+        return reply.get('update') or {}
+
+    def end(self):
+        if getattr(self, '_ended', True):
+            return
+        self._ended = True
+        proc = self._proc
+        if proc is None:
+            return
+        try:
+            if proc.poll() is None:
+                proc.stdin.write(json.dumps({'cmd': 'end'}) + '\n')
+                proc.stdin.flush()
+                proc.wait(timeout=5)
+        except Exception:
+            pass
+        finally:
+            if proc.poll() is None:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=5)
+                except Exception:
+                    proc.kill()
+
+    def __del__(self):
+        try:
+            self.end()
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Conformance (D5, contract 2)
+# ---------------------------------------------------------------------------
+def _face_of(edge_or_interface) -> Dict[str, dict]:
+    if isinstance(edge_or_interface, dict) and (
+            'inputs' in edge_or_interface or 'outputs' in edge_or_interface):
+        return {
+            'inputs': dict(edge_or_interface.get('inputs') or {}),
+            'outputs': dict(edge_or_interface.get('outputs') or {}),
+        }
+    interface = getattr(edge_or_interface, 'interface', None)
+    if callable(interface):
+        face = interface() or {}
+        return {
+            'inputs': dict(face.get('inputs') or {}),
+            'outputs': dict(face.get('outputs') or {}),
+        }
+    raise ConformanceError(
+        f'cannot read a face from {edge_or_interface!r}')
+
+
+def conforms(core, resolved, declared_face) -> tuple:
+    """Return ``(ok, reason)``: does ``resolved`` (an edge or an interface
+    dict) admit every port ``declared_face`` requires, at a resolvable type?
+    Over-providing is fine; under-providing / a type mismatch is not."""
+    provided = _face_of(resolved)
+    required = _face_of(declared_face)
+    for direction in ('inputs', 'outputs'):
+        need = required.get(direction) or {}
+        have = provided.get(direction) or {}
+        for port, port_schema in need.items():
+            if port not in have:
+                return False, (
+                    f'{direction[:-1]} port {port!r} required by the declared '
+                    f'face is missing from the resolved interface '
+                    f'(has {sorted(have)})')
+            if core is not None:
+                try:
+                    core.resolve(port_schema, have[port])
+                except Exception as error:
+                    return False, (
+                        f'{direction[:-1]} port {port!r} does not resolve: '
+                        f'declared {port_schema!r} vs resolved '
+                        f'{have[port]!r} ({error})')
+            elif port_schema != have[port]:
+                return False, (
+                    f'{direction[:-1]} port {port!r} type mismatch: declared '
+                    f'{port_schema!r} vs resolved {have[port]!r}')
+    return True, None
+
+
+def check_conformance(core, resolved, declared_face) -> None:
+    """Raise :class:`ConformanceError` naming the mismatch if ``resolved`` does
+    not admit ``declared_face``. The authoritative pre-run check (D5) — a run
+    never starts against a non-conforming address."""
+    ok, reason = conforms(core, resolved, declared_face)
+    if not ok:
+        raise ConformanceError(f'address does not conform to declared face: {reason}')
+
+
+# ---------------------------------------------------------------------------
+# Protocol type + dispatch
+# ---------------------------------------------------------------------------
+@dataclass(kw_only=True)
+class GitProtocol(Protocol):
+    data: String = field(default_factory=String)
+
+
+def _bind_class(mat: Materialized):
+    """Build a GitRemoteProcess subclass bound to one materialized address
+    (mirrors the ray protocol's per-address shadow subclass)."""
+    return type(
+        f'GitRemote_{mat.address.owner}_{mat.address.repo}',
+        (GitRemoteProcess,),
+        {'_materialized': mat, '__module__': __name__})
+
+
+@load_protocol.dispatch
+def load_protocol(core, protocol: GitProtocol, data):
+    address = parse_git_address(data)
+    check_allow_list(address)
+    mat = materialize(address)
+    bound = _bind_class(mat)
+
+    def instantiate(config, core=None):
+        return bound(config, core)
+
+    instantiate.config_schema = bound.config_schema
+    # Expose the resolution so callers/tests can record the SHA and do
+    # conformance checks (D5) before a run.
+    instantiate.materialized = mat
+    instantiate.address = address
+    instantiate.pin = mat.pin
+    return instantiate
+
+
+def register_types(core):
+    core.register_types({'git': GitProtocol})
+    return core

--- a/process_bigraph/tests/test_git_protocol.py
+++ b/process_bigraph/tests/test_git_protocol.py
@@ -1,0 +1,331 @@
+"""
+End-to-end tests for the ``git:`` / remote protocol.
+
+These drive the full path against a **lightweight local fixture repo** (a real
+git repo with a trivial ``module:callable`` returning a minimal, dependency-free
+process). vEcoli's scientific stack is deliberately never pulled in — the
+fixture proves the machinery (allow-list, resolve/pin/SHA, per-SHA venv
+materialization, stdio-RPC edge, conformance) without the weight.
+"""
+
+import os
+import json
+import shutil
+import textwrap
+import subprocess
+
+import pytest
+
+from process_bigraph import allocate_core
+from process_bigraph.protocols import git as gitproto
+from process_bigraph.protocols.git import (
+    GitAddress,
+    GitProtocolError,
+    AllowListError,
+    ConformanceError,
+    parse_git_address,
+    check_conformance,
+    conforms,
+)
+
+
+FIXTURE_MODULE = textwrap.dedent('''
+    """A dependency-free fixture process for the git: protocol tests."""
+
+
+    class IncrementProcess:
+        def __init__(self, config=None):
+            self.rate = float((config or {}).get("rate", 1.0))
+
+        def inputs(self):
+            return {"value": "float"}
+
+        def outputs(self):
+            return {"value": "float"}
+
+        def interface(self):
+            return {"inputs": self.inputs(), "outputs": self.outputs()}
+
+        def update(self, state, interval):
+            return {"value": self.rate * float(interval or 1.0)}
+
+
+    class MismatchProcess(IncrementProcess):
+        # Exposes a different face — used to prove conformance rejection.
+        def inputs(self):
+            return {"temperature": "float"}
+
+        def outputs(self):
+            return {"temperature": "float"}
+
+
+    def make_process(config=None):
+        return IncrementProcess(config)
+
+
+    def make_mismatch(config=None):
+        return MismatchProcess(config)
+''')
+
+FIXTURE_PYPROJECT = textwrap.dedent('''
+    [build-system]
+    requires = ["setuptools>=61"]
+    build-backend = "setuptools.build_meta"
+
+    [project]
+    name = "pbgfixture"
+    version = "0.0.1"
+
+    [tool.setuptools]
+    py-modules = ["pbgfixture"]
+''')
+
+SLUG = 'pbgtest/fixture'
+
+
+def _git(args, cwd):
+    subprocess.run(
+        ['git', *args], cwd=cwd, check=True,
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+@pytest.fixture(scope='session')
+def fixture_repo(tmp_path_factory):
+    """Create a real local git repo exposing ``pbgfixture:make_process``.
+    Returns ``(url, default_branch, sha)``."""
+    repo = tmp_path_factory.mktemp('pbgfixture-repo')
+    (repo / 'pbgfixture.py').write_text(FIXTURE_MODULE)
+    (repo / 'pyproject.toml').write_text(FIXTURE_PYPROJECT)
+    _git(['init', '--quiet'], repo)
+    _git(['config', 'user.email', 'test@example.com'], repo)
+    _git(['config', 'user.name', 'pbg test'], repo)
+    _git(['add', '.'], repo)
+    _git(['commit', '--quiet', '-m', 'fixture'], repo)
+    branch = subprocess.run(
+        ['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
+        cwd=repo, check=True, text=True,
+        stdout=subprocess.PIPE).stdout.strip()
+    sha = subprocess.run(
+        ['git', 'rev-parse', 'HEAD'],
+        cwd=repo, check=True, text=True,
+        stdout=subprocess.PIPE).stdout.strip()
+    return f'file://{repo}', branch, sha
+
+
+@pytest.fixture
+def clean_registry():
+    """Isolate allow-list / url-override / cache state per test."""
+    gitproto.reset_allow_list()
+    yield
+    gitproto.reset_allow_list()
+    gitproto.clear_repo_url(SLUG)
+
+
+@pytest.fixture
+def cache_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv('PBG_GIT_CACHE', str(tmp_path / 'git_cache'))
+    return tmp_path / 'git_cache'
+
+
+# ---------------------------------------------------------------------------
+# Address parsing
+# ---------------------------------------------------------------------------
+def test_parse_full_address():
+    addr = parse_git_address('CovertLab/vEcoli@main#vecoli.workflow:make_process')
+    assert addr == GitAddress(
+        owner='CovertLab', repo='vEcoli', ref='main',
+        module='vecoli.workflow', entry='make_process')
+    assert addr.repo_slug == 'CovertLab/vEcoli'
+
+
+def test_parse_default_ref():
+    addr = parse_git_address('CovertLab/vEcoli#vecoli.workflow:make_process')
+    assert addr.ref == 'HEAD'
+
+
+def test_parse_rejects_missing_entry():
+    with pytest.raises(GitProtocolError):
+        parse_git_address('CovertLab/vEcoli@main')
+
+
+def test_parse_rejects_garbage():
+    with pytest.raises(GitProtocolError):
+        parse_git_address('not-an-address')
+
+
+# ---------------------------------------------------------------------------
+# Allow-list (contract 4, D2)
+# ---------------------------------------------------------------------------
+def test_default_allow_list_has_vecoli(clean_registry):
+    assert 'CovertLab/vEcoli' in gitproto.get_allow_list()
+
+
+def test_un_allow_listed_address_is_refused(clean_registry, cache_dir):
+    core = allocate_core()
+    protocol = core.access('git')
+    with pytest.raises(AllowListError) as excinfo:
+        gitproto.load_protocol(
+            core, protocol, 'pbgtest/fixture#pbgfixture:make_process')
+    assert 'allow-list' in str(excinfo.value)
+
+
+def test_add_allowed_repo_permits(clean_registry):
+    gitproto.add_allowed_repo(SLUG)
+    assert SLUG in gitproto.get_allow_list()
+
+
+# ---------------------------------------------------------------------------
+# Resolve + pin + SHA record (contract 1, D3)
+# ---------------------------------------------------------------------------
+def test_resolve_and_pin_records_sha(clean_registry, cache_dir, fixture_repo):
+    url, branch, sha = fixture_repo
+    gitproto.add_allowed_repo(SLUG)
+    gitproto.set_repo_url(SLUG, url)
+
+    addr = parse_git_address(f'{SLUG}@{branch}#pbgfixture:make_process')
+    pin = gitproto.resolve_and_pin(addr)
+
+    assert pin.sha == sha
+    assert pin.repo_slug == SLUG
+    # Pin persisted to disk under the content-addressed cache.
+    pin_file = cache_dir / 'pbgtest__fixture' / sha / 'pin.json'
+    assert pin_file.exists()
+    on_disk = json.loads(pin_file.read_text())
+    assert on_disk['sha'] == sha
+
+
+def test_resolve_default_ref(clean_registry, cache_dir, fixture_repo):
+    url, branch, sha = fixture_repo
+    gitproto.add_allowed_repo(SLUG)
+    gitproto.set_repo_url(SLUG, url)
+    # No @ref -> resolves the remote's default branch (HEAD).
+    addr = parse_git_address(f'{SLUG}#pbgfixture:make_process')
+    pin = gitproto.resolve_and_pin(addr)
+    assert pin.sha == sha
+
+
+def test_resolve_refuses_un_allow_listed(clean_registry, cache_dir, fixture_repo):
+    url, branch, _ = fixture_repo
+    gitproto.set_repo_url(SLUG, url)  # url set, but NOT allow-listed
+    addr = parse_git_address(f'{SLUG}@{branch}#pbgfixture:make_process')
+    with pytest.raises(AllowListError):
+        gitproto.resolve_and_pin(addr)
+
+
+# ---------------------------------------------------------------------------
+# Full materialization + RPC edge (contracts 1 + 3, D1)
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def resolved_edge_factory(clean_registry, cache_dir, fixture_repo):
+    """Materialize the fixture once; hand tests a factory that instantiates
+    a bound GitRemoteProcess for a given entrypoint + config."""
+    url, branch, sha = fixture_repo
+    gitproto.add_allowed_repo(SLUG)
+    gitproto.set_repo_url(SLUG, url)
+    core = allocate_core()
+    protocol = core.access('git')
+
+    made = []
+
+    def factory(entry='make_process', config=None):
+        instantiate = gitproto.load_protocol(
+            core, protocol, f'{SLUG}@{branch}#pbgfixture:{entry}')
+        edge = instantiate(config or {}, core)
+        made.append(edge)
+        return instantiate, edge
+
+    yield core, sha, factory
+
+    for edge in made:
+        try:
+            edge.end()
+        except Exception:
+            pass
+
+
+def test_materialize_builds_venv_and_records_sha(resolved_edge_factory, cache_dir):
+    core, sha, factory = resolved_edge_factory
+    instantiate, edge = factory()
+    # SHA recorded on the resolution (reproducibility unit).
+    assert instantiate.pin.sha == sha
+    # The per-SHA venv actually exists on disk with a python.
+    venv_python = cache_dir / 'pbgtest__fixture' / sha / 'venv' / 'bin' / 'python'
+    assert venv_python.exists()
+    repo_dir = cache_dir / 'pbgtest__fixture' / sha / 'repo'
+    assert (repo_dir / 'pbgfixture.py').exists()
+
+
+def test_rpc_edge_interface(resolved_edge_factory):
+    core, sha, factory = resolved_edge_factory
+    _, edge = factory()
+    assert edge.inputs() == {'value': 'float'}
+    assert edge.outputs() == {'value': 'float'}
+    assert edge.interface() == {
+        'inputs': {'value': 'float'},
+        'outputs': {'value': 'float'}}
+
+
+def test_rpc_edge_update(resolved_edge_factory):
+    core, sha, factory = resolved_edge_factory
+    _, edge = factory(config={'rate': 2.5})
+    result = edge.update({'value': 0.0}, 4.0)
+    assert result == {'value': 10.0}
+    # Second call reuses the live subprocess.
+    result2 = edge.update({'value': 0.0}, 2.0)
+    assert result2 == {'value': 5.0}
+
+
+def test_bad_entrypoint_degrades_to_clear_error(resolved_edge_factory):
+    core, sha, factory = resolved_edge_factory
+    with pytest.raises(GitProtocolError) as excinfo:
+        factory(entry='does_not_exist')
+    assert 'does_not_exist' in str(excinfo.value)
+
+
+def test_isolation_worker_runs_in_repo_venv(resolved_edge_factory, cache_dir):
+    """The foreign code runs in the per-SHA venv python, never the host."""
+    core, sha, factory = resolved_edge_factory
+    _, edge = factory()
+    venv_python = cache_dir / 'pbgtest__fixture' / sha / 'venv' / 'bin' / 'python'
+    assert str(edge._proc.args[0]) == str(venv_python)
+
+
+# ---------------------------------------------------------------------------
+# Conformance (contract 2, D5)
+# ---------------------------------------------------------------------------
+def test_conformance_pass(resolved_edge_factory):
+    core, sha, factory = resolved_edge_factory
+    _, edge = factory()
+    declared = {'inputs': {'value': 'float'}, 'outputs': {'value': 'float'}}
+    # Should not raise.
+    check_conformance(core, edge, declared)
+    ok, reason = conforms(core, edge, declared)
+    assert ok and reason is None
+
+
+def test_conformance_over_provide_ok(resolved_edge_factory):
+    core, sha, factory = resolved_edge_factory
+    _, edge = factory()
+    # Declared face requires only outputs.value — under-declaring is fine.
+    declared = {'outputs': {'value': 'float'}}
+    check_conformance(core, edge, declared)
+
+
+def test_conformance_missing_port_rejected(resolved_edge_factory):
+    core, sha, factory = resolved_edge_factory
+    # The mismatch entry provides temperature, not value.
+    _, edge = factory(entry='make_mismatch')
+    declared = {'inputs': {'value': 'float'}, 'outputs': {'value': 'float'}}
+    with pytest.raises(ConformanceError) as excinfo:
+        check_conformance(core, edge, declared)
+    msg = str(excinfo.value)
+    assert "'value'" in msg and 'missing' in msg
+
+
+def test_conformance_names_mismatch_direction(resolved_edge_factory):
+    core, sha, factory = resolved_edge_factory
+    _, edge = factory(entry='make_mismatch')
+    declared = {'inputs': {'value': 'float'}}
+    ok, reason = conforms(core, edge, declared)
+    assert not ok
+    assert 'input port' in reason and "'value'" in reason


### PR DESCRIPTION
## What

Implements the `git:` / remote protocol (spec `docs/superpowers/specs/2026-07-31-git-remote-protocol-design.md`), a new `Protocol` alongside `local:`/`ray:`/`rest:`/`parallel:`. A repo address resolves to a runnable process `Edge`:

```
git:<owner>/<repo>@<ref>#<module>:<callable>
# e.g. git:CovertLab/vEcoli@main#vecoli.workflow:make_process
```

This is the capability behind "compare against a different implementation" (companion study-templates spec §5.1).

## How it works (resolved decisions)

- **Parse + allow-list (D2)** — an `owner/repo` not on the allow-list is refused, not run. The allow-list defaults to `CovertLab/vEcoli` and is **caller-supplied** (`set_allow_list` / `add_allowed_repo`) so process-bigraph stays workspace-agnostic and never reads `workspace.yaml` itself. Forks/mirrors/test fixtures point their clone URL via `set_repo_url`.
- **Resolve + pin (D3)** — `ref` → commit SHA via `git ls-remote`, recorded to a content-addressed cache (`<cache>/<owner>__<repo>/<sha>/pin.json`). The recorded SHA is the reproducibility unit; a moving ref re-resolves to a new SHA rather than silently re-running.
- **Materialize (D1 = a)** — `git checkout` at the SHA + a per-SHA `uv venv` with the repo installed (`uv pip install .`). The foreign scientific stack lives only in that venv.
- **RPC edge** — `GitRemoteProcess.update()` proxies over newline-delimited-JSON stdio to `_git_worker.py` (stdlib-only) running the entrypoint in the repo's **own** venv python. No foreign code is imported into the host interpreter; a fetched-code failure degrades to a clear `GitProtocolError`, not a host crash (contract 3).
- **Entrypoint (D4 = a)** — the `#<module>:<callable>` fragment names the callable; no repo-side manifest convention required.
- **Conformance (D5)** — `check_conformance()` rejects a resolved `interface()` that does not admit the declared face, naming the mismatched port (contract 2). Available as the authoritative pre-run check; the same function serves the cheap declared-face check at fill.

## New API

- `process_bigraph/protocols/git.py` — `GitProtocol`, `parse_git_address`, `GitAddress`, allow-list (`set_allow_list`/`add_allowed_repo`/`get_allow_list`/`reset_allow_list`), URL override (`set_repo_url`), `resolve_and_pin`/`Pin`, `materialize`/`Materialized`, `GitRemoteProcess`, `conforms`/`check_conformance`, errors (`GitProtocolError`/`AllowListError`/`ConformanceError`), `load_protocol` dispatch + `register_types`.
- `process_bigraph/protocols/_git_worker.py` — standalone stdlib-only stdio worker (runs inside the fetched repo's venv).
- Registered in `process_bigraph/protocols/__init__.py` `PROCESS_PROTOCOLS`.

## Tests

19 new tests in `test_git_protocol.py` drive the full path against a **lightweight local fixture repo** (a real git repo exposing a dependency-free `pbgfixture:make_process`; vEcoli's stack is never pulled in): parsing, allow-list refusal, resolve+pin+SHA record, default-ref resolution, per-SHA venv materialization, stdio-RPC `update()`, worker-in-venv isolation, bad-entrypoint error, conformance pass + non-conforming rejection. Full suite green (43 passed locally, excluding a pre-existing `server/rest.py` collection gap that needs the `fastapi-utils` optional dep CI installs).

## Scope

Stays inside process-bigraph. The v2ecoli-side vEcoli `#`-entry adapter and SHA-recording in comparison artifacts (spec §4 steps 3–4) are separate follow-ups in other repos. Out of scope v1: container isolation, sandboxing beyond venv/subprocess, cache GC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)