### PR TITLE
feat(templates): on-disk template loading (`*.template.{yaml,json}`)

### DIFF
--- a/process_bigraph/templates.py
+++ b/process_bigraph/templates.py
@@ -23,8 +23,87 @@ Two things here that the bigraph-schema helpers do not cover:
 """
 
 import copy
+import json
+from pathlib import Path
 
 from bigraph_schema.assembly import fill_sites, interfaces
+
+
+# ── on-disk templates ───────────────────────────────────────────────
+#
+# A template is authorable as a file: a ``*.template.{yaml,json}`` document
+# with sites written in place. Loading is *just* ``core.access`` on the parsed
+# document — access reconstitutes each site as a place-graph hole, and
+# bigraph-schema 1.4.4's ``_sort`` round-trip means a site's value type / face /
+# default survives the file. The loaded document is the same thing the
+# Python-built templates in the tests are: it hands straight to
+# ``fill_template`` / ``template_document`` / ``investigation_document``.
+#
+# A study template and an investigation template are the *same* on-disk shape —
+# a document with sites — so one loader reads both; the caller picks
+# ``template_document`` (study) or ``investigation_document`` (investigation).
+
+TEMPLATE_SUFFIXES = ('.template.yaml', '.template.yml', '.template.json')
+"""Recognised on-disk template extensions (spec §6 authoring format)."""
+
+
+def _read_mapping(path):
+    """Parse a YAML or JSON document to a dict, chosen by extension."""
+    path = Path(path)
+    text = path.read_text(encoding='utf-8')
+    if path.suffix.lower() == '.json':
+        raw = json.loads(text)
+    else:
+        import yaml
+        raw = yaml.safe_load(text)
+    if not isinstance(raw, dict):
+        kind = type(raw).__name__
+        raise ValueError(
+            f'template {path} must parse to a mapping, got {kind}')
+    return raw
+
+
+def load_template(path, core):
+    """Read a ``*.template.{yaml,json}`` document from disk into a template.
+
+    Parses the file (YAML or JSON, by extension) and runs the result through
+    ``core.access``, which reconstitutes every site as an open place-graph
+    hole. Because ``access`` round-trips ``_sort`` (the Layer-1 fix in
+    bigraph-schema 1.4.4), a value site's type, a face site's interface and a
+    site's ``_default`` all survive the file intact — the loaded document has
+    exactly the ``open_sites`` the file declared.
+
+    The returned document is a template like any other: hand it to
+    ``fill_template`` / ``template_document`` (a study) or
+    ``investigation_document`` (an investigation, one member per site). Both
+    file kinds load through this one function; only the caller's follow-on call
+    differs. Any process/step edges named in the file must already be
+    registered on ``core``.
+    """
+    return core.access(_read_mapping(path))
+
+
+def save_template(template, path, core):
+    """Write a template document to disk so it re-loads with identical sites.
+
+    Rendered with ``defaults=True`` on purpose. A plain ``render`` drops each
+    site's ``_default`` and stringizes a face ``_sort`` — after round-tripping
+    through the file an optional site would come back **required** and a face
+    would be flattened, so ``load_template`` would read back a *different*
+    template. ``defaults=True`` is what makes the on-disk round-trip identity
+    (the same subtlety ``template_document`` documents for the fill path).
+
+    Returns the ``Path`` written.
+    """
+    path = Path(path)
+    rendered = core.render(template, defaults=True)
+    if path.suffix.lower() == '.json':
+        text = json.dumps(rendered, indent=2, sort_keys=True)
+    else:
+        import yaml
+        text = yaml.safe_dump(rendered, sort_keys=True)
+    path.write_text(text, encoding='utf-8')
+    return path
 
 
 def open_sites(document):

--- a/tests.py
+++ b/tests.py
@@ -5117,3 +5117,227 @@ def test_a_divergent_recompute_is_flagged_not_served(tmp_path):
     assert check_fingerprint(
         handle, fingerprint_of({'mass': 10.5})) == 'nondeterministic'
     assert handle.provenance_status == 'nondeterministic'
+
+
+# ==========================================
+# Layer 3 (cont.) — templates authored on disk (`*.template.{yaml,json}`)
+# ==========================================
+#
+# A template is a document with sites, so it is authorable as a file. Loading
+# is `core.access` on the parsed mapping — sites survive because bigraph-schema
+# 1.4.4 round-trips `_sort`. A study template and an investigation template are
+# the same on-disk shape; one loader reads both.
+
+# A study template with a *model* site (a face), a *value* site with a default
+# (`rate`), and a fixed report step wired to the model. Authored as literal
+# text so the test exercises hand-authored files, not machine-rendered ones.
+_STUDY_TEMPLATE_YAML = """\
+study:
+  level: 1.0
+  verdict: string
+  rate:
+    _type: site
+    _sort: float
+    _default: 0.5
+  model:
+    _type: site
+    _sort:
+      _type: link
+      _inputs: {level: float}
+      _outputs: {level: float}
+  report:
+    _type: step
+    address: local:ReportCard
+    config: {threshold: 2.0}
+    inputs: {level: [level]}
+    outputs: {verdict: [verdict]}
+"""
+
+
+def _write(path, text):
+    path.write_text(text, encoding='utf-8')
+    return path
+
+
+def test_a_study_template_loads_from_disk(tmp_path):
+    """The file's declared holes are exactly the loaded template's open sites:
+    a required face site (`model`) and a defaulted value site (`rate`)."""
+    from process_bigraph.templates import (
+        load_template, open_sites, required_open_sites, is_ground_document)
+
+    core = _study_core()
+    path = _write(tmp_path / 'growth.template.yaml', _STUDY_TEMPLATE_YAML)
+
+    template = load_template(path, core)
+
+    assert sorted(open_sites(template)) == [('study', 'model'), ('study', 'rate')]
+    # `rate` has a `_default`, so only `model` blocks the build
+    assert required_open_sites(template) == [('study', 'model')]
+    assert not is_ground_document(template)
+
+
+def test_a_loaded_study_template_fills_to_a_runnable_composite(tmp_path):
+    """Load from disk, fill the sites, and `template_document` yields a ground
+    document that constructs and runs — no code, the file is the study."""
+    from process_bigraph.templates import load_template, template_document
+
+    core = _study_core()
+    path = _write(tmp_path / 'growth.template.yaml', _STUDY_TEMPLATE_YAML)
+    template = load_template(path, core)
+
+    document = template_document(
+        core, template,
+        {'study/model': _model(core), 'study/rate': 0.9})
+
+    sim = Composite({'state': document}, core=core)
+    assert list(sim.process_paths) == [('study', 'model')]
+    assert list(sim.step_paths) == [('study', 'report')]
+
+    sim.run(4.0)
+    assert sim.state['study']['level'] > 2.0
+    assert sim.state['study']['verdict'] == 'pass'
+
+
+def test_a_loaded_template_with_a_required_site_open_is_not_ground(tmp_path):
+    """A required site left unfilled keeps the loaded template non-ground, and
+    `template_document` raises naming the empty hole — the same law as the
+    Python-built template, now reached from a file."""
+    from process_bigraph.templates import load_template, template_document
+
+    core = _study_core()
+    path = _write(tmp_path / 'growth.template.yaml', _STUDY_TEMPLATE_YAML)
+    template = load_template(path, core)
+
+    with pytest.raises(ValueError, match='not ground') as raised:
+        template_document(core, template, {})  # model left open
+    assert "'study/model'" in str(raised.value)
+
+
+def test_a_disk_template_round_trips_with_identical_sites(tmp_path):
+    """Save a template to disk and re-load it: identical open sites and
+    identical required sites. This is the Layer-1 `_sort` round-trip in
+    practice — the face `_sort` and the value site's `_default` both survive
+    the file, so `rate` stays *optional* rather than coming back required."""
+    from process_bigraph.templates import (
+        load_template, save_template, open_sites, required_open_sites)
+
+    core = _study_core()
+    # a defaulted value site so the round-trip must preserve `_default`
+    template = core.access({
+        'study': dict(
+            _study_region(),
+            rate={'_type': 'site', '_sort': 'float', '_default': 0.5})})
+
+    path = save_template(template, tmp_path / 'rt.template.yaml', core)
+    reloaded = load_template(path, core)
+
+    assert sorted(open_sites(reloaded)) == sorted(open_sites(template))
+    assert sorted(required_open_sites(reloaded)) == sorted(required_open_sites(template))
+    # `rate` is present but not required — its `_default` survived
+    assert ('study', 'rate') in open_sites(reloaded)
+    assert ('study', 'rate') not in required_open_sites(reloaded)
+
+
+def test_a_study_template_loads_from_json(tmp_path):
+    """JSON and YAML load through the same path (chosen by extension)."""
+    import json
+    from process_bigraph.templates import (
+        load_template, open_sites, template_document)
+
+    core = _study_core()
+    # build the same document, serialise as JSON via the round-trip renderer
+    template = core.access({'study': _study_region()})
+    from process_bigraph.templates import save_template
+    path = save_template(template, tmp_path / 'growth.template.json', core)
+    assert path.suffix == '.json'
+    assert isinstance(json.loads(path.read_text()), dict)
+
+    reloaded = load_template(path, core)
+    assert open_sites(reloaded) == [('study', 'model')]
+
+    document = template_document(core, reloaded, {'study/model': _model(core)})
+    Composite({'state': document}, core=core).run(4.0)
+
+
+def test_load_rejects_a_non_mapping_document(tmp_path):
+    """A file that does not parse to a mapping is rejected, naming the path."""
+    from process_bigraph.templates import load_template
+
+    core = _study_core()
+    path = _write(tmp_path / 'bad.template.yaml', '- just\n- a\n- list\n')
+    with pytest.raises(ValueError, match='must parse to a mapping'):
+        load_template(path, core)
+
+
+# ---- investigation templates on disk ----------------------------------
+
+_INVESTIGATION_TEMPLATE_YAML = """\
+investigation:
+  study_A:
+    level: 1.0
+    verdict: string
+    model:
+      _type: site
+      _sort:
+        _type: link
+        _inputs: {level: float}
+        _outputs: {level: float}
+    report:
+      _type: step
+      address: local:ReportCard
+      config: {threshold: 2.0}
+      inputs: {level: [level]}
+      outputs: {verdict: [verdict]}
+  study_B:
+    level: 1.0
+    verdict: string
+    model:
+      _type: site
+      _sort:
+        _type: link
+        _inputs: {level: float}
+        _outputs: {level: float}
+    report:
+      _type: step
+      address: local:ReportCard
+      config: {threshold: 2.0}
+      inputs: {level: [level]}
+      outputs: {verdict: [verdict]}
+"""
+
+
+def test_an_investigation_template_loads_with_a_site_per_member(tmp_path):
+    from process_bigraph.templates import load_template, open_sites
+
+    core = _study_core()
+    path = _write(
+        tmp_path / 'compare.template.yaml', _INVESTIGATION_TEMPLATE_YAML)
+    template = load_template(path, core)
+
+    assert sorted(open_sites(template)) == [
+        ('investigation', 'study_A', 'model'),
+        ('investigation', 'study_B', 'model')]
+
+
+def test_a_loaded_investigation_prunes_an_unfilled_member(tmp_path):
+    """Filling admits a member; a member left open is pruned — absent from the
+    built document, so it never runs. Gating as filling, read from a file."""
+    from process_bigraph.templates import load_template, investigation_document
+
+    core = _study_core()
+    path = _write(
+        tmp_path / 'compare.template.yaml', _INVESTIGATION_TEMPLATE_YAML)
+    template = load_template(path, core)
+
+    document, blocked = investigation_document(
+        core, template,
+        {'investigation/study_A/model': _model(core)},
+        member_depth=2)
+
+    assert blocked == ['investigation/study_B']
+    assert sorted(document['investigation']) == ['study_A']
+
+    sim = Composite({'state': document}, core=core)
+    sim.run(4.0)
+    assert 'study_B' not in sim.state['investigation']
+    assert sim.state['investigation']['study_A']['verdict'] == 'pass'


### PR DESCRIPTION
## What

Makes study & investigation **templates authorable as files**. Today templates
are constructed in Python in tests; this adds a loader so a `*.template.{yaml,json}`
document with open *sites* can be read from disk into the existing
fill/prune/`Composite` path (spec §6, "Authoring format & coexistence").

Two small functions in `process_bigraph/templates.py` — no reimplementation of
fill/prune, no new parallel loader:

- **`load_template(path, core)`** — parse YAML/JSON (by extension) → `core.access`.
  Access reconstitutes every site as an open place-graph hole. The loaded
  document *is* a template: it hands straight to `fill_template` /
  `template_document` (a study) / `investigation_document` (an investigation,
  one member per site). One loader reads both file kinds; only the caller's
  follow-on call differs.
- **`save_template(template, path, core)`** — render with `defaults=True` → dump.

### How sites survive the load

`core.access` on the parsed mapping round-trips `_sort` (the bigraph-schema 1.4.4
Layer-1 fix), so a value site's type, a face site's interface, and a site's
`_default` all survive the file — the loaded template has exactly the
`open_sites` the file declared.

The one subtlety, confirmed against the serialization code: **`save_template`
must render with `defaults=True`.** A plain `render` (defaults=False) drops each
site's `_default` and stringizes a face `_sort` (`link[level:float,level:float]`),
so after a round-trip an *optional* site comes back **required** and a face is
flattened. `defaults=True` makes the on-disk round-trip an identity — the same
subtlety `template_document` already documents for the fill path. This is the
only place §6 met the serialization code and needed a specific answer; the spec's
"`render`/`access` round-trip it" is correct **only** with `defaults=True`.

## Tests (8, all green; full suite 208 passed / 15 skipped)

- study `*.template.yaml` (model face site + defaulted `rate` value site + wired
  report step): loads → `open_sites` == declared holes → fill → `template_document`
  → runnable ground composite that runs to `pass`.
- a required site left unfilled keeps the loaded template non-ground; `template_document`
  raises naming `'study/model'`.
- **round-trip**: `save_template` → `load_template` has identical open *and*
  required sites — `_default` survives so `rate` stays optional.
- investigation `*.template.yaml` (member per study) loads with a site per member;
  `investigation_document` prunes an unfilled member (absent, never runs).
- JSON and YAML both load; a non-mapping document is rejected.

## Coexistence

Legacy `${name}` `CompositeSpec` is untouched — the site format is opt-in.
process-bigraph only; does not touch v2ecoli or vwb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)