### PR TITLE
chore: bump version 1.5.0 -> 1.6.0 (let downstreams adopt our changes)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "process-bigraph"
-version = "1.5.0"
+version = "1.6.0"
 description = "protocol and execution for compositional systems biology"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Every commit since 1.5.0 reported the same version string, so **uv cannot distinguish them** — `uv --upgrade-package process-bigraph` sees `1.5.0 == 1.5.0` and refuses to re-fetch the branch tip. That blocks downstream re-locks onto our merged work and masks compatibility in CI (a lock keeps "satisfying" 1.5.0 against a stale commit — the "CI illusion").

This minor bump reflects the additive features landed since 1.5.0 — `results` port + higher-order DAG + `SimulationStep`, the `git:` protocol, `CachedResults`/`trigger`/`artifacts`, on-disk template loading, typed `${name}` validation, the emitter-default fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)