### PR TITLE
fix(artifacts): narrow whole floats where it actually works — before the encoder

### DIFF
--- a/process_bigraph/artifacts.py
+++ b/process_bigraph/artifacts.py
@@ -39,15 +39,57 @@ ARTIFACT_ROOT = '.pbg/artifacts'
 
 
 def _stable(o):
+    """json's ``default=`` hook: the last word on a value json cannot encode.
+
+    It also narrows a whole-valued float, but that is a **backstop, not the
+    mechanism** — see :func:`narrow_whole_floats`. ``default=`` is consulted
+    only for types json cannot serialize, and a float is serializable, so this
+    never sees one. The narrowing has to happen before the encoder runs.
+    """
     if isinstance(o, float) and o.is_integer():
         return int(o)
     raise TypeError(type(o))
 
 
+def narrow_whole_floats(value):
+    """Recursively replace whole-valued floats with the equal int.
+
+    ``1.0`` and ``1`` are the same number and must be the same content
+    address. They were not: a config carrying ``seed: 1`` from YAML and the
+    same config after a float-typed parameter pass produced two different
+    addresses for the same study — a silent cache miss and a duplicate
+    recompute, on the exact path content-addressing exists to prevent.
+
+    This has to be a **pre-walk**. The obvious place to put it is json's
+    ``default=`` hook, which is where it lived and never ran: ``default=`` is
+    consulted only for types the encoder cannot handle, and a float is not
+    one of them.
+
+    ``bool`` is deliberately untouched: it is an ``int`` subclass, so
+    narrowing would erase the difference between ``True`` and ``1`` — a
+    widening the address should not perform. ``NaN`` and the infinities are
+    not whole, so ``is_integer()`` already leaves them alone.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, float):
+        return int(value) if value.is_integer() else value
+    if isinstance(value, dict):
+        return {key: narrow_whole_floats(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [narrow_whole_floats(item) for item in value]
+    return value
+
+
 def canonical(config: dict) -> str:
-    """The canonical JSON encoding a content address is computed over."""
+    """The canonical JSON encoding a content address is computed over.
+
+    Sorted keys, no whitespace, and whole floats narrowed to ints so that a
+    value's *spelling* never changes where its artifact lives.
+    """
     return json.dumps(
-        config or {}, sort_keys=True, separators=(",", ":"), default=_stable)
+        narrow_whole_floats(config or {}),
+        sort_keys=True, separators=(",", ":"), default=_stable)
 
 
 def artifact_id(*, composite_id: str, config: dict,
@@ -58,9 +100,43 @@ def artifact_id(*, composite_id: str, config: dict,
     filesystem path, so two worktrees at the same commit resolve the same
     address and share a cache with no symlink between them.
     """
-    payload = "\n".join([composite_id, canonical(config),
+    return _address(composite_id, canonical(config), input_ids, commit)
+
+
+def _address(composite_id, encoded_config, input_ids, commit) -> str:
+    payload = "\n".join([composite_id, encoded_config,
                          "\n".join(sorted(input_ids or [])), commit or ""])
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+
+
+# ── the pre-narrowing formula, for migration only ───────────────────
+#
+# Whole-float narrowing changed where an artifact lives, but only for a
+# config that actually *spells* a whole number as a float. The relation is
+# exact and worth stating, because it is what makes the migration a rename
+# rather than a recompute:
+#
+#     artifact_id(config) == legacy_artifact_id(narrow_whole_floats(config))
+#
+# So a float-spelled config's artifact moves onto the address its
+# int-spelled twin already had — the two spellings converge on the one that
+# was always correct, and no third address is invented. Every config with no
+# whole-valued float keeps its address unchanged.
+
+def legacy_canonical(config: dict) -> str:
+    """``canonical`` as it behaved before whole-float narrowing worked."""
+    return json.dumps(
+        config or {}, sort_keys=True, separators=(",", ":"), default=_stable)
+
+
+def legacy_artifact_id(*, composite_id: str, config: dict,
+                       input_ids: list, commit: str) -> str:
+    """Where this artifact *used to* live. Only migrations should call this.
+
+    Everything else wants :func:`artifact_id`.
+    """
+    return _address(
+        composite_id, legacy_canonical(config), input_ids, commit)
 
 
 def artifact_store(address: str, root: str = ARTIFACT_ROOT) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "process-bigraph"
-version = "1.6.0"
+version = "1.7.0"
 description = "protocol and execution for compositional systems biology"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests.py
+++ b/tests.py
@@ -5491,6 +5491,13 @@ GOLDEN_ADDRESSES = [
     # key order must not matter: canonical() sorts keys
     (('study', {'b': 2, 'a': 1}, [], ''), 'a70c18c5c80eb729'),
     (('study', {'a': 1, 'b': 2}, [], ''), 'a70c18c5c80eb729'),
+    # spelling must not matter: a whole float and its int are one address.
+    # These two constants are the value the INT spelling always had — the
+    # float spelling moved onto it, so the vectors above are unchanged and
+    # only float-spelled configs were re-keyed.
+    (('study', {'seed': 1}, [], ''), '7cfd48d2cf54e4b6'),
+    (('study', {'seed': 1.0}, [], ''), '7cfd48d2cf54e4b6'),
+    (('study', {'n': [1.0, 2, 3.5]}, [], ''), '66e1fbdc641f035a'),
 ]
 
 
@@ -5521,31 +5528,87 @@ def test_canonical_json_is_stable():
     assert canonical({'rate': 0.5}) == '{"rate":0.5}'
 
 
-def test_int_and_whole_float_are_DIFFERENT_addresses():
-    """A known hazard, pinned so it stays visible.
+def test_int_and_whole_float_are_the_same_address():
+    """`1` and `1.0` are the same number, so they are the same artifact.
 
-    `canonical` passes `_stable` as json's `default=` hook, which reads as
-    "narrow whole floats to ints so 1 and 1.0 address the same". It does not
-    do that: `default=` is consulted only for types json *cannot* serialize,
-    and a float is serializable, so `_stable` never sees one. The narrowing
-    has never happened.
+    They were not. `canonical` passed `_stable` as json's `default=` hook,
+    which reads as "narrow whole floats to ints" but never ran: `default=` is
+    consulted only for types json *cannot* serialize, and a float is
+    serializable. So a config carrying `seed: 1` from YAML and `seed: 1.0`
+    after a float-typed parameter pass addressed two different artifacts for
+    the same study — a silent cache miss and a duplicate recompute, on the
+    exact path content-addressing exists to prevent.
 
-    The consequence is real: a config carrying `seed: 1` from YAML and
-    `seed: 1.0` after a float-typed parameter pass addresses two different
-    artifacts for the same study — a silent cache miss and a duplicate
-    recompute, in both this copy and the workbench's.
-
-    This test asserts the CURRENT behaviour on purpose. Fixing it is a wire
-    format change that orphans every stored artifact, so it needs a
-    migration, not a patch.
+    The narrowing is now a pre-walk, which is the only place it can work.
     """
     from process_bigraph.artifacts import artifact_id, canonical
 
-    assert canonical({'seed': 1.0}) != canonical({'seed': 1})
+    assert canonical({'seed': 1.0}) == canonical({'seed': 1}) == '{"seed":1}'
     assert (artifact_id(composite_id='s', config={'seed': 1.0},
                         input_ids=[], commit='')
-            != artifact_id(composite_id='s', config={'seed': 1},
+            == artifact_id(composite_id='s', config={'seed': 1},
                            input_ids=[], commit=''))
+
+
+def test_narrowing_reaches_nested_values():
+    """A config is a tree, and the spelling must not matter anywhere in it."""
+    from process_bigraph.artifacts import canonical, narrow_whole_floats
+
+    assert narrow_whole_floats({'a': [1.0, {'b': 2.0}]}) == {'a': [1, {'b': 2}]}
+    assert canonical({'x': {'y': [1.0, 2.5]}}) == '{"x":{"y":[1,2.5]}}'
+
+
+def test_narrowing_leaves_everything_else_alone():
+    """Only whole floats move.
+
+    `bool` is the one that would bite: it is an `int` subclass, so narrowing
+    it would erase the difference between `True` and `1` — a widening the
+    address must not perform. Non-whole floats and the infinities are not
+    whole, so they are untouched by construction.
+    """
+    from process_bigraph.artifacts import canonical, narrow_whole_floats
+
+    assert narrow_whole_floats(True) is True
+    assert narrow_whole_floats(False) is False
+    assert canonical({'flag': True, 'one': 1}) == '{"flag":true,"one":1}'
+    assert canonical({'rate': 0.5}) == '{"rate":0.5}'
+    assert narrow_whole_floats('1.0') == '1.0'
+    assert narrow_whole_floats(float('inf')) == float('inf')
+
+
+def test_the_fix_only_moves_float_spelled_configs():
+    """The migration rule, asserted rather than described.
+
+        artifact_id(config) == legacy_artifact_id(narrow_whole_floats(config))
+
+    A float-spelled config's artifact moves onto the address its int-spelled
+    twin already had — the two spellings converge on the one that was always
+    correct, and no third address is invented. Any config with no whole float
+    keeps its address unchanged, so the migration is a targeted rename, not a
+    rehash of every store.
+    """
+    from process_bigraph.artifacts import (
+        artifact_id, legacy_artifact_id, narrow_whole_floats)
+
+    unchanged = [{}, {'seed': 0}, {'rate': 0.5}, {'s': 'x'}, {'flag': True}]
+    moved = [{'seed': 1.0}, {'a': 1, 'b': 2.0}, {'n': [1.0, 2, 3.5]},
+             {'d': {'k': 4.0}}, {'z': 0.0}]
+
+    def new(config):
+        return artifact_id(composite_id='s', config=config,
+                           input_ids=[], commit='c')
+
+    def old(config):
+        return legacy_artifact_id(composite_id='s', config=config,
+                                  input_ids=[], commit='c')
+
+    for config in unchanged:
+        assert new(config) == old(config), f'{config} should not have moved'
+
+    for config in moved:
+        assert new(config) != old(config), f'{config} should have moved'
+        # ...and it moved onto the address the int spelling already had
+        assert new(config) == old(narrow_whole_floats(config))
 
 
 def test_artifact_id_is_sensitive_to_every_input():


### PR DESCRIPTION
`1` and `1.0` are the same number and must be the same artifact. They were not.

`canonical` passed `_stable` as json's `default=` hook, which reads as "narrow whole floats to ints" — but `default=` is consulted **only for types the encoder cannot serialize**, and a float is not one of them. The hook never saw a float, so the narrowing it advertised had never once run.

The consequence was live: a config carrying `seed: 1` from YAML and the same config after a float-typed parameter pass addressed two different artifacts for the same study — a silent cache miss and a duplicate recompute, on the exact path content-addressing exists to prevent.

### The fix
Narrowing is now a recursive **pre-walk** over the config, which is the only place it can work. `bool` is deliberately excluded: it is an `int` subclass, so narrowing would erase the difference between `True` and `1` — a widening the address must not perform.

### The blast radius is much smaller than "orphans every artifact"
The relation is exact, and asserted by `test_the_fix_only_moves_float_spelled_configs`:

```
artifact_id(config) == legacy_artifact_id(narrow_whole_floats(config))
```

- A config with **no whole-valued float keeps its address unchanged** — six of the eight golden vectors are byte-identical to before.
- A float-spelled config moves onto the address its **int-spelled twin already had**. The two spellings converge on the one that was always correct; no third address is invented.

That makes the migration a targeted rename of a minority of entries rather than a rehash of every store.

`legacy_canonical` / `legacy_artifact_id` are exported so a migration can find where an artifact used to live. Nothing else should call them.

### Version
1.6.0 → **1.7.0**. This changes a wire format, so it is not a patch. The workbench migration PR floors on it.

### Tests
**232 passing**, 15 skipped. 4 new; the previously-pinned `test_int_and_whole_float_are_DIFFERENT_addresses` is flipped to assert the correct behaviour and renamed. Golden vectors extended with float-spelling coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)