### PR TITLE
harden(spec): "unknown type" and "broken checker" are not the same answer

### DIFF
--- a/process_bigraph/composite_spec.py
+++ b/process_bigraph/composite_spec.py
@@ -163,13 +163,22 @@ def _coerce(value, declared_type, name=None, core=None):
     coerced = _cast(value, declared_type)
 
     # Final guarantee: the coerced value really is of the declared type.
-    # An unrecognized declared type (a workspace type, say) is left alone.
-    try:
-        valid = _validation_core(core).check(declared, coerced)
-    except Exception:
+    #
+    # An unrecognized declared type (a workspace type this core does not
+    # define) is left alone — but *asked about* rather than discovered by
+    # catching whatever `check` throws. A blanket `except Exception: return
+    # coerced` here made "this core doesn't know that type" and "the type
+    # checker itself broke" the same outcome: the value passed through
+    # unvalidated either way, so a genuine bug in `check` silently disabled
+    # parameter validation for every spec. `access` answers the question
+    # directly — it hands back a schema for a type it knows and the bare
+    # string for one it doesn't — and any failure inside `check` now
+    # propagates instead of being read as permission.
+    validation_core = _validation_core(core)
+    if isinstance(validation_core.access(declared), str):
         return coerced
 
-    if not valid:
+    if not validation_core.check(declared, coerced):
         _reject(name, declared, value,
                 f"resolved to {coerced!r}, which is not a valid {declared}")
 

--- a/process_bigraph/tests/test_composite_spec.py
+++ b/process_bigraph/tests/test_composite_spec.py
@@ -228,3 +228,46 @@ def test_top_level_exports():
     assert hasattr(pbg, "CompositeSpec")
     assert hasattr(pbg, "composite_spec")      # the decorator
     assert hasattr(pbg, "discover_specs")
+
+
+# ---------------------------------------------------------------------------
+# Typed parameter validation: "unknown type" and "broken checker" are not
+# the same answer
+# ---------------------------------------------------------------------------
+
+def test_unknown_declared_type_passes_through_unvalidated():
+    """A workspace type this core does not define is not ours to judge."""
+    from process_bigraph.composite_spec import _coerce
+
+    assert _coerce({'a': 1}, 'some_workspace_type', name='p') == {'a': 1}
+
+
+def test_known_declared_type_is_still_enforced():
+    from process_bigraph.composite_spec import _coerce
+
+    assert _coerce('2.5', 'float', name='rate') == 2.5
+    with pytest.raises(Exception):
+        _coerce('not-a-number', 'float', name='rate')
+
+
+def test_a_broken_type_checker_is_not_read_as_permission():
+    """The regression this guards.
+
+    `_coerce` used to wrap the final `core.check` in a blanket
+    `except Exception: return coerced`. That made "this core doesn't know
+    that type" and "the type checker itself broke" the same outcome — the
+    value passed through unvalidated either way — so a genuine bug in
+    `check` would silently disable parameter validation for every spec
+    while every test still passed.
+    """
+    from process_bigraph.composite_spec import _coerce, _validation_core
+
+    class BrokenCore:
+        def access(self, declared):
+            return _validation_core(None).access(declared)
+
+        def check(self, declared, value):
+            raise RuntimeError('the type checker is broken')
+
+    with pytest.raises(RuntimeError, match='type checker is broken'):
+        _coerce(1.0, 'float', name='rate', core=BrokenCore())


### PR DESCRIPTION
`_coerce` finished typed parameter validation with:

```python
try:
    valid = _validation_core(core).check(declared, coerced)
except Exception:
    return coerced
```

The intent was to leave an unrecognized *workspace* type alone. The effect was much broader: **any** failure inside `check` — including a real bug in it — returned the value as though it had been validated.

So a bug in the type checker would silently disable parameter validation for every spec in every workspace, and every test would still pass, because the swallowed path and the success path are indistinguishable from outside. That is the worst shape a `try/except` can have: it converts a loud failure into a quiet loss of a guarantee.

### The fix
Ask the question directly. `core.access` hands back a schema for a type it knows and the bare string for one it doesn't — exactly the discriminator this needs. Failures inside `check` now propagate instead of being read as permission.

Behaviour for the case the `try/except` was actually written for is unchanged: an unknown declared type still passes through unvalidated.

### Tests
**215 passing** (3 new), including one that asserts a deliberately-broken checker now raises rather than silently validating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)