### PR TITLE
fix: ask an emitter for results(), not finalize() — and make a handle idempotent

### DIFF
--- a/process_bigraph/composite.py
+++ b/process_bigraph/composite.py
@@ -2829,19 +2829,29 @@ class Composite(Process):
 
         for path, step in self.step_paths.items():
             instance = step.get('instance') if isinstance(step, dict) else None
-            produce = getattr(instance, 'finalize', None)
-            if not callable(produce):
-                continue
 
-            try:
-                update = produce(path=path) or {}
-            except TypeError:
-                update = produce() or {}
-            if not update:
-                continue
+            # Prefer `results()` — the handle contract itself. `finalize` is a
+            # name durable emitters already used for "flush buffers and close"
+            # (the vivarium lineage: `BufferedEmitter.finalize(*, success)`
+            # returns None and may only be called once). Calling that here
+            # silently produced no handle *and* consumed the buffer close, so
+            # a composite with a zarr/parquet sink finalized to nothing.
+            produce_handle = getattr(instance, 'results', None)
+            if callable(produce_handle):
+                handles[path] = produce_handle(path=path)
+            else:
+                produce = getattr(instance, 'finalize', None)
+                if not callable(produce):
+                    continue
+                try:
+                    update = produce(path=path) or {}
+                except TypeError:
+                    update = produce() or {}
+                if not update:
+                    continue
+                handles[path] = update.get('results')
 
-            handle = update.get('results')
-            handles[path] = handle
+            handle = handles[path]
 
             wire = (step.get('outputs') or {}).get('results')
             if not wire:

--- a/process_bigraph/emitter.py
+++ b/process_bigraph/emitter.py
@@ -224,13 +224,14 @@ class EmitterResults:
     reaching for the imperative ``gather_emitter_results`` pull.
     """
 
-    __slots__ = ('emitter', 'address', 'path', 'context')
+    __slots__ = ('emitter', 'address', 'path', 'context', '_resolved')
 
     def __init__(self, emitter, address=None, path=None, context=None):
         self.emitter = emitter
         self.address = address
         self.path = tuple(path) if path else ()
         self.context = context or {}
+        self._resolved = {}
 
     @property
     def count(self):
@@ -240,8 +241,19 @@ class EmitterResults:
 
     def resolve(self, paths=None):
         """Pull the accumulated data. The handle stays a reference; this is
-        the only place the bulk is materialized."""
-        return self.emitter.query(paths)
+        the only place the bulk is materialized.
+
+        Memoized per ``paths``: a handle refers to a run that has *completed*,
+        so resolving it twice must give the same answer. It also must not cost
+        twice — several flush entities resolve the same handle, and a durable
+        emitter's ``query()`` can be far from free (``XArrayEmitter`` re-reads
+        its zarr store, and flushes buffered rows on the way, which without
+        this appends them again on every read).
+        """
+        key = tuple(paths) if isinstance(paths, list) else paths
+        if key not in self._resolved:
+            self._resolved[key] = self.emitter.query(paths)
+        return self._resolved[key]
 
     def to_dict(self):
         """A JSON-safe summary — the reference, never the data."""

--- a/tests.py
+++ b/tests.py
@@ -4724,3 +4724,40 @@ def test_finalize_survives_an_emitter_that_redefines_finalize():
 
     # the emitter's own finalize was left alone — not consumed for a handle
     assert closed == []
+
+
+def test_resolving_a_handle_twice_is_idempotent_and_cheap():
+    """A handle refers to a run that has completed, so resolving twice must
+    give the same answer — and must not pay twice. Several flush entities
+    resolve the same handle, and a durable emitter's `query()` can be
+    expensive *and* side-effecting (`XArrayEmitter` flushes buffered rows on
+    read, which without memoization appends them again every time)."""
+    core = allocate_core()
+    calls = []
+
+    class CountingEmitter(RAMEmitter):
+        def query(self, paths=None, schema=None, query=None):
+            calls.append(paths)
+            return super().query(paths, schema, query)
+
+    core.register_link('CountingEmitter', CountingEmitter)
+    doc = {
+        'level': 1.0,
+        'model': {
+            '_type': 'process', 'address': 'local:IncreaseProcess',
+            'config': {'rate': 0.5}, 'interval': 1.0,
+            'inputs': {'level': ['level']}, 'outputs': {'level': ['level']}},
+        'emitter': {
+            '_type': 'step', 'address': 'local:CountingEmitter',
+            'config': {'emit': {'level': 'node', 'global_time': 'node'}},
+            'inputs': {'level': ['level'], 'global_time': ['global_time']}}}
+
+    sim = Composite({'state': doc}, core=core)
+    sim.run(3.0)
+    handle = sim.finalize()[('emitter',)]
+
+    first = handle.resolve()
+    second = handle.resolve()
+
+    assert first == second
+    assert len(calls) == 1, f'query() called {len(calls)} times'

--- a/tests.py
+++ b/tests.py
@@ -4674,3 +4674,53 @@ def test_the_harness_gates_a_downstream_member():
 
     assert run(0.5) == ('agree', [], ['downstream'])
     assert run(0.9) == ('diverge', ['investigation/downstream'], [])
+
+
+def test_finalize_survives_an_emitter_that_redefines_finalize():
+    """A durable emitter already uses `finalize` for something else.
+
+    The vivarium lineage (`pbg_emitters.BufferedEmitter`) defines
+    `finalize(*, success: bool) -> None`: it flushes buffers, closes the
+    store, and raises if called twice. Asking *that* for a results handle
+    silently produced none — and consumed the buffer close on the way — so a
+    composite writing zarr or parquet finalized to nothing. `results()` is
+    the handle contract and no emitter overrides it.
+    """
+    core = allocate_core()
+    closed = []
+
+    class BufferedRAMEmitter(RAMEmitter):
+        """Stands in for a durable emitter with the legacy finalize."""
+
+        def finalize(self, *, success: bool = False):
+            if closed:
+                raise RuntimeError('finalize() was already called')
+            closed.append(success)
+            return None
+
+    core.register_link('BufferedRAMEmitter', BufferedRAMEmitter)
+
+    doc = {
+        'level': 1.0, 'results': {},
+        'model': {
+            '_type': 'process', 'address': 'local:IncreaseProcess',
+            'config': {'rate': 0.5}, 'interval': 1.0,
+            'inputs': {'level': ['level']}, 'outputs': {'level': ['level']}},
+        'emitter': {
+            '_type': 'step', 'address': 'local:BufferedRAMEmitter',
+            'config': {'emit': {'level': 'node', 'global_time': 'node'}},
+            'inputs': {'level': ['level'], 'global_time': ['global_time']},
+            'outputs': {'results': ['results']}}}
+
+    sim = Composite({'state': doc}, core=core)
+    sim.run(3.0)
+
+    handles = sim.finalize()
+
+    handle = handles[('emitter',)]
+    assert isinstance(handle, EmitterResults)
+    assert len(handle.resolve()) > 1
+    assert isinstance(sim.state['results'], EmitterResults)
+
+    # the emitter's own finalize was left alone — not consumed for a handle
+    assert closed == []


### PR DESCRIPTION
Two defects found wiring a **real** v2ecoli study to `XArrayEmitter` — the durable case the `results` port exists for, and the case that didn't work.

## 1. `finalize()` was already taken

`Composite.finalize()` asked each emitter for its handle by calling `finalize()`. But durable emitters already use that name for something else — `pbg_emitters.BufferedEmitter` (vivarium lineage) defines:

```python
def finalize(self, *, success: bool = False) -> None:   # flush buffer, close store, raise if called twice
```

So on any composite writing zarr or parquet: `finalize(path=...)` raised `TypeError` on the unexpected keyword, the fallback called `finalize()`, which **closed the store with `success=False` and returned `None`**. Result: no handle, silently — and the emitter's own close consumed, so a later legitimate `finalize(success=True)` would raise.

`results()` is the handle contract and no emitter overrides it, so `Composite.finalize()` now prefers it, falling back to `finalize()` only for a non-emitter edge opting into the completion hook.

## 2. Resolving a handle twice corrupted the store

`XArrayEmitter.query()` calls `flush(final=False)` on every read. With several flush entities resolving the same handle, each resolve re-wrote the buffer:

```
resolve #1: 6 rows
resolve #2: 9 rows      # +buffer_size
resolve #3: 12 rows
```

A handle refers to a run that has **completed**, so resolving it must be idempotent — and must not pay twice, since a durable emitter's `query()` re-reads its store. `EmitterResults.resolve()` is now memoized per `paths`.

This mitigates but does not fix the underlying pbg-emitters defect (`query()` mutating the store on read, and asserting the buffer is exactly full). That is filed separately for that repo.

## Tests

2 added (194 → 196, 0 failures):

- a `BufferedEmitter`-shaped emitter with the legacy `finalize(*, success)` still yields a resolvable handle, and its own finalize is left untouched;
- resolving a handle twice returns the same object and calls `query()` exactly once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)