### PR TITLE
Map-port whole-dict contract test + git-remote-protocol D1/D3 frozen-venv amendment

### DIFF
--- a/docs/superpowers/specs/2026-07-31-git-remote-protocol-design.md
+++ b/docs/superpowers/specs/2026-07-31-git-remote-protocol-design.md
@@ -35,6 +35,24 @@ Running fetched code (vEcoli pulls a large scientific stack) must not pollute or
 
 *Recommendation: (a). The edge is a thin RPC proxy over a subprocess running in the repo's own venv; the `interface()` it advertises is the face.*
 
+> **AMENDMENT 2026-07-31 (venv build must be frozen).** D1's "per-SHA `uv venv`,
+> install the repo" step MUST build the environment **`uv sync --frozen` from the
+> fetched repo's own lockfile** (`uv.lock`), NOT a re-resolving install
+> (`uv pip install -e .`). A re-resolving install picks whatever dep versions
+> resolve at *build time*, which can differ from the versions the repo was tested
+> against — so the built artifact becomes a function of when it was built, not of
+> the SHA, defeating the reproducibility D1/D3 exist to provide. This is not
+> hypothetical: re-resolving vEcoli's env landed an untested SciPy that broke
+> `scipy._lib.array_api_compat` and produced `cannot pickle 'module'` failures in
+> ParCa (root-caused and fixed in pbg #168 by pinning to the frozen lockfile).
+> - **Build rule:** `uv sync --frozen` from the repo's lockfile. Fall back to a
+>   resolved install (`uv pip install -e .` / `uv sync` without `--frozen`) **only
+>   when the fetched repo ships no lockfile**, and record that the env was
+>   resolved (not frozen) so a non-reproducible build is visible, not silent.
+> - **Record the build env by `sys.prefix`**, not `$VIRTUAL_ENV`: `sys.prefix`
+>   reports the interpreter's actual prefix even for a subprocess launched without
+>   activation (where `$VIRTUAL_ENV` is unset or stale).
+
 ### D2. Trust & security — *running foreign code*
 `git:` executes code from a URL.
 - **Allow-list of orgs/repos** in `workspace.yaml` (default: `CovertLab/vEcoli` + explicitly added forks); a `git:` address outside the list is refused, not run.
@@ -45,6 +63,19 @@ Running fetched code (vEcoli pulls a large scientific stack) must not pollute or
 ### D3. Caching & reproducibility
 - Cache key = `(repo, commit-SHA)`; the built venv is cached too (keyed by SHA + a lockfile hash). A pinned SHA is reproducible; a comparison investigation records the SHA in its artifacts.
 - GC/eviction of old checkouts is a workspace maintenance concern (out of scope v1; just don't unbounded-grow silently — log sizes).
+
+> **AMENDMENT 2026-07-31 (pin deps, not just the SHA).** Pinning the repo SHA
+> without pinning its dependency versions makes the fetched artifact a function of
+> *build time*, not of the SHA — the same SHA rebuilt a week later can resolve
+> different deps and behave differently, which is exactly the failure D3 is meant
+> to rule out. The venv MUST therefore be built **`uv sync --frozen` from the
+> fetched repo's lockfile** (see the D1 amendment for the concrete vEcoli/ParCa
+> failure this prevents, pbg #168), falling back to a resolved install only when
+> the repo has no lockfile — and recording that fallback so the loss of
+> reproducibility is explicit. The venv cache key already includes a lockfile
+> hash; the frozen-build rule is what makes that key meaningful (a resolved build
+> under the same key is not reproducible). Record the resolved build env by
+> `sys.prefix` (not `$VIRTUAL_ENV`) alongside the SHA in the comparison artifacts.
 
 ### D4. The entrypoint contract
 How does `git:` know *what* in the repo to run?

--- a/tests.py
+++ b/tests.py
@@ -5381,3 +5381,85 @@ def test_a_loaded_investigation_prunes_an_unfilled_member(tmp_path):
     sim.run(4.0)
     assert 'study_B' not in sim.state['investigation']
     assert sim.state['investigation']['study_A']['verdict'] == 'pass'
+
+
+# ==========================================
+# A Step's `map`-typed output port and whole-dict updates
+# ==========================================
+#
+# CONTRACT (characterization, not a to-be-fixed bug):
+#
+# A `map` / `map[<value>]` port is a *typed collection whose membership is
+# managed by structural sentinels* (`_add` / `_remove` / `_divide`). Those
+# sentinels are the ONLY signal that reaches the composite's structural
+# machinery (the reconcile sink flips `has_structural`, which drives
+# realize()/build_step_network so a new `map[process]` entry is instantiated
+# as a live Edge). A *bare* dict update is therefore a per-key VALUE update
+# against existing keys only — `apply(Map)` in bigraph-schema deliberately
+# skips keys not already present (commit 67108cb, "don't add keys into
+# state"). Auto-adding them would silently bypass structural detection, a
+# worse bug than the drop.
+#
+# Consequence for a Step that emits a whole opaque dict each tick:
+#   * type the port `map[...]` and return `{'_add': {...}}` for typed,
+#     structurally-tracked entries, OR
+#   * type the port `quote` to carry the dict opaquely (overwrite-wholesale).
+# Returning a bare dict on a `map` port updates only pre-existing keys; new
+# keys are dropped. These asserts lock all three behaviors so a future change
+# to Map semantics is caught here.
+
+
+def _run_map_port_step(out_type, ret, initial=None):
+    """One-tick Composite: a Step writes `ret` through a single output port
+    typed `out_type`, wired to a top-level store `result`. Returns the final
+    value at that store."""
+
+    class _MapPortStep(Step):
+        config_schema = {}
+
+        def inputs(self):
+            return {}
+
+        def outputs(self):
+            return {'result': out_type}
+
+        def update(self, state):
+            return {'result': ret}
+
+    core = allocate_core()
+    core.register_link('_MapPortStep', _MapPortStep)
+    composite = Composite({
+        'state': {
+            'result': {} if initial is None else initial,
+            'my_step': {
+                '_type': 'step', 'address': 'local:_MapPortStep',
+                'config': {}, 'inputs': {}, 'outputs': {'result': ['result']}},
+        }}, core=core)
+    composite.run(0.0)
+    return composite.state['result']
+
+
+def test_map_port_bare_dict_updates_only_existing_keys():
+    """A bare dict into an empty `map` drops NEW keys (by design — membership
+    goes through `_add`). Pre-existing keys ARE updated."""
+    # empty map + bare dict of new keys → nothing lands
+    assert _run_map_port_step('map[float]', {'a': 1.0, 'b': 2.0}) == {}
+    # pre-existing key present → its value updates through the value type's
+    # own apply (float apply is additive: 1.0 + 5.0 = 6.0); the unknown key
+    # still drops.
+    assert _run_map_port_step(
+        'map[float]', {'a': 5.0, 'new': 9.0}, initial={'a': 1.0}) == {'a': 6.0}
+
+
+def test_map_port_add_sentinel_lands_new_keys():
+    """The supported way to introduce new `map` entries: the `_add` sentinel,
+    which also flags a structural change to the scheduler."""
+    assert _run_map_port_step(
+        'map[float]', {'_add': {'a': 1.0, 'b': 2.0}}) == {'a': 1.0, 'b': 2.0}
+
+
+def test_quote_port_carries_an_opaque_whole_dict():
+    """For a Step that emits a whole opaque dict, `quote` is the correct port
+    type — the dict is set wholesale, no key-wise interpretation."""
+    payload = {'a': 1.0, 'b': 2.0, 'c': 3.0}
+    assert _run_map_port_step('quote', payload) == payload


### PR DESCRIPTION
Two small polish items on one branch, one commit each.

## 1. Map-typed output port silently drops a bare dict — root-caused as intended bigraph-schema behavior (no code fix)

**Finding:** A Step whose output port is typed \`map\` / \`map[<value>]\` and returns a bare dict has any *new* keys silently dropped. This is **not a process-bigraph bug** and **not a bigraph-schema bug to fix** — it is a deliberate bigraph-schema \`apply(Map)\` design decision.

- \`apply(Map)\` in bigraph-schema skips keys not already in state (\`if key not in state: continue\`), added explicitly in bigraph-schema commit \`67108cb\` titled *"don't add keys into state"* (R. Spangler, Dec 2025).
- Map **membership** changes go through the \`_add\` / \`_remove\` / \`_divide\` structural sentinels. Those sentinels are the *only* signal that flips the reconcile sink's \`has_structural\`, which drives the composite's \`realize()\` / \`build_step_network\` so a new \`map[process]\` entry is instantiated as a live Edge. A bare-dict add would bypass structural detection entirely — a **worse**, subtler bug than the drop.
- Therefore, for a Step emitting a whole opaque dict, **\`quote\` is the correct port type** (wholesale set, no key-wise interpretation) — which is exactly why the \`quote\` workaround worked. For typed, structurally-tracked entries, return \`{'_add': {...}}\`.

**Deliverable:** three characterization/regression tests that lock the contract (bare dict updates only existing keys via the value type's own apply; \`_add\` lands new keys; \`quote\` carries an opaque whole dict), so a future change to Map semantics is caught here.

Full suite green: **177 passed, 7 skipped** (was 174 + 3 new).

## 2. git-remote-protocol spec — D1/D3 amendment: build the per-SHA venv frozen from the lockfile

\`docs/superpowers/specs/2026-07-31-git-remote-protocol-design.md\` D1 (isolation) and D3 (caching/reproducibility) predate the finding that a fetched repo's venv must be built **\`uv sync --frozen\` from the repo's own lockfile**, not re-resolved (\`uv pip install -e .\`). Re-resolving picks build-time dep versions that can differ from what the repo was tested against, making the artifact a function of build time rather than the SHA — the exact failure D3 exists to prevent. This caused the vEcoli ParCa \`scipy._lib.array_api_compat\` / \`cannot pickle 'module'\` failures (fixed in pbg #168). Amendment: frozen build from the lockfile, resolved fallback only when no lockfile is present (recorded as such), and record the build env by \`sys.prefix\` (not \`\$VIRTUAL_ENV\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)