### PR TITLE
fix(git): build a fetched repo's venv from its lockfile, not a re-resolve

### DIFF
--- a/process_bigraph/protocols/git.py
+++ b/process_bigraph/protocols/git.py
@@ -338,6 +338,26 @@ def _build_venv(repo_dir: pathlib.Path, venv_dir: pathlib.Path) -> pathlib.Path:
         subprocess.run([uv, 'venv', '--quiet', str(venv_dir)],
                        check=True,
                        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    # Honour the repo's own lockfile when it ships one. Re-resolving puts
+    # fetched code in an environment its authors never tested: for
+    # CovertLab/vEcoli that means scipy 1.18 where its lock pins 1.15.3 — and
+    # under 1.18 its ParCa cannot pickle the calibration object it just spent
+    # nine minutes fitting (`TypeError: cannot pickle 'module' object`). A
+    # pinned repo deserves its pinned dependencies; otherwise a fetched
+    # artifact is a function of *when* the venv was built, which is the
+    # opposite of what pinning a SHA is for.
+    if (repo_dir / 'uv.lock').is_file():
+        locked = subprocess.run(
+            [uv, 'sync', '--frozen', '--inexact', '--active'],
+            cwd=str(repo_dir),
+            env={**os.environ, 'VIRTUAL_ENV': str(venv_dir)},
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        if locked.returncode == 0:
+            stamp.write_text('ok')
+            return python
+        # A lockfile that will not sync is not fatal — fall through to a
+        # resolved install rather than refusing to run the repo at all.
     # Install the repo into its venv, **editable**. A wheel install ships only
     # what the repo declares as packages, which for a scientific repo is
     # routinely incomplete — CovertLab/vEcoli's wheel omits `ecoli.library`


### PR DESCRIPTION
Recovers Fable's lockfile fix (`d7fe168`, orphaned when #166 was squash-merged — cherry-picked here onto current main).

## Why this matters (the real root cause of the vEcoli pickle failures)
The `git:` protocol pins a repo **SHA**, but `_build_venv` did `uv pip install -e .`, which **re-resolves dependencies** — landing scipy 1.18.0 / numpy 2.4.6 instead of the scipy 1.15.3 / numpy 2.2.6 that CovertLab/vEcoli's own `uv.lock` (287 pkgs) pins. So a fetched artifact became a function of **when the venv was built**, not the pinned SHA — the opposite of reproducibility.

This single fact explained BOTH vEcoli ParCa failures:
- **read**: `ModuleNotFoundError: scipy._lib.array_api_compat` (July pickle written under ~1.15, read under 1.18)
- **write**: `TypeError: cannot pickle 'module' object` (sim_data built under 1.18 holds a module ref) — after 8.7 min of wasted fitting

## The fix
`_build_venv` now `uv sync --frozen` from the fetched repo's lockfile when present (→ 287 pkgs, scipy 1.15.3 / numpy 2.2.6, matching the lock); a lockfile that won't sync falls through to the resolved install rather than refusing to run the repo.

Verified: 208 tests pass. Pairs with the compute-in-venv ParCa work (v2ecoli #437) — computing in a **lockfile-frozen** venv is the actual structural cure for the stale-pickle failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)