### PR TITLE
fix(emitter): a declared emitter is a default — don't duplicate a builder's own sink

### DIFF
--- a/process_bigraph/composite_spec.py
+++ b/process_bigraph/composite_spec.py
@@ -348,21 +348,36 @@ class CompositeSpec:
     def _with_emitters(self, doc, core=None):
         """Install this spec's declared emitters into a built document.
 
-        Installing is idempotent — the sinks land at fixed ``emitter`` /
-        ``emitter_<i>`` keys — so a caller that also installs (the
-        ``viva_superpowers`` shim, the dashboard's observable injection)
-        rewrites the same slots rather than giving the composite two sinks.
+        The declared ``emitters`` are a *default* observation sink, applied
+        only when the builder produced a document that observes nothing. A
+        builder that already installs and configures its own emitter — e.g. a
+        workspace generator that resolves a run-specific ``out_dir`` and nests
+        a fully-built emitter instance inside an agent sub-composite — keeps
+        it untouched: reinstalling the bare declaration on top would add a
+        second, differently-configured sink (which, for a ParquetEmitter,
+        realizes with an empty ``out_dir`` and fails). A composite built
+        through the pure API whose builder installs no sink still gets the
+        declared one, so the pure-API path is not left observing nothing.
+
+        Installing is idempotent — the declared sinks land at fixed
+        ``emitter`` / ``emitter_<i>`` keys — so a caller that installs the same
+        declaration again rewrites the same slots rather than adding a second
+        sink.
         """
-        from process_bigraph.emitter import install_emitters
+        from process_bigraph.emitter import install_emitters, document_has_emitter
 
         if not self.emitters or not isinstance(doc, dict):
             return doc
 
         if "state" in doc:
-            return {**doc, "state": install_emitters(
-                doc["state"] or {}, self.emitters, core=core)}
+            state = doc["state"] or {}
+            if document_has_emitter(state, core):
+                return doc
+            return {**doc, "state": install_emitters(state, self.emitters, core=core)}
 
         # A builder that returned a bare state tree.
+        if document_has_emitter(doc, core):
+            return doc
         return install_emitters(doc, self.emitters, core=core)
 
     def to_composite(self, overrides=None, core=None, emit=True):

--- a/process_bigraph/emitter.py
+++ b/process_bigraph/emitter.py
@@ -160,6 +160,45 @@ def emitter_node_from_declaration(
     return node
 
 
+def _node_is_emitter(node, core=None):
+    '''True when ``node`` is an edge node that resolves to an Emitter.
+
+    Works on a *raw* document node (not yet realized): an already-built
+    ``instance`` that is an Emitter, an ``address`` the core resolves to an
+    Emitter subclass, or — as a last resort when no core is on hand — an
+    address whose class name ends in ``Emitter``.
+    '''
+    if not isinstance(node, dict) or node.get('_type') not in ('step', 'process', 'edge'):
+        return False
+    if isinstance(node.get('instance'), Emitter):
+        return True
+    address = node.get('address')
+    if not isinstance(address, str):
+        return False
+    name = address.split(':', 1)[-1]
+    registry = getattr(core, 'link_registry', None) if core is not None else None
+    if registry is not None:
+        cls = registry.get(name) or registry.get(name.rsplit('.', 1)[-1])
+        if isinstance(cls, type) and issubclass(cls, Emitter):
+            return True
+        if cls is not None:
+            return False
+    return name.rsplit('.', 1)[-1].endswith('Emitter')
+
+
+def document_has_emitter(state, core=None):
+    '''Recursively test whether a document ``state`` already contains an
+    emitter node (at any depth — e.g. one a builder nested inside an agent
+    sub-composite).'''
+    if _node_is_emitter(state, core):
+        return True
+    if isinstance(state, dict):
+        return any(document_has_emitter(v, core) for v in state.values())
+    if isinstance(state, (list, tuple)):
+        return any(document_has_emitter(v, core) for v in state)
+    return False
+
+
 def install_emitters(state, declarations, run_id=None, out_dir=None, core=None):
     '''Return a copy of ``state`` with the declared emitter(s) installed.
 

--- a/tests.py
+++ b/tests.py
@@ -3693,6 +3693,46 @@ def test_a_spec_with_no_emitters_installs_none():
     assert list(_emitting_spec([]).to_composite().step_paths) == []
 
 
+def test_builder_installed_emitter_is_not_duplicated():
+    """A builder that installs and configures its OWN emitter (possibly nested
+    inside a sub-composite) must keep it — ``to_document`` must not add a
+    second, differently-configured sink from the declaration on top.
+
+    Regression: a workspace generator (v2ecoli) nests a fully-built emitter
+    with a resolved ``out_dir`` under ``agents.<id>.emitter``; the bare
+    declaration reinstalled at the top level realized with an empty ``out_dir``
+    and failed. The declared emitter is a *default* — applied only when the
+    built document observes nothing."""
+    from process_bigraph.composite_spec import CompositeSpec
+    from process_bigraph.emitter import document_has_emitter
+
+    def builder(core=None):
+        # The builder places its own emitter, nested inside a sub-composite,
+        # with a config the declaration does not carry.
+        return {'state': {
+            'agents': {'0': {
+                'level': 1.0,
+                'emitter': {
+                    '_type': 'step',
+                    'address': 'local:RAMEmitter',
+                    'config': {'a_builder_only_key': 123,
+                               'emit': {'level': 'node'}},
+                    'inputs': {'level': ['level']}}}},
+            'global_time': 0.0}}
+
+    spec = CompositeSpec(
+        id='nested', name='nested', builder=builder, parameters={},
+        emitters=[{'address': 'local:RAMEmitter', 'paths': ['level']}])
+
+    state = spec.to_document()['state']
+    # The nested builder emitter is detected...
+    assert document_has_emitter(state, None)
+    # ...so no spurious top-level emitter is installed,
+    assert 'emitter' not in state
+    # and the builder's own configured node is untouched.
+    assert state['agents']['0']['emitter']['config']['a_builder_only_key'] == 123
+
+
 def test_installing_emitters_twice_yields_one_sink():
     """The shim and the dashboard also install; fixed keys mean a second
     install rewrites the same slot instead of adding a second sink."""


### PR DESCRIPTION
## Root cause

`build_composite("ecoli_baseline")` (v2ecoli) raised against process-bigraph `main`:

```
ValueError: ParquetEmitter requires either config['out_dir'] or config['out_uri']
```

Bisected to **#156 (`eaf99d7`, composite hardening Part A / A1)**. That PR made `CompositeSpec.to_document` install a spec's declared `emitters` unconditionally via a new `install_emitters`.

The mechanism is a **double-install**, not a clobber. v2ecoli's `baseline` builder places and configures its **own** emitter — a fully-built `ParquetEmitter` *instance* with a resolved `out_dir`, nested at `agents.<id>.emitter` — and uses the spec's `emitters` field only as the declaration its builder consumes. #156 then installs the *bare* declaration a second time at the top-level `emitter` key (config `{}`). bigraph-schema realizes that node with the ParquetEmitter schema defaults (`out_dir=''`) → the raise. Under pre-#156 pbg (`38c0d47`) `to_document` installed nothing extra, so only the builder's good nested emitter existed.

## Fix (in process-bigraph — this is a pbg regression)

The declared `emitters` are a **default** sink: apply them only when the built document observes nothing. `document_has_emitter` walks the built state recursively (so a nested agent sub-composite counts) and, when an emitter is already present — by built `instance`, by an address the core resolves to an `Emitter` subclass, or by an `*Emitter` class name — `to_document` skips the declaration. A pure-API spec whose builder installs no sink still gets its declared one (the gap #156 set out to close), and `install_emitters` itself is unchanged, so the dashboard's idempotent same-slot reinstall still holds.

Chose the pbg side because the v2ecoli builder already produces a correct, run-partitioned emitter; forcing v2ecoli to bake a static `out_dir` into the decorator declaration would drop the run-specific `out_dir`/preset the builder resolves and still leave a wrong duplicate.

## Verification

- New regression test `test_builder_installed_emitter_is_not_duplicated` — fails without this change, passes with it.
- Full pbg suite: **158 passed, 15 skipped**.
- v2ecoli against this branch: `ecoli_baseline` **builds and runs one tick**; `test_composite_run_one_sec_does_not_refire_loop` and `test_golden_monomer_names_in_output_metadata` now **pass**.

### Note on the third listed test
`test_parquet_emitter_ported::test_expected_failures` is **not** caused by this regression: it constructs a `ParquetEmitter` directly (never through `to_document`) and fails identically on pre-regression pbg (`38c0d47`) at line 1054 — a polars 1.43.0 behavior change (`pytest.raises(TypeError, ...)` no longer raises). It is out of scope for this fix and should be addressed separately as a polars-version issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)