### PR TITLE
fix(git): install a fetched repo editable, not as a wheel

### DIFF
--- a/process_bigraph/protocols/git.py
+++ b/process_bigraph/protocols/git.py
@@ -338,10 +338,15 @@ def _build_venv(repo_dir: pathlib.Path, venv_dir: pathlib.Path) -> pathlib.Path:
         subprocess.run([uv, 'venv', '--quiet', str(venv_dir)],
                        check=True,
                        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    # Install the repo into its venv. ``uv pip install .`` builds the repo's
-    # own dependency closure inside the venv — never touching the host env.
+    # Install the repo into its venv, **editable**. A wheel install ships only
+    # what the repo declares as packages, which for a scientific repo is
+    # routinely incomplete — CovertLab/vEcoli's wheel omits `ecoli.library`
+    # and every `.tsv`/`.json` data file its reconstruction reads. The worker
+    # cannot fall back to the source tree either: it is launched as
+    # `python _git_worker.py`, so `sys.path[0]` is the *worker's* directory,
+    # not `cwd`. Editable makes the checkout itself importable, data and all.
     result = subprocess.run(
-        [uv, 'pip', 'install', '--python', str(python), '--quiet', '.'],
+        [uv, 'pip', 'install', '--python', str(python), '--quiet', '-e', '.'],
         cwd=str(repo_dir),
         stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
     if result.returncode != 0:


### PR DESCRIPTION
Found driving the `git:` protocol against the real CovertLab/vEcoli for the first time (v2ecoli #437).

## The bug

A `git:` address could resolve, pin, and build its venv — and then fail to import the repo it had just installed:

```
ModuleNotFoundError: No module named 'ecoli.library'
```

`_build_venv` did `uv pip install .`, a wheel build. A wheel ships only what the repo *declares* as packages, and for a scientific repo that is routinely incomplete. CovertLab/vEcoli declares six top-level packages but its wheel omits `ecoli.library` outright, plus every `.tsv`/`.json` data file its reconstruction reads at import time.

**The source tree cannot compensate.** The worker is launched as `python _git_worker.py`, so `sys.path[0]` is the *worker's* directory — the `cwd=repo_dir` the protocol sets does not put the checkout on `sys.path`. This is what makes the bug easy to miss: a `python -c` probe from the same directory works fine (for `-c`, `sys.path[0]` *is* cwd), so the repo looks importable right up until the protocol actually runs it.

## The fix

`uv pip install -e .`. The checkout itself becomes importable, data files and all — which is also how vEcoli's own docs and CI install it.

## Measured

Against `CovertLab/vEcoli@d2f95129`:

- editable venv rebuilds in seconds on a warm uv cache;
- the adapter entrypoint loads and answers `interface()` over the RPC boundary;
- the failure moves from an import error to **25.6s into unpickling ParCa `sim_data`** — i.e. past the protocol entirely and into the fetched repo's own data compatibility, which is where a failure at that stage belongs.

Suite: 208 passed, 7 skipped, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)