### PR TITLE
feat: partial graph triggering — a cached study result is a filled results site

### DIFF
--- a/process_bigraph/artifacts.py
+++ b/process_bigraph/artifacts.py
@@ -1,0 +1,285 @@
+"""Content-addressed study artifacts.
+
+A study node produces an **artifact**, and some artifacts are trajectories.
+That is the generalization ``sim_data`` forces: a simulation's ``results`` is a
+zarr trajectory, but a calibration object is not a trajectory at all, and both
+are things a downstream study consumes through the same ``results`` port.
+
+Three pieces:
+
+- the **content address** — ported verbatim from the workbench's artifact store
+  so both sides agree on where an artifact lives (see the lock-step note);
+- :class:`ArtifactRef` — a typed reference: *what kind*, *which address*,
+  *where on disk*;
+- :class:`ArtifactResults` — the resolved handle a ``results`` site carries,
+  dispatching ``resolve()`` on kind. ``EmitterResults`` is the ``trajectory``
+  case and keeps its own API.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+# ── content address ─────────────────────────────────────────────────
+#
+# LOCK-STEP: this is a hand-port of
+# ``vivarium_workbench/lib/artifacts/hashing.py``. process-bigraph cannot
+# import the workbench (the dependency runs the other way), so the formula is
+# duplicated deliberately — the same two-writers/one-store arrangement the
+# reproducible-rerun spine already has. **Any change to either copy must be
+# made to both**, or the workbench pipeline and the engine will disagree about
+# where an artifact lives and every cache lookup will silently miss.
+
+ARTIFACT_ROOT = '.pbg/artifacts'
+"""Store convention: an artifact lives under ``.pbg/artifacts/<hash>/``."""
+
+
+def _stable(o):
+    if isinstance(o, float) and o.is_integer():
+        return int(o)
+    raise TypeError(type(o))
+
+
+def canonical(config: dict) -> str:
+    """The canonical JSON encoding a content address is computed over."""
+    return json.dumps(
+        config or {}, sort_keys=True, separators=(",", ":"), default=_stable)
+
+
+def artifact_id(*, composite_id: str, config: dict,
+                input_ids: list, commit: str) -> str:
+    """The content address of an artifact.
+
+    A function of *what produced it* and *what went into it* — never of a
+    filesystem path, so two worktrees at the same commit resolve the same
+    address and share a cache with no symlink between them.
+    """
+    payload = "\n".join([composite_id, canonical(config),
+                         "\n".join(sorted(input_ids or [])), commit or ""])
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+
+
+def artifact_store(address: str, root: str = ARTIFACT_ROOT) -> str:
+    """Where the artifact at ``address`` lives."""
+    return os.path.join(root, address)
+
+
+def artifact_exists(address: str, root: str = ARTIFACT_ROOT) -> bool:
+    """Is this artifact already in the store?"""
+    return os.path.isdir(artifact_store(address, root))
+
+
+# ── typed references ────────────────────────────────────────────────
+
+TRAJECTORY = 'trajectory'
+SIM_DATA = 'sim_data'
+FIGURES = 'figures'
+
+
+@dataclass
+class ArtifactRef:
+    """A typed, content-addressed reference to a study's output."""
+
+    kind: str
+    hash: str = ''
+    store: str = ''
+    context: dict = field(default_factory=dict)
+    fingerprint: str = ''
+
+    @classmethod
+    def coerce(cls, ref) -> 'ArtifactRef':
+        if isinstance(ref, ArtifactRef):
+            return ref
+        if isinstance(ref, dict):
+            known = {'kind', 'hash', 'store', 'context', 'fingerprint'}
+            return cls(**{k: v for k, v in ref.items() if k in known})
+        raise TypeError(f'not an artifact reference: {ref!r}')
+
+    def to_dict(self) -> dict:
+        return {'kind': self.kind, 'hash': self.hash, 'store': self.store,
+                'context': dict(self.context), 'fingerprint': self.fingerprint}
+
+
+# ── loaders: one per kind ───────────────────────────────────────────
+
+_LOADERS: dict = {}
+
+
+def register_artifact_loader(kind: str, loader: Callable) -> None:
+    """Teach ``ArtifactResults`` how to resolve a kind.
+
+    ``loader(ref) -> value``. Kinds are open on purpose: a workspace adds
+    ``sim_data`` by registering the loader that knows its calibration format,
+    without the engine knowing anything about it.
+    """
+    _LOADERS[kind] = loader
+
+
+def artifact_loader(kind: str) -> Callable:
+    loader = _LOADERS.get(kind)
+    if loader is None:
+        raise KeyError(
+            f'no loader registered for artifact kind {kind!r} — '
+            f'known kinds: {sorted(_LOADERS)}. Register one with '
+            f'`register_artifact_loader({kind!r}, ...)`.')
+    return loader
+
+
+def _load_trajectory(ref: ArtifactRef):
+    """Read a trajectory back from its store.
+
+    The default understands a zarr directory via xarray, which is what the
+    emitters write; a workspace with another format registers its own.
+    """
+    import xarray as xr
+    return xr.open_datatree(ref.store, engine='zarr')
+
+
+def _load_pickle(ref: ArtifactRef):
+    """Load a calibration object (the shape ParCa writes).
+
+    A stand-in: it reads the single pickle in the artifact's store. The real
+    v2ecoli loader replaces it by registering over this kind.
+    """
+    import pickle
+    from pathlib import Path
+
+    store = Path(ref.store)
+    candidate = store if store.is_file() else None
+    if candidate is None:
+        pickles = sorted(store.glob('*.pkl')) + sorted(store.glob('*.pickle'))
+        if not pickles:
+            raise FileNotFoundError(
+                f'no calibration object under {store} for artifact '
+                f'{ref.hash!r}')
+        candidate = pickles[0]
+    with open(candidate, 'rb') as handle:
+        return pickle.load(handle)
+
+
+register_artifact_loader(TRAJECTORY, _load_trajectory)
+register_artifact_loader(SIM_DATA, _load_pickle)
+
+
+# ── the resolved handle ─────────────────────────────────────────────
+
+class ArtifactResults:
+    """The handle a ``results`` site carries for a **stored** artifact.
+
+    The counterpart of ``EmitterResults``: that one references a live
+    emitter, this one references the store. Both answer ``kind``, ``context``
+    and ``resolve()``, so a downstream consumer cannot tell whether the study
+    ran or was pulled — which is the whole point of caching a study.
+    """
+
+    def __init__(self, ref, context=None):
+        self.ref = ArtifactRef.coerce(ref)
+        if context:
+            self.ref.context = {**self.ref.context, **context}
+        self._resolved = {}
+        self.provenance_status = 'ok'
+
+    @classmethod
+    def from_ref(cls, ref) -> 'ArtifactResults':
+        return cls(ref)
+
+    @property
+    def kind(self) -> str:
+        return self.ref.kind
+
+    @property
+    def context(self) -> dict:
+        return self.ref.context
+
+    @property
+    def hash(self) -> str:
+        return self.ref.hash
+
+    @property
+    def store(self) -> str:
+        return self.ref.store
+
+    def resolve(self, paths=None):
+        """Load the artifact. Memoized, like ``EmitterResults.resolve``: a
+        stored artifact does not change under us, and several flush entities
+        resolve the same handle."""
+        key = tuple(paths) if isinstance(paths, list) else paths
+        if key not in self._resolved:
+            self._resolved[key] = artifact_loader(self.kind)(self.ref)
+        return self._resolved[key]
+
+    def to_dict(self) -> dict:
+        return {**self.ref.to_dict(),
+                'provenance_status': self.provenance_status}
+
+    def __repr__(self) -> str:
+        return (f'ArtifactResults(kind={self.kind!r}, hash={self.hash!r}, '
+                f'status={self.provenance_status!r})')
+
+
+# ── determinism ─────────────────────────────────────────────────────
+
+def fingerprint_of(value) -> str:
+    """A cheap, stable fingerprint of a produced result.
+
+    Used to catch the unsound case: a content address is a hash of *inputs*,
+    so it is only a valid cache key when the producer is deterministic given
+    them. A recompute that disagrees with the stored fingerprint means it is
+    not.
+    """
+    return hashlib.sha256(
+        canonical(value if isinstance(value, dict) else {'value': value})
+        .encode('utf-8')).hexdigest()[:16]
+
+
+def check_fingerprint(results, observed: str) -> str:
+    """Compare a recomputed fingerprint against the stored one.
+
+    Returns (and records) ``'ok'`` or ``'nondeterministic'``. A divergence is
+    *flagged*, never silently served — the address said these results should
+    be identical and they were not.
+    """
+    stored = getattr(getattr(results, 'ref', None), 'fingerprint', '')
+    status = 'ok' if (not stored or stored == observed) else 'nondeterministic'
+    try:
+        results.provenance_status = status
+    except AttributeError:
+        pass
+    return status
+
+
+# ── admitting kinds at a `results` site ─────────────────────────────
+
+def results_kind(filler) -> str:
+    """The artifact kind a filler carries, or '' if it is not a handle."""
+    return getattr(filler, 'kind', '') or ''
+
+
+def register_artifact_sorts(core, kinds=(TRAJECTORY, SIM_DATA, FIGURES)):
+    """Register the sorts a ``results`` site is constrained by.
+
+    ``'results'`` admits any handle; ``'results_<kind>'`` admits only that
+    kind — so a study declaring it needs ``sim_data`` cannot be wired to a
+    trajectory.
+
+    The names use an underscore, not a colon: ``_sort`` is a schema field, so
+    ``access`` runs it through the type grammar, where ``a:b`` is the
+    named-parameter form and would be parsed rather than kept as a name.
+    """
+    core.register_sort('results', lambda core, site, filler: bool(
+        results_kind(filler)))
+    for kind in kinds:
+        core.register_sort(
+            results_sort(kind),
+            (lambda wanted: (lambda core, site, filler:
+                             results_kind(filler) == wanted))(kind))
+    return core
+
+
+def results_sort(kind: str) -> str:
+    """The sort name constraining a ``results`` site to one artifact kind."""
+    return f'results_{kind}'

--- a/process_bigraph/emitter.py
+++ b/process_bigraph/emitter.py
@@ -224,6 +224,16 @@ class EmitterResults:
     reaching for the imperative ``gather_emitter_results`` pull.
     """
 
+    #: This handle's artifact kind. ``EmitterResults`` *is* the trajectory
+    #: case of ``artifacts.ArtifactResults`` — it answers the same
+    #: ``kind``/``context``/``resolve()`` protocol, so a consumer cannot tell
+    #: a live emitter from a pulled artifact. The difference is only where
+    #: the data comes from: an emitter still in memory, or a store on disk.
+    kind = 'trajectory'
+
+    #: Set when a recompute disagreed with a stored fingerprint.
+    provenance_status = 'ok'
+
     __slots__ = ('emitter', 'address', 'path', 'context', '_resolved')
 
     def __init__(self, emitter, address=None, path=None, context=None):

--- a/process_bigraph/processes/__init__.py
+++ b/process_bigraph/processes/__init__.py
@@ -1,4 +1,5 @@
 from process_bigraph.processes.parameter_scan import ToySystem, ODE, RunProcess, ParameterScan
 from process_bigraph.processes.growth_division import Grow, Divide
 from process_bigraph.processes.simulation import SimulationStep
+from process_bigraph.processes.cached import CachedResults
 

--- a/process_bigraph/processes/cached.py
+++ b/process_bigraph/processes/cached.py
@@ -1,0 +1,67 @@
+"""The pull half of pull-or-compute.
+
+``SimulationStep`` computes a study's results by running it. ``CachedResults``
+produces the same thing by resolving an artifact that already exists. They
+share the ``{results: node}`` face and both produce at finalize, so nothing
+downstream can tell which one it is wired to — a study that was pulled and a
+study that just ran look identical from the outside.
+
+That indistinguishability is the contract, not an implementation detail: it is
+what lets ``trigger`` swap one for the other in a document without rewiring
+anything.
+"""
+
+from __future__ import annotations
+
+from process_bigraph.composite import Step
+from process_bigraph.artifacts import ArtifactResults
+
+
+class CachedResults(Step):
+    """Resolve a content-addressed artifact and emit its handle.
+
+    Never runs a simulation. Config is the ``artifact_ref``
+    (``{kind, hash, store, context}``) that ``trigger`` bound when it found
+    the artifact in the store.
+    """
+
+    config_schema = {'artifact_ref': 'quote'}
+
+    def inputs(self):
+        return {}
+
+    def outputs(self):
+        return {'results': 'node'}
+
+    def results(self, path=None, context=None) -> ArtifactResults:
+        """The handle for the stored artifact.
+
+        Named to match the emitter contract — ``Composite.finalize()`` asks
+        every edge for ``results()``, so a pulled study surfaces its handle by
+        exactly the route a computed one does.
+        """
+        ref = self.config.get('artifact_ref')
+        if not ref:
+            raise ValueError(
+                'CachedResults has no `artifact_ref` — it can only pull an '
+                'artifact that trigger() already resolved.')
+        return ArtifactResults(ref, context=context)
+
+    def update(self, state) -> dict:
+        """Emit the handle the way ``SimulationStep`` does.
+
+        This is where indistinguishability is actually won. An *emitter*
+        produces ``results`` at finalize, because its results only exist once
+        the run is over — but a study node is a producer *in the step DAG*,
+        and ``SimulationStep.update()`` returns the handle so its consumers
+        are ordered after it. A ``CachedResults`` that produced only at
+        finalize would leave those consumers unordered: they would fire first
+        and read an empty store. Matching ``SimulationStep`` — not matching
+        the emitter — is what the contract requires.
+        """
+        return {'results': self.results()}
+
+    def finalize(self, path=None, context=None) -> dict:
+        """Also answer the completion-time route, so a composite that asks
+        every edge for its results at finalize gets this one too."""
+        return {'results': self.results(path=path, context=context)}

--- a/process_bigraph/templates.py
+++ b/process_bigraph/templates.py
@@ -114,3 +114,160 @@ def investigation_document(core, template, bindings=None, member_depth=1):
     filled = fill_template(core, template, bindings)
     pruned, blocked = prune_open_regions(filled, member_depth=member_depth)
     return core.render(pruned, defaults=True), blocked
+
+
+# ── partial graph triggering: pull-or-compute ───────────────────────
+#
+# A cached study result is simply a **filled** results site. Nothing new is
+# scheduled: an open results site means the study computes, a filled one means
+# it does not and its consumers read the cached handle instead. `trigger` is
+# the operation that decides which, using the same fill/prune law gating uses.
+
+STUDY_META = '_study'
+"""Per-member metadata: ``{id, config, inputs: [{artifact, from}], kind}``."""
+
+
+def study_members(document):
+    """Every member of an investigation document, by name.
+
+    A member is a top-level region carrying ``_study`` metadata.
+    """
+    return {
+        name: region for name, region in document.items()
+        if isinstance(region, dict) and isinstance(region.get(STUDY_META), dict)}
+
+
+def _meta(region, key, default=None):
+    return (region.get(STUDY_META) or {}).get(key, default)
+
+
+def study_ancestors(document, target):
+    """``target``'s transitive prerequisites, nearest last.
+
+    Edges come from each member's ``inputs: [{artifact, from}]`` — the same
+    declaration the investigation format already carries, so the DAG is read
+    rather than restated.
+    """
+    members = study_members(document)
+    if target not in members:
+        raise KeyError(
+            f'no study {target!r} in the document — members are '
+            f'{sorted(members)}')
+
+    order, seen = [], set()
+
+    def walk(name):
+        if name in seen:
+            return
+        seen.add(name)
+        for edge in _meta(members.get(name, {}), 'inputs', []) or []:
+            upstream = edge.get('from')
+            if upstream and upstream in members:
+                walk(upstream)
+                if upstream not in order:
+                    order.append(upstream)
+
+    walk(target)
+    return order
+
+
+def study_address(document, name, *, commit=''):
+    """The content address of a member's artifact.
+
+    A function of the member's id, its config, its inputs' addresses and the
+    workspace commit — so it is worktree-independent and an upstream change
+    invalidates everything downstream of it.
+    """
+    from process_bigraph.artifacts import artifact_id
+
+    members = study_members(document)
+    region = members[name]
+
+    input_ids = [
+        study_address(document, edge['from'], commit=commit)
+        for edge in (_meta(region, 'inputs', []) or [])
+        if edge.get('from') in members]
+
+    return artifact_id(
+        composite_id=_meta(region, 'id', name),
+        config=_meta(region, 'config', {}) or {},
+        input_ids=input_ids,
+        commit=commit)
+
+
+def cached_node(ref):
+    """The step that replaces a member's simulation when it is pulled."""
+    return {
+        '_type': 'step',
+        'address': 'local:CachedResults',
+        'config': {'artifact_ref': ref},
+        'inputs': {},
+        'outputs': {'results': ['results']}}
+
+
+def trigger(document, target, *, on_missing='error', commit='',
+            root=None, sim_key='sim'):
+    """Build the sub-document that runs ``target``.
+
+    Prerequisites already in the artifact store are **pulled**: their
+    simulation node is swapped for a ``CachedResults`` bound to the resolved
+    reference, so they are ground and do not run. The target is left open, so
+    it computes. Everything that is neither is **pruned** — absent from the
+    document, never constructed.
+
+    "Run one study" and "rerun this study reusing its upstream" are the same
+    call with different targets.
+
+    ``on_missing='error'`` (default) refuses to silently recompute a
+    prerequisite the caller meant to reuse, naming it instead;
+    ``on_missing='compute'`` leaves it open so it computes too.
+
+    Returns ``(document, report)`` where report is
+    ``{'target', 'pulled', 'computed', 'pruned'}``.
+    """
+    from process_bigraph.artifacts import (
+        ARTIFACT_ROOT, ArtifactRef, artifact_exists, artifact_store)
+
+    if on_missing not in ('error', 'compute'):
+        raise ValueError(
+            f"on_missing must be 'error' or 'compute', got {on_missing!r}")
+    root = ARTIFACT_ROOT if root is None else root
+
+    members = study_members(document)
+    ancestors = study_ancestors(document, target)
+    keep = set(ancestors) | {target}
+
+    built = copy.deepcopy(document)
+    pulled, computed, missing = [], [], []
+
+    for name in ancestors:
+        address = study_address(document, name, commit=commit)
+        if artifact_exists(address, root):
+            ref = ArtifactRef(
+                kind=_meta(members[name], 'kind', 'trajectory'),
+                hash=address,
+                store=artifact_store(address, root),
+                context={'study': name})
+            built[name][sim_key] = cached_node(ref.to_dict())
+            pulled.append(name)
+        elif on_missing == 'compute':
+            computed.append(name)
+        else:
+            missing.append(name)
+
+    if missing:
+        raise FileNotFoundError(
+            f'cannot trigger {target!r}: prerequisite(s) '
+            f'{", ".join(repr(n) for n in missing)} have no cached artifact. '
+            f'Run them first, or pass on_missing="compute" to compute them '
+            f'as part of this trigger.')
+
+    pruned = sorted(set(members) - keep)
+    for name in pruned:
+        built.pop(name, None)
+
+    return built, {
+        'target': target,
+        'pulled': pulled,
+        'computed': computed + [target],
+        'pruned': pruned}

--- a/tests.py
+++ b/tests.py
@@ -5,6 +5,7 @@ Tests for Process Bigraph
 """
 
 import os
+import pathlib
 import sys
 import random
 import inspect
@@ -4761,3 +4762,358 @@ def test_resolving_a_handle_twice_is_idempotent_and_cheap():
 
     assert first == second
     assert len(calls) == 1, f'query() called {len(calls)} times'
+
+
+# ==========================================
+# Layer 3.5 — partial graph triggering (pull-or-compute)
+# ==========================================
+
+PARCA_RUNS = []
+STUDY_RUNS = []
+
+
+class SpyParca(Step):
+    """A stand-in for an expensive root study. Records every time it runs."""
+
+    config_schema = {'name': {'_type': 'string', '_default': 'parca'}}
+
+    def inputs(self):
+        return {}
+
+    def outputs(self):
+        return {'results': 'node'}
+
+    def update(self, state):
+        PARCA_RUNS.append(self.config['name'])
+        return {'results': self.results()}
+
+    def results(self, path=None, context=None):
+        from process_bigraph.artifacts import ArtifactResults, ArtifactRef
+        return ArtifactResults(ArtifactRef(
+            kind='sim_data', hash='computed', store='',
+            context={'computed': True}))
+
+    def finalize(self, path=None, context=None):
+        return {'results': self.results(path=path, context=context)}
+
+
+class SpyStudy(SpyParca):
+    """A study that records its runs the same way."""
+
+    def update(self, state):
+        STUDY_RUNS.append(self.config['name'])
+        return {'results': self.results()}
+
+    def results(self, path=None, context=None):
+        from process_bigraph.artifacts import ArtifactResults, ArtifactRef
+        return ArtifactResults(ArtifactRef(
+            kind='trajectory', hash='computed', store='',
+            context={'computed': True, 'name': self.config['name']}))
+
+
+def _trigger_core():
+    core = allocate_core()
+    core.register_link('SpyParca', SpyParca)
+    core.register_link('SpyStudy', SpyStudy)
+    return core
+
+
+def _member(name, address, config, inputs=None, kind='trajectory'):
+    return {
+        '_study': {'id': name, 'config': config,
+                   'inputs': inputs or [], 'kind': kind},
+        'results': {},
+        'sim': {
+            '_type': 'step', 'address': address,
+            'config': {'name': name},
+            'inputs': {}, 'outputs': {'results': ['results']}}}
+
+
+def _chain_document():
+    """`parca -> A -> B`, the shape the spec's tests describe."""
+    return {
+        'parca': _member('parca', 'local:SpyParca', {'mode': 'full'},
+                         kind='sim_data'),
+        'A': _member('A', 'local:SpyStudy', {'seed': 1},
+                     inputs=[{'artifact': 'sim_data', 'from': 'parca'}]),
+        'B': _member('B', 'local:SpyStudy', {'seed': 2},
+                     inputs=[{'artifact': 'trajectory', 'from': 'A'}])}
+
+
+def _seed_store(root, document, names, commit=''):
+    """Put artifacts for `names` in the store, at their real addresses."""
+    from process_bigraph.templates import study_address
+    from process_bigraph.artifacts import artifact_store
+
+    for name in names:
+        address = study_address(document, name, commit=commit)
+        pathlib.Path(artifact_store(address, str(root))).mkdir(parents=True,
+                                                       exist_ok=True)
+
+
+def test_the_content_address_is_worktree_independent(tmp_path):
+    """The address is a function of inputs, never of a path — which is what
+    lets two worktrees at the same commit share a cache with no symlink."""
+    from process_bigraph.artifacts import artifact_id
+
+    def address_from(worktree):
+        os.chdir(worktree)
+        return artifact_id(composite_id='parca', config={'mode': 'full'},
+                           input_ids=['raw@1'], commit='abc123')
+
+    here = os.getcwd()
+    try:
+        one = tmp_path / 'worktree-a'
+        two = tmp_path / 'worktree-b'
+        one.mkdir()
+        two.mkdir()
+        assert address_from(one) == address_from(two)
+    finally:
+        os.chdir(here)
+
+    # ...and it does change when an input changes
+    assert artifact_id(composite_id='parca', config={'mode': 'full'},
+                       input_ids=['raw@1'], commit='abc123') != \
+        artifact_id(composite_id='parca', config={'mode': 'fast'},
+                    input_ids=['raw@1'], commit='abc123')
+
+
+def test_trigger_one_study_pulls_its_root_and_prunes_the_rest(tmp_path):
+    """Trigger A in `parca -> A -> B`: parca is pulled (never runs), A
+    computes, B is absent from the document entirely."""
+    from process_bigraph.templates import trigger
+
+    PARCA_RUNS.clear()
+    STUDY_RUNS.clear()
+
+    document = _chain_document()
+    _seed_store(tmp_path, document, ['parca'])
+
+    built, report = trigger(document, 'A', root=str(tmp_path))
+
+    assert report['pulled'] == ['parca']
+    assert report['pruned'] == ['B']
+    assert 'B' not in built
+
+    # parca's node was swapped for the pull step; A's was not
+    assert built['parca']['sim']['address'] == 'local:CachedResults'
+    assert built['A']['sim']['address'] == 'local:SpyStudy'
+
+    sim = Composite({'state': built}, core=_trigger_core())
+    sim.run(0.0)
+
+    assert PARCA_RUNS == [], 'parca ran despite being cached'
+    assert STUDY_RUNS == ['A']
+
+
+def test_rerun_downstream_reusing_upstream(tmp_path):
+    """With parca and A cached, triggering B runs only B — both ancestors
+    are pulled and neither recomputes."""
+    from process_bigraph.templates import trigger
+
+    PARCA_RUNS.clear()
+    STUDY_RUNS.clear()
+
+    document = _chain_document()
+    _seed_store(tmp_path, document, ['parca', 'A'])
+
+    built, report = trigger(document, 'B', root=str(tmp_path))
+
+    assert sorted(report['pulled']) == ['A', 'parca']
+    assert report['computed'] == ['B']
+    assert report['pruned'] == []
+
+    sim = Composite({'state': built}, core=_trigger_core())
+    sim.run(0.0)
+
+    assert PARCA_RUNS == []
+    assert STUDY_RUNS == ['B'], f'expected only B to run, got {STUDY_RUNS}'
+
+
+def test_a_missing_prerequisite_is_named_not_silently_recomputed(tmp_path):
+    from process_bigraph.templates import trigger
+
+    document = _chain_document()   # nothing cached
+
+    with pytest.raises(FileNotFoundError, match='parca') as raised:
+        trigger(document, 'A', root=str(tmp_path))
+    assert 'on_missing' in str(raised.value)
+
+
+def test_on_missing_compute_computes_the_prerequisite(tmp_path):
+    from process_bigraph.templates import trigger
+
+    PARCA_RUNS.clear()
+    STUDY_RUNS.clear()
+
+    document = _chain_document()
+    built, report = trigger(document, 'A', on_missing='compute',
+                            root=str(tmp_path))
+
+    assert report['pulled'] == []
+    assert sorted(report['computed']) == ['A', 'parca']
+
+    sim = Composite({'state': built}, core=_trigger_core())
+    sim.run(0.0)
+
+    assert PARCA_RUNS == ['parca'], 'parca should have computed'
+    assert STUDY_RUNS == ['A']
+
+
+def test_an_upstream_config_change_invalidates_downstream(tmp_path):
+    """The address folds in its inputs' addresses, so changing parca's
+    config changes A's address — the old A artifact no longer answers."""
+    from process_bigraph.templates import study_address
+
+    document = _chain_document()
+    before = study_address(document, 'A')
+
+    document['parca']['_study']['config'] = {'mode': 'fast'}
+    after = study_address(document, 'A')
+
+    assert before != after
+
+
+def test_a_pulled_study_is_indistinguishable_downstream(tmp_path):
+    """A consumer gives the same verdict whether its upstream ran or was
+    pulled from an identical artifact — the contract that makes caching
+    safe."""
+    from process_bigraph.templates import trigger
+    from process_bigraph.artifacts import (
+        register_artifact_loader, ArtifactResults)
+
+    verdicts = []
+
+    class Card(Step):
+        config_schema = {}
+
+        def inputs(self):
+            return {'results': 'node'}
+
+        def outputs(self):
+            return {'verdict': 'string'}
+
+        def update(self, state):
+            handle = state.get('results')
+            payload = handle.resolve() if handle is not None else None
+            verdict = 'pass' if payload == {'mass': [1, 2, 3]} else 'fail'
+            verdicts.append(verdict)
+            return {'verdict': verdict}
+
+    # the stored artifact and the computed one carry identical payloads
+    register_artifact_loader('trajectory', lambda ref: {'mass': [1, 2, 3]})
+
+    class ComputingStudy(SpyStudy):
+        def results(self, path=None, context=None):
+            from process_bigraph.artifacts import ArtifactRef
+            return ArtifactResults(ArtifactRef(kind='trajectory', store=''))
+
+    core = _trigger_core()
+    core.register_link('Card', Card)
+    core.register_link('ComputingStudy', ComputingStudy)
+
+    def build(cached):
+        document = {
+            'A': _member('A', 'local:ComputingStudy', {'seed': 1}),
+            'B': {
+                '_study': {'id': 'B', 'config': {},
+                           'inputs': [{'artifact': 'trajectory', 'from': 'A'}]},
+                'verdict': '',
+                'card': {
+                    '_type': 'step', 'address': 'local:Card',
+                    'inputs': {'results': ['..', 'A', 'results']},
+                    'outputs': {'verdict': ['verdict']}}}}
+        if cached:
+            _seed_store(tmp_path, document, ['A'])
+        built, _ = trigger(document, 'B', root=str(tmp_path),
+                           on_missing='compute')
+        sim = Composite({'state': built}, core=core)
+        sim.run(0.0)
+        return sim.state['B']['verdict']
+
+    ran = build(cached=False)
+    pulled = build(cached=True)
+
+    assert ran == pulled == 'pass', f'ran={ran!r} pulled={pulled!r}'
+
+
+def test_one_resolve_dispatches_on_kind(tmp_path):
+    """`sim_data` resolves the calibration object, `trajectory` the
+    trajectory — one dispatch, two kinds."""
+    import pickle
+    from process_bigraph.artifacts import ArtifactRef, ArtifactResults
+
+    store = tmp_path / 'simdata'
+    store.mkdir()
+    calibration = {'doubling_time': 44.0, 'conditions': 51}
+    with open(store / 'sim_data.pkl', 'wb') as handle:
+        pickle.dump(calibration, handle)
+
+    loaded = ArtifactResults(
+        ArtifactRef(kind='sim_data', store=str(store))).resolve()
+    assert loaded == calibration
+
+    from process_bigraph.artifacts import register_artifact_loader
+    register_artifact_loader('trajectory', lambda ref: {'rows': 6})
+    assert ArtifactResults(
+        ArtifactRef(kind='trajectory', store='')).resolve() == {'rows': 6}
+
+
+def test_an_unknown_kind_says_so(tmp_path):
+    from process_bigraph.artifacts import ArtifactRef, ArtifactResults
+
+    with pytest.raises(KeyError, match='no loader registered'):
+        ArtifactResults(ArtifactRef(kind='hologram', store='')).resolve()
+
+
+def test_emitter_results_is_the_trajectory_kind():
+    """`EmitterResults` answers the artifact protocol without changing its
+    own API — it is the trajectory case."""
+    core = allocate_core()
+    emitter = RAMEmitter({'emit': {'level': 'node'}}, core)
+    handle = emitter.results(path=('emitter',))
+
+    assert handle.kind == 'trajectory'
+    assert handle.provenance_status == 'ok'
+    assert hasattr(handle, 'resolve') and hasattr(handle, 'context')
+
+
+def test_a_results_site_can_require_a_kind():
+    """`admits` type-checks a filler's kind, so a study needing sim_data
+    cannot be wired to a trajectory."""
+    from bigraph_schema.assembly import fill_sites
+    from process_bigraph.artifacts import (
+        ArtifactRef, ArtifactResults, register_artifact_sorts)
+
+    core = register_artifact_sorts(allocate_core())
+    trajectory = ArtifactResults(ArtifactRef(kind='trajectory'))
+    sim_data = ArtifactResults(ArtifactRef(kind='sim_data'))
+
+    body = core.access({'study': {'needs': {
+        '_type': 'site', '_sort': 'results_sim_data'}}})
+
+    filled = fill_sites(core, body, {'study/needs': sim_data})
+    assert filled['study']['needs'].kind == 'sim_data'
+
+    with pytest.raises(ValueError, match="site 'study/needs'"):
+        fill_sites(core, body, {'study/needs': trajectory})
+
+
+def test_a_divergent_recompute_is_flagged_not_served(tmp_path):
+    """A content address hashes *inputs*, so it is only a valid cache key
+    when the producer is deterministic. A recompute that disagrees with the
+    stored fingerprint is flagged rather than silently served."""
+    from process_bigraph.artifacts import (
+        ArtifactRef, ArtifactResults, fingerprint_of, check_fingerprint)
+
+    stored = fingerprint_of({'mass': 10.0})
+    handle = ArtifactResults(
+        ArtifactRef(kind='trajectory', store='', fingerprint=stored))
+
+    assert check_fingerprint(handle, fingerprint_of({'mass': 10.0})) == 'ok'
+    assert handle.provenance_status == 'ok'
+
+    # a stochastic producer recomputes something else at the same address
+    assert check_fingerprint(
+        handle, fingerprint_of({'mass': 10.5})) == 'nondeterministic'
+    assert handle.provenance_status == 'nondeterministic'


### PR DESCRIPTION
Implements the approved spec (#162) §11 steps 1–3. The v2ecoli conversion (step 4) is the next build and is **not** here.

Run one study instead of a whole investigation, and rerun a downstream study without recomputing what it consumes — with **no new execution concept**. A cached study result is simply a **filled** results site, decided by the same fill/prune law gating already uses.

## New API

**`process_bigraph/artifacts.py`**
- `artifact_id(*, composite_id, config, input_ids, commit)` — a **verbatim hand-port** of `vivarium_workbench/lib/artifacts/hashing.py`, with a lock-step comment. pbg cannot import the workbench (dependency direction), so the formula is duplicated deliberately — the same two-writers/one-store arrangement the rerun spine already has. Store convention `.pbg/artifacts/<hash>/`.
- `ArtifactRef{kind, hash, store, context, fingerprint}` and `ArtifactResults`, resolving through an **open loader registry** (`register_artifact_loader`) — `trajectory` reads the store back, `sim_data` loads the calibration object, a workspace registers its own format.
- `fingerprint_of` / `check_fingerprint` — a content address hashes *inputs*, so it is only a valid cache key when the producer is deterministic. A divergent recompute is flagged `nondeterministic`, never silently served.
- `register_artifact_sorts(core)` — `admits` type-checks a filler's kind.

**`CachedResults`** (`process_bigraph/processes/`, sibling to `SimulationStep`) — the pull half. Resolves an artifact and emits its handle; never simulates.

**`trigger(document, target, *, on_missing='error', commit='', root=None)`** → `(document, report)` with `report = {target, pulled, computed, pruned}`.

## How `ArtifactResults` widens `EmitterResults` without breaking it

`EmitterResults` is untouched except for two class attributes — `kind = 'trajectory'` and `provenance_status` — so it answers the same `kind`/`context`/`resolve()` protocol as `ArtifactResults`. Its own API, its memoized `resolve`, and every #160/#163 test are unchanged. The two are siblings by protocol rather than by inheritance: one references a live emitter, the other a store.

## Two places the spec met the code and lost

1. **§4 says `CachedResults` produces `results` at finalize.** That breaks the very contract it exists for. An *emitter* produces at finalize because its results only exist once the run is over — but a study node is a producer **in the step DAG**, and `SimulationStep` returns the handle from `update()`. Producing only at finalize leaves consumers unordered: they fire first and read an empty store. Indistinguishability means matching `SimulationStep`, **not** matching the emitter. Caught by the indistinguishability test itself.

2. **Kind sorts cannot be named `results:<kind>`.** `_sort` is a schema field, so `access` runs it through the type grammar where `a:b` is the named-parameter form — the name is parsed rather than kept and the registered sort is never found. They are `results_<kind>`. (Same trap as `local:edge` in the address work.)

## Tests — 196 → 208, 0 failures

Behaviour, not shape:

- **trigger one study** — `parca → A → B`, trigger `A`: only A's node computes, parca is swapped for `CachedResults`, B is absent; a spy asserts **zero** parca runs;
- **rerun downstream reusing upstream** — with parca and A cached, trigger `B` runs only B; both ancestors pulled, neither recomputes;
- **missing prerequisite** — raises naming it (default) / computes it under `on_missing='compute'`;
- **indistinguishability** — a card gives the same verdict whether its upstream ran or was pulled from an identical artifact;
- **one dispatch, two kinds** — `sim_data` resolves a real pickled calibration object, `trajectory` resolves its trajectory;
- **worktree independence** — the same `(config, commit)` hashes identically from two different directories, and an upstream config change invalidates downstream;
- **nondeterminism flagged** — a divergent recompute surfaces `provenance_status='nondeterministic'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)