### PR TITLE
harden(git): a warm cache must be verifiable, not assumed

### DIFF
--- a/process_bigraph/protocols/git.py
+++ b/process_bigraph/protocols/git.py
@@ -44,8 +44,9 @@ import shutil
 import hashlib
 import pathlib
 import subprocess
+import warnings
 from dataclasses import dataclass, field, asdict
-from typing import Any, Dict, Optional, Callable
+from typing import Any, Dict, Optional, Callable, Tuple
 
 from bigraph_schema.schema import Protocol, String
 from bigraph_schema.methods import load_protocol
@@ -69,6 +70,13 @@ class AllowListError(GitProtocolError):
 class ConformanceError(GitProtocolError):
     """The resolved ``interface()`` does not admit the declared face
     (D5, contract 2)."""
+
+
+LOCKED = 'locked'
+"""Venv built from the repo's own ``uv.lock`` — dependencies are pinned."""
+
+RESOLVED = 'resolved'
+"""Venv built by re-resolving dependencies — **not** reproducible over time."""
 
 
 # ---------------------------------------------------------------------------
@@ -259,6 +267,13 @@ class Pin:
     ref: str
     sha: str
     resolved_at: float
+    #: The full 40-hex SHA the checkout actually landed on, filled in by
+    #: ``_checkout``. ``sha`` may be an abbreviated form the caller supplied
+    #: (``ls-remote`` cannot expand one without cloning), and an abbreviated
+    #: pin is not a reproducible pin: it aliases the per-SHA cache, so the
+    #: same commit fetched twice under two spellings gets two directories.
+    #: Defaulted so pins written before this field still load.
+    resolved_sha: str = ''
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -304,6 +319,9 @@ class Materialized:
     pin: Pin
     repo_dir: pathlib.Path
     venv_python: pathlib.Path
+    #: :data:`LOCKED` or :data:`RESOLVED` — how the venv's dependencies were
+    #: chosen. Record it in any manifest that claims this run is reproducible.
+    install_mode: str = RESOLVED
 
 
 def _uv() -> str:
@@ -315,23 +333,64 @@ def _uv() -> str:
     return uv
 
 
-def _checkout(address: GitAddress, pin: Pin, repo_dir: pathlib.Path) -> None:
+def _head_sha(repo_dir: pathlib.Path) -> str:
+    return _run_git(['rev-parse', 'HEAD'], cwd=str(repo_dir)).strip()
+
+
+def _checkout(address: GitAddress, pin: Pin, repo_dir: pathlib.Path) -> str:
+    """Check the pinned commit out, and return the full SHA it landed on.
+
+    A warm cache is **verified**, not assumed. The per-SHA directory existing
+    is not evidence that the code in it is the pinned commit: an interrupted
+    clone, a manual `git checkout` in the cache, or an abbreviated pin that
+    aliased two commits onto one directory all leave a `.git` behind at the
+    wrong revision. Silently running that is the worst failure this protocol
+    can have — the whole point of a SHA is that the code is known.
+    """
     if (repo_dir / '.git').exists():
-        return
+        head = _head_sha(repo_dir)
+        if not head.startswith(pin.sha):
+            raise GitProtocolError(
+                f'cached checkout of {address.repo_slug} at {repo_dir} is on '
+                f'{head}, not the pinned {pin.sha}. Refusing to run code that '
+                f'is not the pinned commit — delete that directory to '
+                f're-fetch.')
+        return head
+
     repo_dir.parent.mkdir(parents=True, exist_ok=True)
     # Full clone then checkout the pinned SHA — robust across servers that
     # don't allow fetching arbitrary SHAs directly. Repos are cached per-SHA
     # so this is paid once.
     _run_git(['clone', '--quiet', pin.url, str(repo_dir)])
     _run_git(['checkout', '--quiet', pin.sha], cwd=str(repo_dir))
+    return _head_sha(repo_dir)
 
 
-def _build_venv(repo_dir: pathlib.Path, venv_dir: pathlib.Path) -> pathlib.Path:
-    """``uv venv`` + install the repo into it. Returns the venv python path."""
+def _read_stamp(stamp: pathlib.Path) -> dict:
+    """The recorded build mode, tolerating the pre-provenance ``ok`` stamp."""
+    try:
+        record = json.loads(stamp.read_text())
+    except (OSError, ValueError):
+        return {'mode': RESOLVED, 'legacy': True}
+    return record if isinstance(record, dict) else {
+        'mode': RESOLVED, 'legacy': True}
+
+
+def _build_venv(repo_dir: pathlib.Path,
+                venv_dir: pathlib.Path) -> Tuple[pathlib.Path, str]:
+    """``uv venv`` + install the repo into it.
+
+    Returns ``(venv_python, mode)`` where mode is :data:`LOCKED` or
+    :data:`RESOLVED`. **The mode is part of the result, not a detail.** A venv
+    built from a lockfile and one built by re-resolving are different
+    environments, and a warm cache cannot tell them apart from the filesystem
+    alone — so the mode is recorded in the stamp and reported back, and a
+    caller that needs reproducibility can refuse a ``resolved`` one.
+    """
     python = venv_dir / 'bin' / 'python'
     stamp = venv_dir / '.pbg-installed'
     if stamp.exists() and python.exists():
-        return python
+        return python, _read_stamp(stamp).get('mode', RESOLVED)
 
     uv = _uv()
     if not python.exists():
@@ -354,10 +413,20 @@ def _build_venv(repo_dir: pathlib.Path, venv_dir: pathlib.Path) -> pathlib.Path:
             env={**os.environ, 'VIRTUAL_ENV': str(venv_dir)},
             stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
         if locked.returncode == 0:
-            stamp.write_text('ok')
-            return python
+            stamp.write_text(json.dumps({'mode': LOCKED}))
+            return python, LOCKED
         # A lockfile that will not sync is not fatal — fall through to a
-        # resolved install rather than refusing to run the repo at all.
+        # resolved install rather than refusing to run the repo at all. But
+        # say so: this is the exact silent degradation the lockfile exists to
+        # prevent, and it is about to be cached under a stamp that a warm run
+        # will never question.
+        warnings.warn(
+            f'{repo_dir.name}: `uv sync --frozen` failed, falling back to a '
+            f'RESOLVED install — this environment is not the one the repo '
+            f'pins, and results from it are a function of when the venv was '
+            f'built. uv said: {(locked.stderr or "").strip()[:400]}',
+            RuntimeWarning,
+            stacklevel=2)
     # Install the repo into its venv, **editable**. A wheel install ships only
     # what the repo declares as packages, which for a scientific repo is
     # routinely incomplete — CovertLab/vEcoli's wheel omits `ecoli.library`
@@ -373,8 +442,8 @@ def _build_venv(repo_dir: pathlib.Path, venv_dir: pathlib.Path) -> pathlib.Path:
         raise GitProtocolError(
             f'failed to install repo into venv (uv pip install .): '
             f'{result.stderr.strip()}')
-    stamp.write_text('ok')
-    return python
+    stamp.write_text(json.dumps({'mode': RESOLVED}))
+    return python, RESOLVED
 
 
 def materialize(address: GitAddress) -> Materialized:
@@ -383,13 +452,20 @@ def materialize(address: GitAddress) -> Materialized:
     sha_dir = _sha_dir(address, pin.sha)
     repo_dir = sha_dir / 'repo'
     venv_dir = sha_dir / 'venv'
-    _checkout(address, pin, repo_dir)
-    venv_python = _build_venv(repo_dir, venv_dir)
+    head = _checkout(address, pin, repo_dir)
+    if head and pin.resolved_sha != head:
+        # Only knowable after a checkout: `ls-remote` cannot expand an
+        # abbreviated SHA. Record the full one so a manifest names the commit
+        # unambiguously even when the address gave a short form.
+        pin.resolved_sha = head
+        (sha_dir / 'pin.json').write_text(json.dumps(pin.to_dict(), indent=2))
+    venv_python, install_mode = _build_venv(repo_dir, venv_dir)
     return Materialized(
         address=address,
         pin=pin,
         repo_dir=repo_dir,
-        venv_python=venv_python)
+        venv_python=venv_python,
+        install_mode=install_mode)
 
 
 # ---------------------------------------------------------------------------

--- a/process_bigraph/tests/test_git_protocol.py
+++ b/process_bigraph/tests/test_git_protocol.py
@@ -329,3 +329,85 @@ def test_conformance_names_mismatch_direction(resolved_edge_factory):
     ok, reason = conforms(core, edge, declared)
     assert not ok
     assert 'input port' in reason and "'value'" in reason
+
+
+# ---------------------------------------------------------------------------
+# Environment provenance (D3) — a warm cache must be verifiable, not assumed
+# ---------------------------------------------------------------------------
+
+def test_materialize_reports_how_the_venv_was_built(
+        clean_registry, cache_dir, fixture_repo):
+    """`install_mode` is part of the result.
+
+    The fixture ships no `uv.lock`, so it must come back RESOLVED. A caller
+    that claims reproducibility has to be able to tell that apart from a
+    lockfile-frozen build, and the filesystem alone cannot say.
+    """
+    url, branch, sha = fixture_repo
+    gitproto.add_allowed_repo(SLUG)
+    gitproto.set_repo_url(SLUG, url)
+    addr = parse_git_address(f'{SLUG}@{branch}#pbgfixture:make_process')
+
+    materialized = gitproto.materialize(addr)
+    assert materialized.install_mode == gitproto.RESOLVED
+
+    # And it survives the warm-cache path, which is the case that matters:
+    # a second run must not forget how the first one built the environment.
+    assert gitproto.materialize(addr).install_mode == gitproto.RESOLVED
+
+
+def test_pin_records_the_full_sha(clean_registry, cache_dir, fixture_repo):
+    """An abbreviated address still yields an unambiguous recorded commit."""
+    url, branch, sha = fixture_repo
+    gitproto.add_allowed_repo(SLUG)
+    gitproto.set_repo_url(SLUG, url)
+    addr = parse_git_address(f'{SLUG}@{sha[:8]}#pbgfixture:make_process')
+
+    materialized = gitproto.materialize(addr)
+    assert materialized.pin.resolved_sha == sha
+    # ...and it is persisted, not just returned.
+    pin_file = cache_dir / 'pbgtest__fixture' / sha[:8] / 'pin.json'
+    assert json.loads(pin_file.read_text())['resolved_sha'] == sha
+
+
+def test_checkout_at_the_wrong_commit_is_refused(
+        clean_registry, cache_dir, fixture_repo):
+    """A cached checkout is verified against the pin, not trusted.
+
+    An interrupted clone or a stray `git checkout` in the cache leaves a
+    `.git` behind at the wrong revision. Running it would silently execute
+    code that is not the pinned commit — the one thing a SHA is supposed to
+    rule out.
+    """
+    url, branch, sha = fixture_repo
+    gitproto.add_allowed_repo(SLUG)
+    gitproto.set_repo_url(SLUG, url)
+    addr = parse_git_address(f'{SLUG}@{branch}#pbgfixture:make_process')
+    gitproto.materialize(addr)
+
+    # Add a commit in the cached checkout so HEAD no longer matches the pin.
+    repo_dir = cache_dir / 'pbgtest__fixture' / sha / 'repo'
+    (repo_dir / 'intruder.txt').write_text('not the pinned commit')
+    _git(['add', '.'], repo_dir)
+    _git(['commit', '--quiet', '-m', 'drift'], repo_dir)
+
+    with pytest.raises(GitProtocolError) as excinfo:
+        gitproto.materialize(addr)
+    assert 'not the pinned' in str(excinfo.value)
+
+
+def test_legacy_ok_stamp_still_loads(clean_registry, cache_dir, fixture_repo):
+    """Venvs stamped before provenance existed read back as RESOLVED.
+
+    They were built by whatever path was current then, so `resolved` is the
+    honest answer — the conservative one, never a false `locked`.
+    """
+    url, branch, sha = fixture_repo
+    gitproto.add_allowed_repo(SLUG)
+    gitproto.set_repo_url(SLUG, url)
+    addr = parse_git_address(f'{SLUG}@{branch}#pbgfixture:make_process')
+    gitproto.materialize(addr)
+
+    stamp = cache_dir / 'pbgtest__fixture' / sha / 'venv' / '.pbg-installed'
+    stamp.write_text('ok')  # the pre-provenance format
+    assert gitproto.materialize(addr).install_mode == gitproto.RESOLVED

--- a/process_bigraph/tests/test_git_protocol.py
+++ b/process_bigraph/tests/test_git_protocol.py
@@ -84,8 +84,13 @@ SLUG = 'pbgtest/fixture'
 
 
 def _git(args, cwd):
+    # Inject an identity on every call: some commits happen in a *fetched*
+    # checkout (not the fixture repo), which carries no user.name/user.email —
+    # locally git falls back to the dev's global config, but CI has none, so a
+    # bare `git commit` there fails with exit 128 ("please tell me who you are").
     subprocess.run(
-        ['git', *args], cwd=cwd, check=True,
+        ['git', '-c', 'user.email=test@example.com', '-c', 'user.name=pbg test',
+         *args], cwd=cwd, check=True,
         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
 


### PR DESCRIPTION
Three ways the `git:` protocol could serve a run that was not what it claimed — all silent, all only visible on a **warm** cache.

### 1. The lockfile fallback left no trace
When `uv sync --frozen` failed we fell through to a re-resolved install and stamped the venv `ok` — byte-identical to a locked build. The degradation #168 was written to prevent became permanent and invisible: one failed sync and every later run reuses the wrong environment forever, with no signal.

Now: the stamp records the mode, `materialize()` returns it as `Materialized.install_mode` (`LOCKED` / `RESOLVED`), and the fallback warns with uv's actual stderr instead of discarding it.

### 2. A cached checkout was trusted on sight
`_checkout` returned early whenever `.git` existed, without asking what commit was there. An interrupted clone or a stray `git checkout` in the cache meant running code that is not the pinned commit — the one thing a SHA is supposed to rule out. Now verified against the pin; refuses otherwise.

### 3. An abbreviated SHA was recorded as the pin
`ls-remote` cannot expand one, so a short ref went straight into the cache key *and* the pin — the same commit under two spellings got two cache directories. `Pin.resolved_sha` now records the full 40-hex SHA read back from the checkout.

### Compatibility
- `Pin.resolved_sha` is defaulted, so pins written before this field still load.
- Pre-provenance `ok` stamps read back as `resolved` — the honest answer for a venv built by whatever path was current then, and never a false `locked`.
- `_build_venv` now returns `(python, mode)`; it is module-private.

### Tests
23 in `test_git_protocol.py` (4 new, all against the existing real local-git fixture), **216 passing** overall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)