### PR TITLE
harden(artifacts): pin the address, wire the determinism check, expose the version

### DIFF
--- a/process_bigraph/__init__.py
+++ b/process_bigraph/__init__.py
@@ -1,5 +1,21 @@
 from bigraph_schema import allocate_core  # noqa: F401
 
+# The installed distribution's version, exposed so a run manifest can record
+# *which* engine produced an artifact. Read from installed metadata rather
+# than hardcoded, so the two can never disagree — and note the trap that
+# makes it worth a test: an editable install freezes this at install time, so
+# every later commit reports the version that was in `pyproject.toml` when
+# `pip install -e` ran. `tests.py::test_version_matches_pyproject` fails
+# loudly when they drift instead of letting a manifest lie.
+try:
+    from importlib.metadata import PackageNotFoundError, version as _version
+    try:
+        __version__ = _version('process-bigraph')
+    except PackageNotFoundError:      # not installed (running from a tree)
+        __version__ = '0+unknown'
+except ImportError:                   # pragma: no cover — py<3.8
+    __version__ = '0+unknown'
+
 from process_bigraph.composite import (  # noqa: F401
     Process, Step, Composite, TimingSummary, interval_time_precision, wire_step_layers,
 )

--- a/process_bigraph/artifacts.py
+++ b/process_bigraph/artifacts.py
@@ -73,6 +73,41 @@ def artifact_exists(address: str, root: str = ARTIFACT_ROOT) -> bool:
     return os.path.isdir(artifact_store(address, root))
 
 
+FINGERPRINT_FILE = 'fingerprint'
+"""Where a stored artifact records what it produced, next to the payload."""
+
+
+def write_fingerprint(address: str, value: str,
+                      root: str = ARTIFACT_ROOT) -> str:
+    """Record an artifact's fingerprint in its store entry.
+
+    Producers call this after writing the payload. Without it the address is
+    the *only* thing a cache hit is checked against — and an address is a hash
+    of inputs, which says what *should* come out, never what did.
+    """
+    store = artifact_store(address, root)
+    os.makedirs(store, exist_ok=True)
+    path = os.path.join(store, FINGERPRINT_FILE)
+    with open(path, 'w', encoding='utf-8') as handle:
+        handle.write(value)
+    return path
+
+
+def read_fingerprint(address: str, root: str = ARTIFACT_ROOT) -> str:
+    """The recorded fingerprint, or '' when the producer wrote none.
+
+    Absent is not a failure: artifacts stored before fingerprinting, and
+    producers that opt out, simply cannot be checked — and
+    :func:`check_fingerprint` treats an empty stored value as "no claim".
+    """
+    try:
+        with open(os.path.join(artifact_store(address, root),
+                               FINGERPRINT_FILE), encoding='utf-8') as handle:
+            return handle.read().strip()
+    except OSError:
+        return ''
+
+
 # ── typed references ────────────────────────────────────────────────
 
 TRAJECTORY = 'trajectory'
@@ -245,10 +280,7 @@ def check_fingerprint(results, observed: str) -> str:
     """
     stored = getattr(getattr(results, 'ref', None), 'fingerprint', '')
     status = 'ok' if (not stored or stored == observed) else 'nondeterministic'
-    try:
-        results.provenance_status = status
-    except AttributeError:
-        pass
+    results.provenance_status = status
     return status
 
 

--- a/process_bigraph/templates.py
+++ b/process_bigraph/templates.py
@@ -250,20 +250,36 @@ def study_ancestors(document, target):
     return order
 
 
-def study_address(document, name, *, commit=''):
+def study_address(document, name, *, commit='', _visiting=None):
     """The content address of a member's artifact.
 
     A function of the member's id, its config, its inputs' addresses and the
     workspace commit — so it is worktree-independent and an upstream change
     invalidates everything downstream of it.
+
+    A cyclic ``inputs`` graph is named, not recursed into: an address is only
+    well-defined on a DAG, and without this the recursion bottoms out in a
+    ``RecursionError`` that says nothing about which studies form the loop.
     """
     from process_bigraph.artifacts import artifact_id
 
     members = study_members(document)
+    if name not in members:
+        raise KeyError(
+            f'no study {name!r} in the document — members are '
+            f'{sorted(members)}')
     region = members[name]
 
+    visiting = _visiting or ()
+    if name in visiting:
+        loop = ' -> '.join([*visiting[visiting.index(name):], name])
+        raise ValueError(
+            f'cyclic study inputs: {loop}. A content address is only defined '
+            f'on a DAG — a study cannot be an input to itself.')
+
     input_ids = [
-        study_address(document, edge['from'], commit=commit)
+        study_address(document, edge['from'], commit=commit,
+                      _visiting=(*visiting, name))
         for edge in (_meta(region, 'inputs', []) or [])
         if edge.get('from') in members]
 
@@ -305,7 +321,8 @@ def trigger(document, target, *, on_missing='error', commit='',
     ``{'target', 'pulled', 'computed', 'pruned'}``.
     """
     from process_bigraph.artifacts import (
-        ARTIFACT_ROOT, ArtifactRef, artifact_exists, artifact_store)
+        ARTIFACT_ROOT, ArtifactRef, artifact_exists, artifact_store,
+        read_fingerprint)
 
     if on_missing not in ('error', 'compute'):
         raise ValueError(
@@ -322,11 +339,16 @@ def trigger(document, target, *, on_missing='error', commit='',
     for name in ancestors:
         address = study_address(document, name, commit=commit)
         if artifact_exists(address, root):
+            # Carry the recorded fingerprint onto the ref. Without it
+            # `check_fingerprint` has nothing to compare against and the
+            # determinism check is inert on the one path it exists for —
+            # a pulled artifact being served in place of a recompute.
             ref = ArtifactRef(
                 kind=_meta(members[name], 'kind', 'trajectory'),
                 hash=address,
                 store=artifact_store(address, root),
-                context={'study': name})
+                context={'study': name},
+                fingerprint=read_fingerprint(address, root))
             built[name][sim_key] = cached_node(ref.to_dict())
             pulled.append(name)
         elif on_missing == 'compute':

--- a/tests.py
+++ b/tests.py
@@ -5463,3 +5463,227 @@ def test_quote_port_carries_an_opaque_whole_dict():
     type — the dict is set wholesale, no key-wise interpretation."""
     payload = {'a': 1.0, 'b': 2.0, 'c': 3.0}
     assert _run_map_port_step('quote', payload) == payload
+
+
+# ==========================================
+# Reproducibility guards
+# ==========================================
+#
+# The content address is a *wire format*. Every artifact already in every
+# store was placed by the current formula, so a change to it is not a
+# refactor — it silently orphans every cached result and every lookup misses.
+# And the formula is duplicated: process-bigraph cannot import the workbench
+# (the dependency runs the other way), so
+# `vivarium_workbench/lib/artifacts/hashing.py` is a hand-port of this one.
+#
+# Golden vectors are what make that duplication safe. The workbench asserts
+# the SAME constants against ITS copy, so the two cannot drift apart without
+# a suite going red — including the case where a same-shape edit is applied
+# to both sides and would otherwise hide.
+
+GOLDEN_ADDRESSES = [
+    # (composite_id, config, input_ids, commit) -> address
+    (('study', {}, [], ''), '78ae3a35a0fe5f89'),
+    (('study', {'seed': 0}, [], 'abc123'), '5c4c0be0af218633'),
+    # input order must not matter: input_ids are sorted before hashing
+    (('study', {'seed': 0}, ['bbb', 'aaa'], 'abc123'), '365bd943a78cd82f'),
+    (('study', {'seed': 0}, ['aaa', 'bbb'], 'abc123'), '365bd943a78cd82f'),
+    # key order must not matter: canonical() sorts keys
+    (('study', {'b': 2, 'a': 1}, [], ''), 'a70c18c5c80eb729'),
+    (('study', {'a': 1, 'b': 2}, [], ''), 'a70c18c5c80eb729'),
+]
+
+
+def test_artifact_id_golden_vectors():
+    """Pin the address wire format against fixed constants.
+
+    Changing the formula orphans every artifact in every store. If this test
+    fails, that is the question to answer — not a number to update.
+    """
+    from process_bigraph.artifacts import artifact_id
+
+    for (composite_id, config, input_ids, commit), expected in (
+            GOLDEN_ADDRESSES):
+        assert artifact_id(
+            composite_id=composite_id, config=config,
+            input_ids=input_ids, commit=commit) == expected, (
+            f'address formula changed for {composite_id!r}/{config!r}')
+
+
+def test_canonical_json_is_stable():
+    """The encoding the address is computed over: sorted keys, no
+    whitespace."""
+    from process_bigraph.artifacts import canonical
+
+    assert canonical({'b': 2, 'a': 1}) == '{"a":1,"b":2}'
+    assert canonical({}) == '{}'
+    assert canonical(None) == '{}'
+    assert canonical({'rate': 0.5}) == '{"rate":0.5}'
+
+
+def test_int_and_whole_float_are_DIFFERENT_addresses():
+    """A known hazard, pinned so it stays visible.
+
+    `canonical` passes `_stable` as json's `default=` hook, which reads as
+    "narrow whole floats to ints so 1 and 1.0 address the same". It does not
+    do that: `default=` is consulted only for types json *cannot* serialize,
+    and a float is serializable, so `_stable` never sees one. The narrowing
+    has never happened.
+
+    The consequence is real: a config carrying `seed: 1` from YAML and
+    `seed: 1.0` after a float-typed parameter pass addresses two different
+    artifacts for the same study — a silent cache miss and a duplicate
+    recompute, in both this copy and the workbench's.
+
+    This test asserts the CURRENT behaviour on purpose. Fixing it is a wire
+    format change that orphans every stored artifact, so it needs a
+    migration, not a patch.
+    """
+    from process_bigraph.artifacts import artifact_id, canonical
+
+    assert canonical({'seed': 1.0}) != canonical({'seed': 1})
+    assert (artifact_id(composite_id='s', config={'seed': 1.0},
+                        input_ids=[], commit='')
+            != artifact_id(composite_id='s', config={'seed': 1},
+                           input_ids=[], commit=''))
+
+
+def test_artifact_id_is_sensitive_to_every_input():
+    """Each component of the address actually participates in it."""
+    from process_bigraph.artifacts import artifact_id
+
+    base = dict(composite_id='s', config={'seed': 0}, input_ids=['x'],
+                commit='c0')
+    addresses = {
+        artifact_id(**base),
+        artifact_id(**{**base, 'composite_id': 't'}),
+        artifact_id(**{**base, 'config': {'seed': 1}}),
+        artifact_id(**{**base, 'input_ids': ['y']}),
+        artifact_id(**{**base, 'commit': 'c1'})}
+    assert len(addresses) == 5, 'an input does not affect the address'
+
+
+def test_version_matches_pyproject():
+    """`__version__` must be the version the package actually declares.
+
+    This is the guard for the trap that every commit reports the same
+    version: an editable install freezes the metadata at install time, so a
+    `pyproject.toml` bump is invisible to `importlib.metadata` until someone
+    reinstalls — and a manifest recording "produced by pbg X" then lies.
+    Failing here means reinstall, not edit the test.
+    """
+    import re
+    from pathlib import Path
+
+    import process_bigraph
+
+    pyproject = Path(process_bigraph.__file__).parent.parent / 'pyproject.toml'
+    if not pyproject.is_file():
+        pytest.skip('not running from a source checkout')
+
+    declared = re.search(
+        r'^version\s*=\s*["\']([^"\']+)["\']',
+        pyproject.read_text(), re.MULTILINE)
+    assert declared, 'no version in pyproject.toml'
+    assert process_bigraph.__version__ == declared.group(1), (
+        f'process_bigraph.__version__ is {process_bigraph.__version__!r} but '
+        f'pyproject.toml declares {declared.group(1)!r} — reinstall the '
+        f'package (`uv pip install -e .`) so the recorded version is real.')
+
+
+def _pull_document():
+    """A two-member investigation: `down` consumes `up`."""
+    return {
+        'up': {'_study': {'id': 'up', 'config': {}, 'inputs': [],
+                          'kind': 'sim_data'},
+               'sim': {}, 'results': {}},
+        'down': {'_study': {'id': 'down', 'config': {},
+                            'inputs': [{'artifact': 'a', 'from': 'up'}],
+                            'kind': 'trajectory'},
+                 'sim': {}, 'results': {}}}
+
+
+def test_a_pulled_artifact_carries_its_fingerprint(tmp_path):
+    """`trigger` must load the stored fingerprint onto the ref it binds.
+
+    Without this the determinism check is inert on the exact path it exists
+    for: `check_fingerprint` compares against `ref.fingerprint`, and a pulled
+    ref whose fingerprint is blank always reports 'ok'.
+    """
+    from process_bigraph.artifacts import (
+        ArtifactResults, artifact_store, check_fingerprint, fingerprint_of,
+        write_fingerprint)
+    from process_bigraph.templates import study_address, trigger
+
+    document = _pull_document()
+    root = str(tmp_path / 'store')
+    address = study_address(document, 'up')
+    os.makedirs(artifact_store(address, root), exist_ok=True)
+    stored = fingerprint_of({'mass': 10.0})
+    write_fingerprint(address, stored, root)
+
+    built, report = trigger(document, 'down', root=root)
+    assert report['pulled'] == ['up']
+
+    ref = built['up']['sim']['config']['artifact_ref']
+    assert ref['fingerprint'] == stored
+
+    # ...and it is live: a divergent recompute is now catchable
+    handle = ArtifactResults(ref)
+    assert check_fingerprint(handle, stored) == 'ok'
+    assert check_fingerprint(
+        handle, fingerprint_of({'mass': 99.0})) == 'nondeterministic'
+    assert handle.provenance_status == 'nondeterministic'
+
+
+def test_missing_fingerprint_is_no_claim_not_a_failure(tmp_path):
+    """Artifacts stored before fingerprinting must still pull, unchecked."""
+    from process_bigraph.artifacts import artifact_store, read_fingerprint
+    from process_bigraph.templates import study_address, trigger
+
+    document = _pull_document()
+    root = str(tmp_path / 'store')
+    address = study_address(document, 'up')
+    os.makedirs(artifact_store(address, root), exist_ok=True)
+
+    assert read_fingerprint(address, root) == ''
+    built, report = trigger(document, 'down', root=root)
+    assert report['pulled'] == ['up']
+    assert built['up']['sim']['config']['artifact_ref']['fingerprint'] == ''
+
+
+def test_fingerprint_round_trips_through_the_store(tmp_path):
+    from process_bigraph.artifacts import (
+        fingerprint_of, read_fingerprint, write_fingerprint)
+
+    root = str(tmp_path / 'store')
+    value = fingerprint_of({'mass': 3.0})
+    write_fingerprint('deadbeefdeadbeef', value, root)
+    assert read_fingerprint('deadbeefdeadbeef', root) == value
+    assert read_fingerprint('0000000000000000', root) == ''
+
+
+def test_cyclic_study_inputs_are_named_not_recursed():
+    """A content address is only defined on a DAG. A cycle used to bottom out
+    in a RecursionError that named none of the studies in the loop."""
+    from process_bigraph.templates import study_address
+
+    document = {
+        'a': {'_study': {'id': 'a', 'config': {},
+                         'inputs': [{'artifact': 'r', 'from': 'b'}],
+                         'kind': 'trajectory'}},
+        'b': {'_study': {'id': 'b', 'config': {},
+                         'inputs': [{'artifact': 'r', 'from': 'a'}],
+                         'kind': 'trajectory'}}}
+
+    with pytest.raises(ValueError) as excinfo:
+        study_address(document, 'a')
+    message = str(excinfo.value)
+    assert 'cyclic' in message and 'a -> b -> a' in message
+
+
+def test_study_address_names_an_unknown_member():
+    from process_bigraph.templates import study_address
+
+    with pytest.raises(KeyError):
+        study_address(_pull_document(), 'nope')


### PR DESCRIPTION
Three places where a reproducibility guarantee existed in prose but nothing enforced it.

### The determinism check was inert
`fingerprint_of` / `check_fingerprint` were called from **nothing but their own unit test**. `trigger` built the `ArtifactRef` for a pulled artifact with no `fingerprint` at all, and `check_fingerprint` treats a blank stored value as "no claim" — so on the one path the check exists for (a pulled artifact served instead of a recompute) it could only ever answer `ok`.

Added the store convention (`write_fingerprint` / `read_fingerprint` — a `fingerprint` file beside the payload) and taught `trigger` to load it onto the ref. Producers opt in; artifacts stored before this still pull, just unchecked.

### The address wire format was unpinned
Every artifact in every store was placed by the current formula, and the formula is hand-duplicated into `vivarium_workbench/lib/artifacts/hashing.py`. **Golden vectors** now pin it to fixed constants. The workbench asserts the *same* constants against its copy (follow-up PR), so the two cannot drift without a suite going red — including the case where a same-shape edit is applied to both sides, which a "compare the two implementations" test would miss.

### The version was unreadable
There was no `process_bigraph.__version__` at all, so nothing could record which engine produced an artifact. Added it from installed metadata, plus a guard for the trap it invites: an editable install freezes that metadata at install time, so a `pyproject` bump stays invisible until someone reinstalls — and a manifest recording "produced by pbg X" quietly lies. The test fails loudly on drift.

### Also
- `study_address` names a cycle instead of bottoming out in a `RecursionError` that identified none of the studies in the loop.
- `check_fingerprint` no longer swallows `AttributeError` while recording the status it just computed.

### ⚠️ Found, not fixed — needs your call
`test_int_and_whole_float_are_DIFFERENT_addresses` pins a **latent bug**. `canonical`'s `_stable` hook advertises narrowing whole floats to ints so `seed: 1` and `seed: 1.0` address the same artifact. **It has never done that**: json's `default=` is consulted only for types it *cannot* serialize, and a float is serializable, so `_stable` never sees one.

So a config carrying `seed: 1` from YAML and `seed: 1.0` after a float-typed parameter pass addresses two different artifacts for the same study — a silent cache miss and a duplicate recompute, in **both** copies. The test asserts the current behaviour on purpose: fixing it is a wire-format change that orphans every stored artifact, so it needs a migration, not a patch.

### Tests
**222 passing**, 15 skipped (10 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)