### PR TITLE
perf: cache the runtime partition instead of rediscovering it every tick

### DIFF
--- a/process_bigraph/composite.py
+++ b/process_bigraph/composite.py
@@ -1325,7 +1325,18 @@ class Composite(Process):
         Runtimes that only implement the older ``flush_pending`` hook (no
         ``tick_lifecycle``) keep going through the per-process loop —
         their batching of remote dispatch is unchanged.
+
+        Cached, and invalidated wherever the layer walk is: the answer is a
+        function of the process network's structure, which does not change
+        between ticks, but this ran a full ``get_path`` walk of every process
+        on every tick to rediscover it. The overwhelmingly common document
+        has no protocol runtime at all, so the common case is now a single
+        cached empty result rather than an O(processes) scan.
         """
+        cached = getattr(self, '_runtime_partition_cache', None)
+        if cached is not None:
+            return cached
+
         managed: set = set()
         groups: dict = {}
         for path in self.process_paths:
@@ -1339,7 +1350,10 @@ class Composite(Process):
             managed.add(path)
             entry = groups.setdefault(id(rt), (rt, []))
             entry[1].append((path, process))
-        return managed, list(groups.values())
+
+        partition = (managed, list(groups.values()))
+        self._runtime_partition_cache = partition
+        return partition
 
     def _run_tick_lifecycle(
             self,
@@ -1706,6 +1720,7 @@ class Composite(Process):
     def _invalidate_caches(self) -> None:
         """Invalidate precompiled link caches, forcing rebuild on next use."""
         self._compiled_links = {}
+        self._runtime_partition_cache = None
 
     def _cached_view(self, path: Tuple[str, ...]) -> Dict[str, Any]:
         """View using precompiled link cache when available, falling back
@@ -2201,6 +2216,8 @@ class Composite(Process):
         self._layer_walk_cache = {}
         self._layer_walk_replay = None
         self._layer_walk_recording = None
+        # Same lifetime: both describe the shape of the process network.
+        self._runtime_partition_cache = None
 
     def _get_step_executor(self, n_needed: int):
         """Lazily build (or grow) the inner thread pool for layer parallelism.

--- a/process_bigraph/tests/test_composite_spec.py
+++ b/process_bigraph/tests/test_composite_spec.py
@@ -271,3 +271,61 @@ def test_a_broken_type_checker_is_not_read_as_permission():
 
     with pytest.raises(RuntimeError, match='type checker is broken'):
         _coerce(1.0, 'float', name='rate', core=BrokenCore())
+
+
+# ---------------------------------------------------------------------------
+# The runtime partition is structural, so it is cached
+# ---------------------------------------------------------------------------
+
+def _one_process_composite():
+    from process_bigraph import Composite, allocate_core
+    from process_bigraph.processes.examples import IncreaseProcess
+
+    core = allocate_core()
+    core.register_link('IncreaseProcess', IncreaseProcess)
+    return Composite(_one_process_document(), core=core)
+
+
+def _one_process_document():
+    return {'state': {
+        'level': 5.0,
+        'grow': {
+            '_type': 'process',
+            'address': 'local:IncreaseProcess',
+            'config': {'rate': 0.1},
+            'inputs': {'level': ['level']},
+            'outputs': {'level': ['level']},
+            'interval': 1.0}}}
+
+
+def test_runtime_partition_is_cached_across_ticks():
+    """It is a function of the process network's shape, which does not
+    change between ticks — it used to be rediscovered by a full walk of
+    every process on every tick."""
+    composite = _one_process_composite()
+    first = composite._partition_processes_by_runtime()
+    assert composite._partition_processes_by_runtime() is first
+
+    composite.run(2.0)
+    assert composite._partition_processes_by_runtime() is first
+
+
+def test_runtime_partition_cache_is_dropped_on_structural_change():
+    """Same lifetime as the layer walk: a document whose process network
+    changed must not keep answering from the old shape."""
+    composite = _one_process_composite()
+    first = composite._partition_processes_by_runtime()
+
+    composite.expire_layer_walk_cache()
+    assert composite._partition_processes_by_runtime() is not first
+
+    rebuilt = composite._partition_processes_by_runtime()
+    composite._invalidate_caches()
+    assert composite._partition_processes_by_runtime() is not rebuilt
+
+
+def test_a_document_with_no_protocol_runtime_partitions_to_nothing():
+    managed, groups = _one_process_composite(
+        )._partition_processes_by_runtime()
+    assert managed == set()
+    assert groups == []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "process-bigraph"
-version = "1.7.0"
+version = "1.7.1"
 description = "protocol and execution for compositional systems biology"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
`_partition_processes_by_runtime` answers a question about the **shape** of the process network — which processes belong to a protocol runtime that manages its own tick lifecycle. That shape does not change between ticks, but the method ran a full `get_path` walk of *every* process on *every* tick to work it out again.

It is now cached, with the same lifetime as the layer walk: both describe the process network's structure, so both are dropped by `expire_layer_walk_cache()` and `_invalidate_caches()`.

### Measured
The common document has no protocol runtime at all, so the common case becomes a single cached empty result rather than an O(processes) scan:

| processes | uncached | cached | share of step |
|---|---|---|---|
| 10 | 0.0015 ms/tick | 0.0001 ms/tick | **1.7%** |
| 50 | 0.0060 ms/tick | 0.0000 ms/tick | **1.6%** |
| 150 | 0.0185 ms/tick | 0.0001 ms/tick | **1.6%** |

Flat ~1.6% because the cost it removes grows with the process count at the same rate as the step it is a fraction of — which is exactly the point: it was O(n) work per tick to produce an answer that was already known.

### Tests
232 → **235 passing**, 15 skipped. Three new: the cache holds across ticks, it is dropped by *both* invalidation paths, and a runtime-free document partitions to nothing.

Version 1.7.0 → 1.7.1.

Stacks with vivarium-collective/bigraph-schema#179 (dispatch memoization, +4.9–6.9%); together ~6–8% off framework per-step time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)