### PR TITLE
docs: Tutorial 4 — study & investigation templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ rendered to HTML and published automatically on GitHub Pages.
   *Defining mathematical relationships, signal pipelines, and events using `MathExpressionStep`*  
   https://vivarium-collective.github.io/process-bigraph/notebooks/tutorial_3.html
 
+- **Tutorial 4 — Study & Investigation Templates**  
+  *Documents with open **sites**; filling a hole turns a study or investigation into a runnable `Composite`; gating expressed as filling*  
+  https://vivarium-collective.github.io/process-bigraph/notebooks/tutorial_4.html
+
 More tutorials are added continuously and appear automatically in the index.
 
 ### Architecture

--- a/notebooks/tutorial_4.ipynb
+++ b/notebooks/tutorial_4.ipynb
@@ -1,0 +1,740 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "858acac2",
+   "metadata": {},
+   "source": [
+    "# Tutorial 4 — Study & Investigation Templates\n",
+    "\n",
+    "A **template** is a document that is *not ground*: it has open **sites** — the holes\n",
+    "bigraph-schema fills. This tutorial shows the framework's central move:\n",
+    "\n",
+    "> a **study** and an **investigation** are *the same kind of thing* as a composite —\n",
+    "> a bigraph document. Filling their open sites turns them into a runnable `Composite`.\n",
+    "> No new execution engine, no scheduler, no special-casing: one object, one operation\n",
+    "> (*fill*), one law (*groundness*).\n",
+    "\n",
+    "By the end you will be able to:\n",
+    "\n",
+    "1. build a **study template** — a fixed analysis network with the *model* left as a hole,\n",
+    "2. **fill** the hole and get a `Composite` that constructs and runs,\n",
+    "3. see the hole is **face-sorted** — only a model with the right interface fits,\n",
+    "4. build an **investigation template** — one hole per member study,\n",
+    "5. express **gating as filling** — a filled member runs, an unfilled one is pruned,\n",
+    "6. save/load templates as **`*.template.yaml`** files.\n",
+    "\n",
+    "The API lives in [`process_bigraph.templates`](https://github.com/vivarium-collective/process-bigraph/blob/main/process_bigraph/templates.py).\n",
+    "For the wider picture (higher-order DAG, content-addressed artifacts, the `git:` protocol)\n",
+    "see [`doc/architecture.md`](https://github.com/vivarium-collective/process-bigraph/blob/main/doc/architecture.md)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "e2f05677",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T22:42:25.211872Z",
+     "iopub.status.busy": "2026-07-31T22:42:25.211778Z",
+     "iopub.status.idle": "2026-07-31T22:42:25.493292Z",
+     "shell.execute_reply": "2026-07-31T22:42:25.492739Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from process_bigraph import allocate_core\n",
+    "from process_bigraph.composite import Composite, Step\n",
+    "from process_bigraph.templates import (\n",
+    "    open_sites,            # the paths of every hole still open\n",
+    "    required_open_sites,   # holes with no default — the ones that block a build\n",
+    "    is_ground_document,    # True when nothing is left to fill (the runnable predicate)\n",
+    "    fill_template,         # fill some sites; unbound sites stay open (incremental)\n",
+    "    template_document,     # fill a STUDY and render the doc a Composite consumes\n",
+    "    investigation_document,# fill an INVESTIGATION, pruning members left open\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5033964e",
+   "metadata": {},
+   "source": [
+    "## 1. The ingredients: a face, a flush step, a model\n",
+    "\n",
+    "A study here is deliberately tiny so the machinery is visible:\n",
+    "\n",
+    "- **`MODEL_FACE`** — the *interface* the model must present: it reads and writes a\n",
+    "  `level`. This is what the site is *sorted* by; it is the contract a filler must meet.\n",
+    "- **`ReportCard`** — a fixed downstream `Step` (a \"flush\"): it turns the model's final\n",
+    "  `level` into a `pass`/`fail` verdict. This part of the study is **not** a hole — every\n",
+    "  study built from this template shares the same analysis network.\n",
+    "- **`IncreaseProcess`** — a stock example process (already registered by `allocate_core`)\n",
+    "  that grows `level` by a fraction `rate` each step (`level *= 1 + rate`). This is the\n",
+    "  *model* we will drop into the hole; `rate > 0` grows the level, `rate < 0` decays it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "5d057776",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T22:42:25.494719Z",
+     "iopub.status.busy": "2026-07-31T22:42:25.494635Z",
+     "iopub.status.idle": "2026-07-31T22:42:26.354277Z",
+     "shell.execute_reply": "2026-07-31T22:42:26.353872Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "module `pbg_emitters.parquet_emitter` not found during dynamic import\n",
+      "core ready\n"
+     ]
+    }
+   ],
+   "source": [
+    "# The interface the model site is sorted by: reads a level, writes a level.\n",
+    "MODEL_FACE = {'_type': 'link', '_inputs': {'level': 'float'}, '_outputs': {'level': 'float'}}\n",
+    "\n",
+    "\n",
+    "class ReportCard(Step):\n",
+    "    \"\"\"A study's fixed flush: final level -> pass/fail verdict.\"\"\"\n",
+    "    config_schema = {'threshold': 'float'}\n",
+    "    def inputs(self):  return {'level': 'float'}\n",
+    "    def outputs(self): return {'verdict': 'string'}\n",
+    "    def update(self, state):\n",
+    "        return {'verdict': 'pass' if state['level'] >= self.config['threshold'] else 'fail'}\n",
+    "\n",
+    "\n",
+    "core = allocate_core()\n",
+    "core.register_link('ReportCard', ReportCard)   # make ReportCard resolvable as local:ReportCard\n",
+    "print('core ready')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d85c2fc",
+   "metadata": {},
+   "source": [
+    "## 2. A study template: fixed network, model as a hole\n",
+    "\n",
+    "`study_region` returns an ordinary document — two stores (`level`, `verdict`), a fixed\n",
+    "`report` step wired to them, and a **`model` site**. The site is written *in place*\n",
+    "with `_type: 'site'` and `_sort: MODEL_FACE`. That single line is the whole difference\n",
+    "between a template and a plain composite: a hole, sorted by an interface.\n",
+    "\n",
+    "`model(rate)` is a conforming filler — an `IncreaseProcess` presenting exactly the\n",
+    "`level -> level` face the site demands."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "82fb3b44",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T22:42:26.355621Z",
+     "iopub.status.busy": "2026-07-31T22:42:26.355549Z",
+     "iopub.status.idle": "2026-07-31T22:42:26.358689Z",
+     "shell.execute_reply": "2026-07-31T22:42:26.358301Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "open sites:  [('study', 'model')]\n",
+      "required:    [('study', 'model')]\n",
+      "is ground?   False   <- not runnable yet: a hole is open\n"
+     ]
+    }
+   ],
+   "source": [
+    "def study_region(threshold=2.0):\n",
+    "    \"\"\"A study: fixed report step + stores, with the MODEL left as a site (a hole).\"\"\"\n",
+    "    return {\n",
+    "        'level': 1.0,\n",
+    "        'verdict': 'string',\n",
+    "        'model': {'_type': 'site', '_sort': MODEL_FACE},          # <- the hole\n",
+    "        'report': {\n",
+    "            '_type': 'step', 'address': 'local:ReportCard',\n",
+    "            'config': {'threshold': threshold},\n",
+    "            'inputs':  {'level': ['level']},\n",
+    "            'outputs': {'verdict': ['verdict']}},\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "def model(rate=0.5):\n",
+    "    \"\"\"A conforming filler: grows level by a fraction `rate` each step.\"\"\"\n",
+    "    return core.access({\n",
+    "        '_type': 'process', 'address': 'local:IncreaseProcess',\n",
+    "        'config': {'rate': rate}, 'interval': 1.0,\n",
+    "        'inputs':  {'level': ['level']},\n",
+    "        'outputs': {'level': ['level']}})\n",
+    "\n",
+    "\n",
+    "template = core.access({'study': study_region(threshold=2.0)})\n",
+    "\n",
+    "print('open sites: ', open_sites(template))\n",
+    "print('required:   ', required_open_sites(template))\n",
+    "print('is ground?  ', is_ground_document(template), '  <- not runnable yet: a hole is open')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b9fd27a1",
+   "metadata": {},
+   "source": [
+    "The template has exactly one open, required site: `('study', 'model')`. `is_ground_document`\n",
+    "is `False`, so the framework knows it cannot run yet — and it will *say so by name* rather\n",
+    "than fail obscurely at construction."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3620dabc",
+   "metadata": {},
+   "source": [
+    "## 3. Fill the hole → a runnable Composite\n",
+    "\n",
+    "`template_document(core, template, bindings)` fills the sites named in `bindings` and\n",
+    "renders the document a `Composite` consumes. Bindings are keyed by the site's path,\n",
+    "joined with `/` — here `'study/model'`. Once the required site is filled the document is\n",
+    "ground, and it constructs and runs like any composite. **No code changed** — we only\n",
+    "dropped a value into a hole."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "af40cbe2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T22:42:26.359880Z",
+     "iopub.status.busy": "2026-07-31T22:42:26.359824Z",
+     "iopub.status.idle": "2026-07-31T22:42:26.380010Z",
+     "shell.execute_reply": "2026-07-31T22:42:26.379658Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "process paths: [('study', 'model')]\n",
+      "step paths:    [('study', 'report')]\n",
+      "final level: 5.062\n",
+      "verdict:     pass\n"
+     ]
+    }
+   ],
+   "source": [
+    "document = template_document(core, template, {'study/model': model(rate=0.5)})\n",
+    "\n",
+    "sim = Composite({'state': document}, core=core)\n",
+    "print('process paths:', list(sim.process_paths))   # the model we dropped in\n",
+    "print('step paths:   ', list(sim.step_paths))       # the fixed report card\n",
+    "\n",
+    "sim.run(4.0)\n",
+    "print(f\"final level: {sim.state['study']['level']:.3f}\")\n",
+    "print(f\"verdict:     {sim.state['study']['verdict']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72e9e525",
+   "metadata": {},
+   "source": [
+    "### The template is reusable: one network, any conforming model\n",
+    "\n",
+    "Because the site accepts *any* filler meeting `MODEL_FACE`, the same template scores a\n",
+    "whole family of models. Below we fill it with a sweep of `rate` values and read off each\n",
+    "study's verdict. A large enough positive `rate` grows the level past the threshold within\n",
+    "the run (**pass**); a small or negative `rate` leaves it short (**fail**). This is the\n",
+    "study as a *reusable measuring instrument*."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "41afe891",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T22:42:26.381364Z",
+     "iopub.status.busy": "2026-07-31T22:42:26.381282Z",
+     "iopub.status.idle": "2026-07-31T22:42:26.492314Z",
+     "shell.execute_reply": "2026-07-31T22:42:26.492013Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAArIAAAGGCAYAAACHemKmAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjYsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvq6yFwwAAAAlwSFlzAAAPYQAAD2EBqD+naQAAXIhJREFUeJzt3QeY1NT+//EvLLs0gaW3pSNKBymKoqBwQeCigmJXbKiICoINvQIqtqsiqNjwKlexgB0BsSDFgtKkCaIU6UWKdFjYzf/5nPub+c/Mzla2zc779TwDO0kmOTk5Sb45OTkp5HmeZwAAAECEKZzXCQAAAACygkAWAAAAEYlAFgAAABGJQBYAAAARiUAWAAAAEYlAFgAAABGJQBYAAAARiUAWAAAAEYlAFgAAABGJQBZRq2PHju4TjUaMGGGFChXK62QgD82aNcuVAf2fWePHj3e//fPPP3MkbQU1f6+77jqrXbt2ji97+/btdskll1j58uVdGkaPHp3h32qb6jfaxgXpeKFjfZMmTXJlWW+//badeuqpFhsba/Hx8WHPNwU1n/MCgWyU+PXXX+3qq6+26tWrW9GiRa1atWp21VVXueH52bvvvpupg3BeOXTokDsIZSUoiDQvvfRS0MEXQM56/PHH7dNPP83w9HfddZd9+eWXNnToUBdUnX/++RYNtmzZ4o7DixcvzrM0/Pbbb+6CpV69ejZu3Dh77bXX8iwt0aJIXicAOe/jjz+2K664wsqVK2c33nij1alTx10N/uc//7EPP/zQ3n//fevVq1e+DWSXL19ugwYNsvweyD788MPu74Jey6tAtkKFCu5gDSDjFNgkJydnKZBVDetFF12Uoem//fZbu/DCC+3uu++Oqs2jQFbHYdV6t2jRIk/SoMoMbeMxY8ZY/fr1/cO/+uqrPElPNCCQLeDWrFlj11xzjdWtW9fmzJljFStW9I8bOHCgnX322W780qVL3TQAgPR5nmdHjhyx4sWLZzi7dKs5N+zYscN/Sxu5S3kvofkfFxeXJxUsJUqUsIKOpgUF3NNPP+0Ks25vBAaxolq1V1991Q4ePGj//ve/U7TTWb16tat10w5ZpkwZu/766928Qk2YMMFatWrlDuiq9b388stt48aN6aZt//79rqZVV89q7lCpUiX7xz/+YYsWLfLXbE6dOtXWr1/v0qOPr31Zam30Umv3p/XXrR6lsW3btvbdd98FjT9w4ICVLFnSBfehNm3aZDExMfbEE0+EXQ+lwZe3qg3wpVX5GHi7STUqyp9ixYpZ69atbfLkyUHz8a3T999/b3feeaebp/L+lltuscTERPv777/t2muvtbJly7rPvffe606mgenQ75955hl77rnnrFatWm59O3To4Gq10/Pmm2/aeeed57aDtkejRo3s5ZdfDppG+a/mKLNnz/avZ2ANtNKobVqjRg03D9VIPPXUU1mqhcpIGfH5+eef3e1TlVMduLXOP/zwg3+87jworUp3KO0DGheYR5nZXlrO4MGD3fZSGdLdjb/++ivdddO+ddJJJ9mGDRvsn//8p/tbTX/Gjh3rxi9btsxtD81T21J3J0KtXbvW+vTp49Kp9T7jjDPcPhOuDKs2T/NSHurW89GjR8OmK728TM2CBQusa9eu7riicqc7PzfccIPlBbWFPPfcc1MMVzlUHmvbBg5T86XGjRu7bV25cmW3z+3ZsyfotyqD2k66Za/yoHVU2clM/oZrI+urvWvatKlbvsqR8l/5KSpjOkb/97//9e9zqd0N8ZVJHRdUjnzTZ7a8ZMTx48ft0UcfdcdV7ZtarwceeCBovbVfqJ1u4HHqjjvucGl6/vnng9r0aljg8eaFF15w20Tp1PFOeR5uH/DRMb9Nmzbub52rfOse2gxqxYoVrmxovioLgec+H63D8OHD3fFL66bjmY63qe0zPsoD/U60HQPPAyfyTEZGzrEd/68N8MKFC+2cc85x66ftERU8FGjVqlXzateuneY0Gp+QkOD/Pnz4cB11vJYtW3q9e/f2XnrpJe+mm25yw+69996g344cOdIrVKiQd9lll7npHn74Ya9ChQpunnv27ElzuVdeeaUXFxfnDR482Hv99de9p556yuvZs6c3YcIEN/6rr77yWrRo4eb39ttvu88nn3zixr355psuPevWrQua58yZM91w/e+jeWvYmWee6T3//PPeoEGDvPj4eK9u3bpehw4d/NNdddVVXuXKlb3jx48HzfPf//63W8f169eHXY8DBw54L7/8sltGr169/GldsmSJG798+XKvTJkyXqNGjdw6vvjii94555zj5vnxxx/75+NbJ63z+eef740dO9a75ppr/Pnevn17l2fK53/+859u+H//+1//75UXGta0aVOX/1qWtke5cuW8ihUretu2bUuxjQO1adPGu+6667znnnvOe+GFF7wuXbq4aZReH+W/ysqpp57qX09tJzl48KDXrFkzr3z58t4DDzzgvfLKK961117r1nPgwIFeVqRXRmTGjBlumnbt2nnPPvusS7/SoWE///yzm+bQoUPeSSed5N12220plnHuued6jRs39n/P7PbSfnLeeee5PBsyZIgXExPjXXrppemuW9++fb1ixYq55dx6661ue6uMap6at/bde+65x81X6dN8165d6/+9tqfKa6lSpbwHH3zQGzVqlNe8eXOvcOHCQenUujdo0MAtS+Vo9OjRXqtWrVwehe4rGcnLcPvf9u3bvbJly7rlPP300964ceNcmho2bOjlhUceecTlw9atW4OGz54926X7gw8+8A/Tsa1IkSJev379XJm97777vJIlS7r9ITEx0T9drVq1vPr167v1vP/++920yrvM5K+2ueYTSPucpuvWrZv77TPPPONdeOGFbruL9rGiRYt6Z599tn+f+/HHH8Ou95o1a9x4ze8f//iHf/rMlBffcUTbOK3jhdZFwy655BJXdrWv6/tFF13kn0bz1bBly5b5h/mWqd/5aHtoOu178tprr/nn/eqrr3pjxozxbrzxRu/OO+9MdZtr/bTd9bubb77Zv+7KE9GxXvtUjRo13PFIx1Htt5p+2rRp/vkkJSW5Y1+JEiXcuULLv/32210Z0XZJi46POgdonjonBJ4HtPzA801G8zmj59gOHTp4VapUccf6O+64w6X7008/9aIBgWwB9vfff7udIr2d74ILLnDT7du3L2hnuuGGG4Km0w6qIMXnzz//dCfXxx57LGg6HbS004cOD6VgYcCAAWlO06NHjxQH/swEsjoRVapUyQWHR48e9U/nO1AGHli+/PJLN+yLL74ImqdOSIHThfPXX3+53yrvQnXq1MkFl0eOHPEPS05OdkHLySefnGKdunbt6sb7KKjQgUzBjo+CbQWU4Q6MxYsX9zZt2uQfrgBEw++66640D5g6IYdSWhTwB1JQFS4/Hn30URcA/P7770HDddJXOdmwYYOXWemVEeWT8jA0z7QuderUcSdznyuuuMKVhcALFQU6OqnqBJjV7dW5c+egZSuftb7a/9LiCwQef/xx/zCdmLT9tL3ff/99//DffvstRfnSSVbDvvvuO/+w/fv3u/XWSU4nZFFwpOkmTZrkn04XHQrKAveVzORl6P6nE7i+z58/38sPVq1a5dLjCwZ9dCGjCxpfWVfeabp33nknaLrp06enGK7jkIZpXKCM5m+4QPbbb79104QL0AK3gfYr/TajNM/Q/Saj5SUjAdbixYvdd10EBLr77rvdcK2X7Nixw31XACbaJ7S/9enTxwXVPlp/XXD71lnnrMCLy4xS+QtNu4+OWRr31ltv+YfpnKDg7+KLL/YPU/CpNAbmk+jCRb//4Ycf0kyDL690TghdfmYD2cycYzv83/opndGGpgUFmG7LSqlSpdKczjd+3759QcNvvfXWoO9qT7tr1y7/dHqITLfFLr30Utu5c6f/U6VKFTv55JNt5syZaS5Xt811G1MN9HOKbs+pzZLWJbCNkm7N6dZpoM6dO7veHN555x3/MN1uVvth9fiQFbt373YPXiiPtD18eaR81G3YP/74wzZv3hz0Gz2QF3g78PTTT3e35jTcR00ddKtNtwpD6Ranbpn5qCmF5jFt2rQ00xrY1m/v3r0unbqtrGXoe3o++OADV0Z0GzCwPChfk5KSXBvtzEqvjOjpZOXhlVde6fLUt0zdiu3UqZNbpq9Zw2WXXebKQmCzEzU50HiNy+r2uvnmm4O2l/JA66smMRlx0003Ba3vKaec4m5RKw0+GqZxgdtb21Pbtn379v5hap6g9KiZiW6h+qarWrVq0O103XbUdFnNy1C+9oBTpkyxY8eOWV5r0KCBe9hn4sSJ/mHaJtrePXv29Jd1lVkdB9RcJbDM6jau8jL0GKbmEioHgTKav+F89NFHruz4bkcHyu5umDJaXjI6L1/TgUBDhgxx//uaK+j2urqh8u37aqKiY9c999zjmhOovImaeildvnVWeVJzjfnz51t20voGHst1TlCeBO5XKhMNGzZ06Q4sE2rmI+md17JTZs+xRYsWdc0qog0PexVgvgDVF9BmNuCtWbNm0HcFKKK2Y6VLl3YHIQVY2qGy8mCD2ib17dvXtT/SiaN79+6uDWh2PnTmCyZC06i0hS6ncOHCrksytdPyNZJXUKt2a2pXlhVqZ6w8euihh9wnHAVXgYFnaL77Am7lU+jw0HZ8Em576MQ+adKkNNOqk4xOqHPnzk3RFlqBbGjgH0rlQUF/aFvs0IcgMiO9MuI7EWqa1CjtKru+dp8KbhSYif5WwKP8ya7tFbifpMfXJjKQ0piQkJAikAnd3irbukAJpZOwb7zazOl/tfULnZ+C40CZyctQuuC5+OKLXRtxtc9Wez1dUCko1sk1rfkdPnzYskL5kdaDVro4URtBXXhoe+kCRtvOd9HiW2elQe1aM1JmFciGymj+pvYwri6e1e4xp2W0vGR0XjpeBj6VLwqwFIQGXsTpws4X+Cpg1QW4PlpnfVeb5CVLlriy4nPffffZN99844JMLaNLly5u/FlnnWUnItx+pfKs41ZgmVi5cmW2HseyKrPn2OrVq+fJQ2V5jUC2ANOBXjUFgTtpOBqvHUDBaSBdOYfja7ivK0UdFL744ouw0+rqNy26ytRB7pNPPnFdk+jBND0YpKvQbt26pfnb1GorVOtyIhQkKR3qs1FdlunhAj3gkV4QlxpfDZa6wQmtyfEJPRmklu/hhgc+RHEidEJVcKdaiFGjRrnAUQdEnYAUmGTkYS1No5otPRQRji9YzIz0yogvXRqeWnc7vnKogErBlealLsRUI6TgXV0bBa5Ddm2vjGybzGzrjM4zqzKTl+H2R9V2/vTTT/b555+7B6L0oNezzz7rhqX2Oz1cqYeYskIPJ6bVBZwCVvWjqho2PTCoCzntx4F9qmqdFcQG3oUJFBrMZKaHgmiQkVpj1bSq2zHVeipw1f6s32m4viuQ13bQ8MDgetWqVa6Gf/r06a7mWvvssGHD/N0cZkVG9iulRQ/e6TgYTmiFQk7K7Dm2eJSWTwLZAk5BmA4iehI+8JaSjw4kuq2kp3QzS0+r6gCgWoqsBCmiQPu2225zH13pnnbaafbYY4/5A9nUDpS+WiE9JR8o9Haunvb2Xdn6bg2Jbn+uW7fOmjdvHjS9aiRatmzpTmy6etcT5Xp6Nj2ppdNXc6grZ91izw2+mrVAv//+e5pvFFLwoSdy9WR+YA1juNtoqa2ryoN6f8ju9UyrjGiZoouwjCxXwY0CpxkzZrhaF5XfwBq6vNheWaWyrZN9KPW44Bvv+19NZLSugdsu9LeZzctw9BS8Pto+ugjUHQ71Ux3YfCKQLnqy2mxHT7SnRccl1eip1v322293Fz+6kAmsIdY6q+ZPNX1ZDQIymr/haPkK+tWkJa1a2exoZpDR8pLReSnI0rHGV6MrujjUMTlwXr4A9euvv3ZNBe6//373XU/W6+6XAlk1pdEdl0Aapn1TH/Xa0rt3b1eudHGiOxk5lU/aJqoh1oV9Xr9lKzvOsdGANrIFnNoi6QCtQFXt3gLp4Km2o7qFrukySwcWXSXqCjm0pkjfQ5cXWnMa2u5SNSM6qAV2caKDWbj2mb6TbmC7S80z9C0quoWlWpVXXnnFHQx91CVLaBDso351VfunLnnUdUx6tcPi66svdJ5aJ91mVTc9W7duTfG7jHTTlFmqTQ5sxzlv3jzXzjSt9fBd7QduR+W7ar1CaZuEyzvVnqpZgk7MoTS9uuvJjIyUEZ38VBbU5ZiC6PTyVwGaAgYFN/oo0Am8XZwX2yur1MxC21Z57qP2rNoHdNGi7tN806mNsWpMfXxd8gXKbF4GUpOH0GOAr1Y3rS6LlEZtk6x8dIGTHgVBqhF+4403XNvCwIsWX5lVOVM3UqFUXlM7RgTKaP6Go+YYyrdwtYyB+ZnaPpcT5SWj85LQty76ajF79OjhH6b9S3f8dGdHFQi+5gEKcHUnSPmmi58iRf5/vVrouUN3h5Q+5UlabbCVT3IieaUyoeOnKoBCqRmM8iy3nMg5NppQI1vAqW2NaqBUM6LbJaFv9tLB/b333vMHhpmh34wcOdJdIWt+qu1QO1vVdOr2rR4iSO3NMmqXqxpPPSChWlHdIlHNiK7YdTsy8OSqgEMPFaiPQE2nhzVUG6ODn5btq81QzU9osKSaNaVRgbxqZHUiU/oUoKXWFldtsVRTpHXo379/hjox18WCDrRKq66clR7V7uqj/hxVG67879evn1uuai50QtEDDbr6z0669a3lKe0KInwBeWq3/EVt0HSyUN4qrxTI6ECuwC40oNM2UU2K8lXL0jTKW10MqUZXdwF0y1fT6aCv/lB1slIZUR+jovEql9oWqdUUZ6SMqJ3e66+/7oJ0lQk96KCTpk5Eqk1W7aJqm320LXVyUFlR2hS0hcrt7ZVVqtnSvqt1V7/DKnO+PNWtWOWNaB1efPFF12xGfUwqANRrS0M7Ss9sXgbScnXrV33o6rigbafyo9/4gp68oKBExyB9lD+hNc1q26vyrj6i9bCb9gOVEdU0qkmC+ncNfIgrnIzmbzjqz1QXzupTVctUswfVdOpOmcapJlm0L6nsK1DUhZyO4eHau2ZHeckI7Y9qS60gWEGj8lFBsuan80BoH74KWrXPaZ/y3U3TnRUFnrpbFNg+VrQd1N5WQa/a0OruifJYAXJaDy+r7KmNriouNJ3mr3wK17Y5NdoeaoaiSh6Ve6VBFzuqudZwXz/CueFEzrFRJa+7TUDuWLp0qet+qGrVql5sbKzrckTfA/v3S6/7kNS6vProo49cH6fqIkYf9TGqrl/UBU5q1O2J+shUn4Lq11C/09++bloC+2hVX6Lq91XLDuy6Rv0Dqusj9bGorlzUd+nXX3+dossb0XzVzYymbd26tTdnzpwU3aEE6t69u5tPav01hqNp1X+k+twM7SpJaVU/i8p35X/16tVdX7AffvhhivwN7cIote2h7niUb6HduagfT/UBqv4Sff1P+voyDJ1noMmTJ7uuxtQfpq8f2jfeeCPFNld/jeoWTdsttAszdeczdOhQ1/WQ8kH9HarbKvWNGdgnp7q7UTdTafU1nNEyIr/88ovr81jdw2mdVU7Ul6v6RQ3lKyPq4mrjxo1hl30i2ytcX8bhhG4/H+VnuK6HtE7K99B0qq9N7R/abm3btvWmTJmS4rfqA1nd7KlvTG0T9aPp62IqNJ0ZycvQY8GiRYvc8aRmzZruN+rmTPm1YMECL6+dddZZYbuKCqTu+LTvqkyqrKn7NfUJu2XLljTzP7P5G64fWXUHp31Wx03tM+oHVH3KLly4MKj7NfVlrPRpnul1xRWu+62MlpeM9m967Ngx16epjqvaR3S80b4f2G2dj/qZ1e/79+8fNFzHbw0P3U/VB6rW11cG69Wr544Fe/fu9dLz2Wefub6Z1T1V4Hqktl+F2yY6Vun4p+m1fPUdrPKh9U0vDdnZ/VZmzrEdUlm/aFBI/+R1MA3kN6pZUk2inmKPFLpiV82DHtbJ71fpqmXxPVgHAEBW0UYWCKFb6eoHUbeYkP30ilu1NVMXOwAAnAjayAL/R+2O1B2T2gmqnVxWenJA+tT+MvTlGwAAZAU1ssD/mT17tquFVUCrhxb0sAEAAMi/aCMLAACAiESNLAAAACISgSwAAAAiEg97pUEdU+uNLeqAOK9fVQcAABANPM9zL1bRC0DSe1kHgWwaFMTWqFEju7cPAAAA0rFx40b3hse0EMimwfcqPGWkXrUIAACAnKUuGlWRmNYriX0IZNPga06gIJZAFgAAIPdkpFknD3uFMXbsWGvUqJG1adMmJ7YLAAAAsgH9yKZTtV2mTBnbu3cvNbIAAAD5LP6iRhYAAAARiTay2SApKcmOHTuWHbMCUhUbG2sxMTHkEAAUAM2HtbJ+59xoc37/3g4fO2y3duxnPZp3d+OGfvig/blzvR1LOmZVSle2ERcNswqlKtjug3vcuJ37d7r2ow2rNbRHe42wpRuX2eNTnrRkL9mOJyfZ5W372KVt+1g0IJA9wX7Otm3bZn///Xf2bREgDfHx8ValShX6NQaAgqCQ2aTb3rVNuzfZFa9eYy1qtrDqZavZPd3utnIly7pJ/jPnTXt55mv20AUP2NQl06x62er2at+X3Li9h/b+b5rv3rS+Z11j3Zqd777vO7zPogWB7AnwBbGVKlWyEiVKEFwgRy+aDh06ZDt27HDfq1atSm4DQITr3aqX+z+hXIK1qtXSFq1f5ALZL5Z+YVOWTLOjxxMt8fhRiy8R76ZrltDUJsx9x56ZPspa1TrNzjr5TDe8Te3W9trs1239rg3Wtm4bO61WS4sWBLIn0JzAF8SWL18+e7cKEEbx4sXd/wpmVe5oZgAABU0hW7T+F3v3p/ftrX7jrfxJ5WzWb7PtpW9fcWOb12xmk/q/Zz+t/dlmrPzWxn77sk3s/65dfeaV1rFhB/t5zc/2wjdjrX6levZgz6EWDXjYK4t8bWJVEwvkFl95o002AES+zxZNdv9v3rPFFq1f7GpS9x3ebyWLlrT4EmXs2PFj9uH8j/zTb9qz2UrElbCuTbrY/d3vdTWwhxIP2Z87/7SEstXt4ta97aZzbrClm5ZZtKBGNhc66wWyC+UNAAqOJC/JLn3pSvew133d73bNCiqVrmhTl06zC5/vbWWKl7Ez6p1uO/b/5aZfsG6hvf3jBIspHOMe6rqry0ArVayUvTjjZZu3dr7FxsRaTOHCNqTrXRYt6Ec2i/2YHTlyxNatW2d16tSxYsWK5fR2Aih3AFDAei34bugsK108/dewRpt99COLzJo1a5ar7cvtHhjGjx/vnsQ/EX/++adL++LFi/Pd+gEAgJxD04Io1LFjR2vRooWNHj06r5NSYOzevduGDx9uX331lW3YsMEqVqxoF110kT366KOuVj+t3gj0u3Hjxrkg+6yzzrKXX37ZTj755FxNPwAg7drTnHD2Ex0jJtuXPLLQ8iMe9kKWJSYmknv/Z8uWLe7zzDPP2PLly11N8/Tp0+3GG29MM4/+/e9/2/PPP2+vvPKK/fzzz1ayZEnr2rWra7oCAADSRiAbZa677jqbPXu2jRkzxt1q10e35n0WLlxorVu3dk/Hn3nmmbZq1Sr/uBEjRria3Ndffz2obbBqEm+66SZXC6m2xOedd54tWbLE/zv9fe6551qpUqXc+FatWtmCBQuC0vXll19aw4YN7aSTTrLzzz/ftm7d6h+XnJxsjzzyiCUkJFjRokVdGhQkpmXatGnWoEED12WVlh24jjmhSZMm9tFHH1nPnj2tXr16Lg8ee+wx+/zzz+348eOp1saqVvxf//qXXXjhhdasWTN76623XED86aef5mh6AQAoCAhko4wC2Hbt2lm/fv1csKhPjRo1/OMffPBBe/bZZ12gWaRIEbvhhhuCfr969WoXsH388cf+Nql9+vRxfZt+8cUXLhA+7bTTrFOnTu52u1x11VUuCJ0/f74bf//997vXrfqoo3/VZL799ts2Z84cd2v+7rvvDkqz0qRpli5d6mosL7jgAvvjjz/CruPGjRutd+/eLqhUGhVka5np6datmwukU/s0btw4U3nte0hQ+RiOHhbUSzU6d+7sH6ZmCKeffrrNnTs3U8sCACAa0UY2B/gCxEBly5Z1tZi6ZbxixYoUv1HwJ6oBPXjwYNC42rVrW7ly5eyvv/5yQVog1XJmpj2lAqW4uDhX46pXnYZSLWKHDh3c3wr+evTo4dLsq31VcwLVGqr2Vb7//nubN2+eC2RVWyoKOFWj+OGHH9rNN9/sAtN77rnHTj31VDc+NL3qE1W31lWTKbfffrurgfXR/O677z67/PLL3fennnrKZs6c6Wozx44dm2Id1MZU81LwK6eccootW7bM/S4tqmk+fPhwquMDg+/07Ny507WP1fqnRkGsVK5cOWi4vvvGAQCA1BHI5oBXX33VHn744aBhqpWcMGGCbdq0yd1aD3eb2Xfr/6effgoap5rKq6++2iZNmuSCvEBdunRxt+Wzi25v+/heg6ogtWbNmu7vWrVq+YNYX7OBAwcOpHi7mQLCNWvWuL8HDx7sakW1Hqp9VA2uL2gVBdWB37Vc36tY1QWHbrXrIahA+h7YfCHQypUrXa1mINVCp6d69eqWHZRmXQA0atTINccAAAA5g0A2B9xyyy3u1ndojazoFrtur6dGDwmFq5GVSy+9NEVAphrZ7BRY6+jrfF9tVH30MFIgBbEKPNW9VShft1oK5q688kqbOnWqa36gp/Tff/9969WrV9iaTi3XF9jnJjUt+O6771IdryD+119/TXMe+/fvd218tV0++eSTNGtxfTXi27dv9180+L6rHTAAAEgbgWwOUFASGJgE0i16XzOCcHQbPDWqCQ2sDc0qNS1ISkqy7KB10W1wtQP1Bdzh6MErfe666y674oor7M033/QHsmlRG9Nq1arZDz/84G/yIPretm3bsL/RQ2OTJ//vtX8+obXcOdG0QDWxar+rJhZafnovylBTEwWzM2bM8Aeumod6L+jfv3+66QUAINoRyEYhBZwKlvQkvx5iUvvbrFJTAdUSq89UdSWlYFVNAVT7qkBVD0ipfewll1ziAjc1rdBDXxdffHGGl6HfqxZXzQ8U8CkI1kNc77zzTtjpb731Vtc+Vr9TkwbVgKumOyebFigAVTMPPbimJiT6ro/o4iMmJsb9rXbCTzzxhMsb1TwPGjTIRo4c6doNK38eeughF7grPwEAQNoIZKOQegTo27eva8OpGkg9PZ9VCsbU1ZV6O7j++uvdA2mqZTznnHPcQ0sK4Hbt2mXXXnutu2VeoUIF16NAaBvitNx5552uB4AhQ4a4trNKt2o8U3vITe151bOCan9feOEFV3P7+OOPp+iBITstWrTIXRxI/fr1g8Ypf3211XqYT+vic++997qmJHooTN2YtW/f3nUtxmuPAQBIXyEvLxojFoB3/epJfgUogf2pAjmNcgcABefNXpFkSS6+2Sut+CsU/cgCAAAgIhHIAgAAICIRyAIAACAiEcgCAAAgIhHIAgAAICIRyJ6gwLdeATmN8gYAQJT1I6vO5/UK1U6dOtmHH36YLfPU27EKFy7sOv9Xh/f67nulK5Dd1EteYmKi66dX5U7lDQCAaBcVgezAgQNdZ/j//e9/s22eCibUh+zWrVtdMAvkhhIlSrgXPqj8AQAQ7aIikO3YsaOrkc1uqhVTUHH8+HFLSkrK9vkDgfSWtCJFilDzDwBApASyc+bMsaefftoWLlzoaj8/+eSTFO+hHzt2rJtm27Zt1rx5c/9rSXODmhPExsa6DwAAAHJPvr8/qffQKzhVsBrOxIkTbfDgwTZ8+HD3vntN27VrV9uxY0eupxUAAAC5J98Hst26dbORI0e6B7bCGTVqlPXr18+uv/56a9Sokb3yyiuuHeEbb7yR62kFAABA7sn3gWxa9BS3mhx07tzZP0wPwej73LlzMz2/o0eP2r59+4I+AAAAyJ8iOpDduXOne8iqcuXKQcP1Xe1lfRTY9unTx6ZNm2YJCQmpBrlPPPGElSlTxv+pUaNGjq8DAAAACujDXtnhm2++ydB0Q4cOde1tfVQjSzALAACQP0V0IFuhQgXXJdH27duDhut7lSpVMj2/okWLug8AAADyv4huWqB+XFu1amUzZswIeoWnvrdr1y5P0wYAAIAor5E9cOCArV692v993bp1tnjxYitXrpx7GYGaAvTt29dat27t+o4dPXq067JLvRgAAACg4Mr3geyCBQvs3HPP9X/3tWFV8Dp+/Hi77LLL3Pvnhw0b5h7watGihU2fPj3FA2CZoT5r9eFtXQAAAPlXIc/zvLxORH6lh73Ue8HevXutdOnSeZ0cAACQB5oPaxX1+b7kkYX5Mv6K6DayAAAAiF4EsgAAAIhIBLIAAACISASyAAAAiEgEsmGox4JGjRpZmzZtcn+LAAAAIEMIZMMYMGCArVixwubPn5+xXAQAAECuI5AFAABARCKQBQAAQEQikAUAAEBEIpAFAABARCKQDYNeCwAAAPI/Atkw6LUAAAAg/yOQBQAAQEQikAUAAEBEIpAFAABARCKQBQAAQEQikAUAAEBEIpAFAABARCKQDYN+ZAEAAPK/InmdgPzaj6w++/btszJlyuR1cgAAyFeaD2tl/c650eb8/r0dPnbYbu3Yz3o07+7GDf3wQftz53o7lnTMqpSubCMuGmYVSlWw3Qf3uHE79++0QoUKWcNqDe3RXiNs6cZl9viUJy3ZS7bjyUl2eds+dmnbPnm9iogQBLIAACDzCplNuu1d27R7k13x6jXWomYLq162mt3T7W4rV7Ksm+Q/c960l2e+Zg9d8IBNXTLNqpetbq/2fcmN23to7/+m+e5N63vWNdat2fnu+77D+9gayDACWQAAkGm9W/Vy/yeUS7BWtVraovWLXCD7xdIvbMqSaXb0eKIlHj9q8SXi3XTNEprahLnv2DPTR1mrWqfZWSef6Ya3qd3aXpv9uq3ftcHa1m1jp9VqydZAhtFGFgAAZINCtmj9L/buT+/bi1c/bx/fPsnuPn+wJR5PdGOb12xmk/q/Z00TmtiMld/ala9eY0nJSXb1mVfaC1ePsYqlKtgL34y1xz5/gq2BDCOQBQAAmfbZosnu/817ttii9YtdTeq+w/utZNGSFl+ijB07fsw+nP+Rf/pNezZbibgS1rVJF7u/+72uBvZQ4iH7c+efllC2ul3curfddM4NtnTTMrYGMoymBQAAINOSvCS79KUr3cNe93W/2zUrqFS6ok1dOs0ufL63lSlexs6od7rt2P+Xm37BuoX29o8TLKZwjHuo664uA61UsVL24oyXbd7a+RYbE2sxhQvbkK53sTWQYYU8z/MyPnl08fVasHfvXitdunReJwcAgHzTa8F3Q2dZ6eKlLFrWN9oteWRhvoy/aFoAAACAiETTglReiKBPUlJS7m8RAAAioDbx7Cc6WqTIzdpE5C5qZMPQyxBWrFhh8+fPz+XNAQAAgIwikAUAAEBEIpAFAABARCKQBQAAQEQikAUAAEBEIpAFAABARCKQBQAAQEQikAUAAEBEIpAFAABARCKQBQAAQEQikA1Dr6dt1KiRtWnTJve3CAAAADKEQDYMXlELAACQ/xHIAgAAICIRyAIAACAiEcgCAAAgIhHIAgAAICIRyAIAACAiEcgCAAAgIhHIAgAAICIRyAIAACAiEcgCAAAgIhHIAgAAICIRyAIAACAiEcgCAAAgIhHIAgAAICIRyIYxduxYa9SokbVp0yb3twgAAAAyhEA2jAEDBtiKFSts/vz5GctFAAAA5Loiub9IAADyTvNhrazfOTfanN+/t8PHDtutHftZj+bd3bihHz5of+5cb8eSjlmV0pVtxEXDrEKpCrb74B43buf+nVaoUCFrWK2hPdprhC3duMwen/KkJXvJdjw5yS5v28cubduHzQvkEgJZAED0KWQ26bZ3bdPuTXbFq9dYi5otrHrZanZPt7utXMmybpL/zHnTXp75mj10wQM2dck0q162ur3a9yU3bu+hvf+b5rs3re9Z11i3Zue77/sO78vDlQKiD4EsACDq9G7Vy/2fUC7BWtVqaYvWL3KB7BdLv7ApS6bZ0eOJlnj8qMWXiHfTNUtoahPmvmPPTB9lrWqdZmedfKYb3qZ2a3tt9uu2ftcGa1u3jZ1Wq2WerhcQbTIVyP7999/2ySef2HfffWfr16+3Q4cOWcWKFa1ly5bWtWtXO/PM/+3YAABElkK2aP0v9u5P79tb/cZb+ZPK2azfZttL377ixjav2cwm9X/Pflr7s81Y+a2N/fZlm9j/Xbv6zCutY8MO9vOan+2Fb8Za/Ur17MGeQ/N6ZYCokaGHvbZs2WI33XSTVa1a1UaOHGmHDx+2Fi1aWKdOnSwhIcFmzpxp//jHP9yT/hMnTsz5VAMAcAI+WzTZ/b95zxZbtH6xq0ndd3i/lSxa0uJLlLFjx4/Zh/M/8k+/ac9mKxFXwro26WL3d7/X1cAeSjxkf+780xLKVreLW/e2m865wZZuWsZ2AfJbjaxqXPv27WsLFy50wWo4Cm4//fRTGz16tG3cuNHuvvvu7E4rAADZIslLsktfutI97HVf97tds4JKpSva1KXT7MLne1uZ4mXsjHqn2479f7npF6xbaG//OMFiCse4h7ru6jLQShUrZS/OeNnmrZ1vsTGxFlO4sA3pehdbCMhFhTzP89KbaNeuXVa+fPkMzzSz0+dX+/btszJlytjevXutdOnSeZ0cAEA29Vrw3dBZVrp4qahZ32i35JGFJ/R78tBOOA9zKv7KUNOCzAalBSGIBQAAQAHrtWDy5P+1KwqlfvWKFStm9evXtzp16mRH2gAAUS6nasLOfqKjRYrcrAkDCnwge9FFF7mgNbRFgm+Y/m/fvr1rL1u27P/64gMAAADy/BW1X3/9tbVp08b9r7YL+ujv008/3aZMmWJz5sxxbWR52AsAAAD5qkZ24MCB9tprrwX1GatuuNSs4Oabb7Zff/3V9Vxwww03ZHdaAQAAgKzXyK5ZsybsE2QatnbtWvf3ySefbDt37szsrAEAAICcC2RbtWpl99xzj/311//61hP9fe+997omB/LHH39YjRo1MjtrAAAAIOeaFvznP/+xCy+80L3Ryxes6gUIdevWtc8++8x9P3DggP3rX//K7KwBAACAnAtkTznlFFuxYoV99dVX9vvvv/uH6RW1hQsX9vdsAAAAAOSrQFYUsJ5//vnuAwAAAERMIDt79mx75plnbOXKle57o0aNXLvZs88+2wqixYsX20knneT/rv5x9dKHI0eOuNrpUKeddpr7f9WqVXbw4MGgcbVr17Zy5cq5dsVqkhGoVKlS7kG5pKQkW7JkSYr5Nm3a1GJjY90Dd+r2LFD16tWtcuXKtmfPHlu3bl3QuOLFi1vDhg3d37/88kuKPoA1TtOsX7/edZ0WSPPUvPfv3+/aPgdSWpQmWbZsmR07dixovNZF67R582bbvn17ire/1apVyw4fPuwvRz7qi7hly5bub43TNIGU99oGmqfmHUivtKtXr55Li9IUqnnz5hYTE+PWResUSE1lKlasaLt377Y///wzaFzJkiXdnQdZtGhRivlqH1DPHcp7bYNAVatWdR+9cm/16tVB44oWLWqNGzd2fy9dutSOHz8eNL5Bgwau7G3atMl27NgRNK5ChQpWs2ZNO3TokP32228pLjZbtGjh/lYZVVkNpKZA8fHxtm3bNtuyZUvQOA3X+MTERFu+fHmKddV8NX/dkVEzokBKj9Klhz03bNgQNE7rofVJTk52+1SoJk2aWFxcnHto9O+//w4aV61aNatSpYob7nuo1Ef5rvwXzVfzD3TqqadaiRIlXHpCH0KtVKmSayal9fDdYfIpUqSINWvWzP2t3liOHj0aNF4vf9FDrlu3bnWfQBwjsu8YkXws2Y7sDC6/hXRcq1rC/X3kr8OWfDz4mBYXH2dFihexYweO2bH9wcuMKRpjRcsVNS/Js8M7go8tUrxycStUuJAd3XXEkhKDy1Jc6VgrUjLWjh8+bol/JwaNKxxb2IpVKOb+PrT1UIr5FqtYzAoXKWyJe47a8SNJQeNiT4q12FKxlnQ0yY7uDi5nhWO0tnZCx4iweVjIrHiV1POwaNk4iymWSh4Wi7GiZYtaclKyHdlxJGUeVinujuNh87BMnBUpUcSOHzpuiXuD8zAmrrAVLV/MnaMOb0u5bYpVKmaFYwrb0T1HLSk0D0vFunxMOnLcju4J2TZF/n8eZvUYkZSYZEd3BW+bQoVVXv4vD3cctuSkkDwsV9SVN+Wf8jFQkWIxFqc8PJ5sR/5KmYclfOV75xG3/cKV7+MHj1nivmPh8zDZs8Pbw5TvSsWtUEwhV85U3sLlYdjyHZCHuRFHhJ5b0uRl0ttvv+0VKVLEu/TSS70xY8a4T58+fbzY2FjvnXfe8QqCF1980WvYsKHXoEEDbakUn6uuuspN98cff4Qd73PGGWekGKf88y0jdFyXLl3cuL1794ad744dO9z4nj17phj37LPPunGTJk1KMa5ly5b+NMXFxaUYv3z5cjfuxhtvTDHu/vvvd+NmzpyZYlz16tX989XfoeP1G9E8QsdpWaJlh45TGn2U9tDxWkfROoeOU96I8ipcHipvRXkdOk7bRLSNQsdpW/qEm6/KgqhshI4bPny4Gzd9+vQU4+rVq+efb4UKFVKM//HHH924u+66K8W42267zY1buHBhinGlSpXyz7dRo0Ypxn/22Wdu3OOPP55i3CWXXOLGbdy4Mey6HjlyxI3v0KFDinHjxo1z4/R/6DhNL/p9uPlqeaLlh45TOkXpDh2n9fPReoeOV/6I8it0nPJVlM+h47Q9fLSdQsdre4q2b+g4jhHZd4xocEvDFOMKxRTymj10mvsUq1I8xfiaF9dx46r+I+UyS51cxo1rNLhp2HLY+N7mbvxJdVOWpWrn13DjalxYK8W4EtVL+tMUbr6nDGjkxsU3KZtiXKVzqrhxda6sn2JcXNmiJ3yMqH/TqSnGFY4r7E9v0QrFUoyvdWldN67KudVSjCvTMN6NO3Vgk7Dr2mRoCze+ZK2TUoyr/s+abpz+Dx2n6TVOvw83Xy1P47X80HFKp8Yp3aHjtH4neoyod33KeCCmRBF/Hmo7hY7X9tQ4bd/QcSoHGqdyEW5dffNVuQodp/KncSqPFjJO5VbjVI7DzVflXuO1H4SO0/6icdp/QsdpP8uLOMJ3zk5LIf2T8bD3f1G3+ou96667goaPGjXKxo0bl6J2LZKpBk01fKqBpkaWGllqZP+HGtn/oUY2d+7aNB3aMuprZFe9suKEamTD5mGU1ciuennFCdXINrm/RdTXyK76vzzMrRrZDh06uLvP4bp8DZTpQFa3QnWbTQfxQLplqluDobcwC0Igm5GMBABkv+bDWkV9ti55ZCF5eILIw7zPw5yKvzLdj6zaEc6YMSPF8G+++Ya+YwEAAJB/H/YaMmSI3Xnnna563vea2h9++MHGjx9vY8aMyYk0AgAAACceyPbv3989Pfzss8/apEmT/G0jJk6c6F6UAAAAAOSGTDctkF69etn333/vGvTqo78JYgEg9+2eMcMW9+hhS3r1soMhXYj5JO7YYcuvvtr/fW7DhnZ8375cTCUA5KN+ZAEA+cP2iRMt4bbbrEKPHqlOE1epkjWZMCFX0wUA+SaQVefe6kojI9SZPAAg56177DHbt3ChHV671rZOmGDFEhLs8Lp15h07ZnFVqli9kSMtrmJFO7J5sy3t1cvazpvHZgEQfYHs6NGjcz4lAIBMqfPgg3Zo1Sqreu21Vq5zZzu2e7fFlivnxm0eN842jR1rdUeMIFcBRHcg27dv35xPCQDghOycMsX+mjzZko8eteTERIuNjydHARRoGQpkDx486N41n1GZnR4AcGLUxEDNC5q+957Fli9vu7/91ja+8ALZCqBAy1CvBXqL15NPPmlbt25NdRq9IOzrr7+2bt262fPPP5+daQQApEO9EMSULGlF4uNdbaweAgOAgi5DNbKzZs2yBx54wEaMGGHNmze31q1bW7Vq1axYsWK2Z88eW7Fihc2dO9eKFCliQ4cOtVtuuSXnUw4A8Itv3952Tp5sv3Tv7poUlGnXznW7BQAW7YHsKaecYh999JFt2LDBPvjgA/vuu+/sxx9/tMOHD1uFChWsZcuWNm7cOFcbGxMTk/OpBgA4jd96y58TDZ57LihXag4a5P4vVr16UI8F7VauJPcARF8/sjVr1nSvqNUHAAAAyEu8EAEAcojeoBXtqP0FkO9eUQsAAADkNQJZAAAARCQCWQAAAEQkAlkAAAAU3Ie9li5dmuEZNmvW7ETSAwAAAGRfINuiRQsrVKiQe3tXOL5x+j8pKSljSwYAAAByOpBdt27diSwDAAAAyJtAtlatWtm/ZAAAACC3H/Z6++237ayzzrJq1arZ+vXr3bDRo0fbZ599diJpAQAAAHIukH355Zdt8ODB1r17d/v777/9bWLj4+NdMAsAAADky0D2hRdesHHjxtmDDz5oMTEx/uGtW7e2ZcuWZXf6AAAAgOwJZPXgV8uWLVMML1q0qB08eDDfZfOUKVPslFNOsZNPPtlef/31vE4OAAAA8iqQrVOnji1evDjF8OnTp1vDhg0tPzl+/LhrBvHtt9/aL7/8Yk8//bTt2rUrr5MFAACA3Oq1IJACwwEDBtiRI0dc37Hz5s2z9957z5544ol8V+OptDVu3NiqV6/uvnfr1s2++uoru+KKK/I6aQAAAMjtGtmbbrrJnnrqKfvXv/5lhw4dsiuvvNI9ADZmzBi7/PLLLTvNmTPHevbs6XpH0MsWPv300xTTjB071mrXrm3FihWz008/3QWvPlu2bPEHsaK/N2/enK1pBAAAQAR1v3XVVVfZH3/8YQcOHLBt27bZpk2b7MYbb8z2xKnNbfPmzV2wGs7EiRNdDfHw4cNt0aJFbtquXbvajh07sj0tAAAAiPBAduTIkf43fZUoUcIqVapkOUVNAbS8Xr16hR0/atQo69evn11//fXWqFEje+WVV1ya3njjDTdeNbmBNbD6W8MAAAAQhYHsBx98YPXr17czzzzTXnrpJdu5c6flhcTERFu4cKF17tzZP6xw4cLu+9y5c933tm3b2vLly10Aq9rjL774wtXYpubo0aO2b9++oA8AAAAKSCC7ZMkSW7p0qXXs2NGeeeYZV8PZo0cPe/fdd12b2dyiAFovY6hcuXLQcH1XcwcpUqSIPfvss3buuedaixYtbMiQIVa+fPlU56kH1sqUKeP/1KhRI8fXAwAAALnYRlY9ATz++OO2du1amzlzpnvYatCgQValShXLby644AL7/fffbfXq1XbzzTenOe3QoUNt7969/s/GjRtzLZ0AAADI4e63QpUsWdKKFy9ucXFxtn//fsstFSpUcG8W2759e9Bwfc9qQK2XOugDAACAAlojq4e9HnvsMVczq1fT6mUDDz/8sP+Wfm5Q4NyqVSubMWOGf1hycrL73q5du1xLBwAAACKkRvaMM86w+fPnW7NmzVxvAXq5QGBfrdlJD2ipSUBgAK23ipUrV85q1qzput7q27evC6b1YNfo0aNdl11KFwAAAAq2TAeynTp1ct1bqburnLZgwQL3oJaPAldR8Dp+/Hi77LLL7K+//rJhw4a52mA90KVX5YY+AJZZ6rdWHz1MBgAAgAISyKpJga/7K9WQ1qtXz/UOkBPUM4Jeg5uW22+/3X2yk17Bq4+631LvBQAAACgAbWQPHz7s3uKlFw+ojeyGDRvc8DvuuMOefPLJnEgjAAAAcOKB7P333+/6kp01a5YVK1bMP1wvItArYwEAAIDckOk2AZ9++qkLWPXQV6FChfzDVTu7Zs2a7E4fAAAAkD01snq4qlKlSimGq7eAwMAWAAAAyFeBrLq6mjp1qv+7L3h9/fXXC0z/reqxQL0ytGnTJq+TAhRou2fMsMU9etiSXr3s4O+/h50mcccOW3711f7vcxs2tOP79uViKgEABaZpgV5N261bN1uxYoUdP37cxowZ4/7+8ccfbfbs2VYQ0GsBkDu2T5xoCbfdZhV69Eh1mrhKlazJhAlsEgDAiQey7du3dy8lUA8FTZs2ta+++spOO+00mzt3rvsOABmx7rHHbN/ChXZ47VrbOmGCFUtIsMPr1pl37JjFVali9UaOtLiKFe3I5s22tFcvaztvHhkLAAiSpQ5g1XfsuHHjsvJTAHDqPPigHVq1yqpee62V69zZju3ebbHlyrlxm8eNs01jx1rdESPILQDAiQWyejFARpUuXTrD0wKAz84pU+yvyZMt+ehRS05MtNj4eDIHAHDigWx8fHy6PRLoDVyahte6AsgsNTFQ84Km771nseXL2+5vv7WNL7xARgIATjyQnTlzpkUT9VqgD0E5kDvUC0FMyZJWJD7e1cbqITAAALIlkO3QoYNFE3otAHJXfPv2tnPyZPule3fXpKBMu3au2y0AALL9YS8AyA6N33rL/3eD554LGldz0CD3f7Hq1YN6LGi3ciWZDwDI2gsRAAAAgPyAGlkAYekNWtGMml8AyP+okQUAAEBEIpAFAABAwW1a0LJly3T7kfVZtGjRiaYJAAAAyJ5A9qKLLrJoQj+yAAAABSSQHT58uEUT+pEFAADI/2gjCwAAgOjofkuvbX3uueds0qRJtmHDBktMTAwav3v37uxMHwAAAJA9NbIPP/ywjRo1yi677DLbu3evDR482Hr37m2FCxe2ESNGZHZ2AAAAQO4Esu+8846NGzfOhgwZYkWKFLErrrjCXn/9dRs2bJj99NNPWUsFAAAAkNOB7LZt26xp06bu75NOOsnVyso///lPmzp1amZnBwAAAOROIJuQkGBbt251f9erV8+++uor9/f8+fOtaNGiWUsFAAAAkNOBbK9evWzGjBnu7zvuuMMeeughO/nkk+3aa6+1G264IbOzAwAAAHKn14Inn3zS/7ce+KpZs6bNnTvXBbM9e/a0goAXIgAAABTAQDZUu3bt3Kcg4YUIAAAABTSQ/eOPP2zmzJm2Y8cOS05ODhqn3gsAAACAfBfIquut/v37W4UKFaxKlSpWqFAh/zj9TSALAACAfBnIjhw50h577DG77777ciZFAAAAQE70WrBnzx7r06dPZn8GAAAA5G0gqyDW13csAAAAEDFNC+rXr+/6jtXraPWGr9jY2KDxd955Z3amDwAAAMieQPa1115zr6adPXu2+wTSw14EsgAAAMiXgey6detyJiUAAABATraRBQAAACKmRnbw4MH26KOPWsmSJd3faRk1apRFOl5RCwAAUEAC2V9++cWOHTvm/l60aFHQSxACpTY80vCKWgAAgAISyI4ZM8ZKly7t/p41a1ZOpwmICLtnzLANo0ZZobg4q//UU1ayQYMU0yTu2GG/Dx5sTSZMcN/nNmxobX7+2Yr83/4EAAByuI1sy5YtbefOne7vunXr2q5du05gkUDBsH3iREu47TZr/sknYYNYiatUyR/EAgCAPKiRjY+Pd70VVKpUyf78809LTk7O5mQAkWXdY4/ZvoUL7fDatbZ1wgQrlpBgh9etM+/YMYurUsXqjRxpcRUr2pHNm21pr17Wdt68vE4yAADRGchefPHF1qFDB6tataprB9u6dWuLiYkJO+3atWuzO41AvlPnwQft0KpVVvXaa61c5852bPduiy1Xzo3bPG6cbRo71uqOGJHXyQQAoEArktGXIPTu3dtWr17tXnjQr18/K1WqVM6nDogQO6dMsb8mT7bko0ctOTHRYuPj8zpJAAAUeBl+IcL555/v/l+4cKENHDiQQBb4P2pioOYFTd97z2LLl7fd335rG194gfwBACC/vdnrzTffzJmUABHq+L59FlOypBWJj3e1sXoIDAAA5MNAFkCw+PbtbefkyfZL9+6uSUGZdu1ct1sAACBnEcgCWdT4rbf8fzd47rmgcTUHDXL/F6tePajHgnYrV5LfAADkZj+yAAAAQH5DjSwKHL09K9pR8wsAiAbUyAIAACAiEcgCAAAgIhHIhjF27Fhr1KiRtWnTJve3CAAAADKEQDaMAQMG2IoVK2z+/PkZy0UAAADkOgJZAAAARCQCWQAAAEQkAlkAAABEJAJZAAAARCQCWQAAAEQkAlkAAABEJAJZAAAARCQCWQAAAEQkAlkAAABEJAJZAAAARCQCWQAAAEQkAlkAAABEJAJZAAAARCQCWQAAAEQkAlkAAABEJAJZAAAARCQCWQAAAEQkAlkAAABEJALZMMaOHWuNGjWyNm3a5P4WAQAAQIYQyIYxYMAAW7Fihc2fPz9juQgAAIBcRyALAACAiEQgCwAAgIhEIAsAAICIRCALAACAiEQgCwAAgIhEIAsAAICIRCALAACAiEQgCwAAgIhEIAsAAICIRCALAACAiEQgCwAAgIhEIAsAAICIRCALAACAiEQgCwAAgIhEIAsAAICIRCALAACAiEQgCwAAgIhEIAsAAICIRCALAACAiEQgCwAAgIhEIAsAAICIRCALAACAiEQgCwAAgIhEIAsAAICIRCALAACAiEQgCwAAgIgUFYFsr169rGzZsnbJJZfkdVIAAACQTaIikB04cKC99dZbeZ0MAAAAZKOoCGQ7duxopUqVyutkAAAAoCAFsnPmzLGePXtatWrVrFChQvbpp5+mmGbs2LFWu3ZtK1asmJ1++uk2b968PEkrAAAA8o88D2QPHjxozZs3d8FqOBMnTrTBgwfb8OHDbdGiRW7arl272o4dO/zTtGjRwpo0aZLis2XLllxcEwAAAOSmIpbHunXr5j6pGTVqlPXr18+uv/569/2VV16xqVOn2htvvGH333+/G7Z48eJsScvRo0fdx2ffvn3ZMl8AAAAUwBrZtCQmJtrChQutc+fO/mGFCxd23+fOnZvty3viiSesTJky/k+NGjWyfRkAAACIgkB2586dlpSUZJUrVw4aru/btm3L8HwU+Pbp08emTZtmCQkJqQbBQ4cOtb179/o/GzduPOF1AAAAQAFtWpAbvvnmmwxNV7RoUfcBAABA/peva2QrVKhgMTExtn379qDh+l6lSpU8SxcAAADyXr4OZOPi4qxVq1Y2Y8YM/7Dk5GT3vV27dnmaNgAAAER504IDBw7Y6tWr/d/XrVvneiEoV66c1axZ03W91bdvX2vdurW1bdvWRo8e7brs8vViAAAAgOiU54HsggUL7Nxzz/V/V+AqCl7Hjx9vl112mf311182bNgw94CX+oydPn16igfAspP6tNVHD5oBAAAgfyqSH14f63lemtPcfvvt7pNbBgwY4D7qR1bdcAEAACD/yddtZAEAAIDUEMgCAAAgIhHIAgAAICIRyAIAACAiEciGoR4LGjVqZG3atMn9LQIAAIAMIZANQz0WrFixwubPn5+xXAQAAECuI5CNQrtnzLDFPXrYkl697ODvv4edJnHHDlt+9dX+73MbNrTj+/blYioBAADyeT+yyH3bJ060hNtuswo9eqQ6TVylStZkwoRcTRcAAEBmEMhGmXWPPWb7Fi60w2vX2tYJE6xYQoIdXrfOvGPHLK5KFas3cqTFVaxoRzZvtqW9elnbefPyOskAAABhEchGmToPPmiHVq2yqtdea+U6d7Zju3dbbLlybtzmceNs09ixVnfEiLxOJgAAQLoIZFPptUCfpKQkK+h2Tplif02ebMlHj1pyYqLFxsfndZIAAAAyhIe9orjXAjUxUPOChq++ai0+/9xq33efC2YBAAAiAYFsFFMvBDElS1qR+HgXwOohMAAAgEhB04IoFt++ve2cPNl+6d7dNSko066d63YLAAAgEhDIRqHGb73l/7vBc88Fjas5aJD7v1j16kE9FrRbuTIXUwgAAJA+mhYAAAAgIlEjm8/oDVrRjtpfAACQEdTIAgAAICIRyIahPmQbNWpkbdq0yf0tAgAAgAwhkI3ifmQBAAAiGYEsAAAAIhKBLAAAACISgSwAAAAiEoEsAAAAIhKBLAAAACISgSwAAAAiEoEsAAAAIhKBbBi8EAEAACD/I5ANgxciAAAA5H9F8joB+Znnee7/ffv25doyDyYlWbQ70fwmD7OnzEZ7PpKH+SMfk45GdzkU8pA8zA/25WIs5FuWLw5LSyEvI1NFqU2bNlmNGjXyOhkAAABRZ+PGjZaQkJDmNASyaUhOTrYtW7ZYqVKlrFChQhYNdBWk4F2Fp3Tp0nmdnIhEHpKH+QHlkDzMLyiL5GFmqY51//79Vq1aNStcOO1WsDQtSIMyL70rgYJKQSyBLHmY1yiH5GF+QDkkH/OLaCqLZcqUydB0POwFAACAiEQgCwAAgIhEIIsgRYsWteHDh7v/kTXk4YkjD8nD/IBySD7mF5TF1PGwFwAAACISNbIAAACISASyAAAAiEgEsgAAAIhIBLJRSB0NDxs2zKpWrWrFixe3zp072x9//JHmb0aMGOFeChH4OfXUUy1aZCXPnnjiCWvTpo17oUalSpXsoosuslWrVgVN07FjxxT5euutt1o0yEqezpkzx3r27Ok6yVZeffrppxbNxo4da7Vr17ZixYrZ6aefbvPmzUt12l9//dUuvvhiN73ybvTo0RaNMpNn48aNs7PPPtvKli3rPiqjodNfd911Kfbh888/36JNZvJ1/PjxKfJMv4tWWTmuzZo1y0477TT3EFj9+vVdnkYrAtko9O9//9uef/55e+WVV+znn3+2kiVLWteuXe3IkSNp/q5x48a2detW/+f777+3aJGVPJs9e7YNGDDAfvrpJ/v666/t2LFj1qVLFzt48GDQdP369QvKVy0rGmQlT5V3zZs3dyfNaDdx4kQbPHiw62Vk0aJFLl+Ufzt27Ag7/aFDh6xu3br25JNPWpUqVSwaZTbPFCxcccUVNnPmTJs7d65766H24c2bNwdNp8A1cB9+7733LJpkNl9FnfoH5tn69estWmX2uLZu3Trr0aOHnXvuubZ48WIbNGiQ3XTTTfbll19aVPIQVZKTk70qVap4Tz/9tH/Y33//7RUtWtR77733Uv3d8OHDvebNm3vRKKt5FmrHjh2edrnZs2f7h3Xo0MEbOHCgF22yI0+Vl5988okXrdq2besNGDDA/z0pKcmrVq2a98QTT6T721q1annPPfecF21OJM/k+PHjXqlSpbz//ve//mF9+/b1LrzwQi+aZTZf33zzTa9MmTK5mMLIkZHj2r333us1btw4aNhll13mde3a1YtG1MhGGV3Jbdu2zd0iC3wNnG4FqcYhLbrtq1sfqtW56qqrbMOGDRYNTiTPAu3du9f9X65cuaDh77zzjlWoUMGaNGliQ4cOdTVnBV125Wm0SkxMtIULFwbln16pre/kX87lmfZN3VkJ3YdVc6vmQ6eccor179/fdu3aZdEiq/l64MABq1WrlqvlvvDCC13TF2SM8jUwv0U14NG67xfJ6wQgdyl4kMqVKwcN13ffuHAUYKgNjg7Uug308MMPu7Zjy5cvd21AC7Ks5lmg5ORkd/vnrLPOcgGrz5VXXukO5rpAWLp0qd13332uHe3HH39sBVl25Gk027lzpyUlJYXNv99++y3P0lXQ80z7p/bVwCBCzQp69+5tderUsTVr1tgDDzxg3bp1c0FFTEyMFXRZyVedR9544w1r1qyZu8B/5pln7Mwzz3TBbEJCQi6lPHLpGBkuv/ft22eHDx92zxxEEwLZAk61fbfccov/+9SpU7M0Hx2YfXTwUWCrAGzSpEl24403WkGSXXkWSG1lFfSHtiu++eab/X83bdrUPfjUqVMnd0KsV6+eFRQ5kadAblLb4vfff9/VvgY+mHT55ZcH7cM6Pmrf1XTal5FSu3bt3MdHQWzDhg3t1VdftUcffZQsQ6YQyBZwF1xwgQs6fY4ePer+3759uwuafPS9RYsWGZ5vfHy8NWjQwFavXm0FTXbn2e23325TpkxxT6amV9vgW67ytSAFsjlVDqOVmqKotk/5FUjfo/VBrpzMM9UYKpD95ptvXKCaFjW90rK0D0dDIJsdZTE2NtZatmxZIM8nOUH5Gi6/S5cuHXW1sUIb2QJOt/3VNYfv06hRI7cTzJgxwz+NbkfoqfHAK+T0qH2Tag0Dg5CCIrvyTO32FcR+8skn9u2337pbj+nRE6hS0PI1p8phtIqLi7NWrVoF5Z+ar+g7+Ze9eabeNVRLOH36dGvdunW622bTpk2ujWxB24dzsiyqacKyZcuiJs9OlPI1ML9FPeNE7b6f10+bIfc9+eSTXnx8vPfZZ595S5cudU/c1qlTxzt8+LB/mvPOO8974YUX/N+HDBnizZo1y1u3bp33ww8/eJ07d/YqVKjgnsSPBlnJs/79+7snc5VvW7du9X8OHTrkxq9evdp75JFHvAULFrh81bzr1q3rnXPOOV40yEqe7t+/3/vll1/cR4evUaNGub/Xr1/vRZv333/f9fIwfvx4b8WKFd7NN9/s8nPbtm1u/DXXXOPdf//9/umPHj3qz7uqVat6d999t/v7jz/+8KJFZvNMZTQuLs778MMPg/ZhlUPR/8rHuXPnun34m2++8U477TTv5JNP9o4cOeJFi8zm68MPP+x9+eWX3po1a7yFCxd6l19+uVesWDHv119/9aJResc15Z3y0Gft2rVeiRIlvHvuucdbuXKlN3bsWC8mJsabPn16Hq5F3iGQjULq+uihhx7yKleu7A4+nTp18latWpWiex51uRXYtYdOfjqoV69e3X1XIBYtspJnOiCF+6jrGdmwYYMLWsuVK+fmWb9+fXdg2rt3rxcNspKnM2fODJun6gIpGinIr1mzptsv1QXSTz/9FNS1W2C+KNAKl3eaLppkJs9U/sLlma9M6qK0S5cuXsWKFb3Y2Fg3fb9+/fwBXDTJTL4OGjTIP632/+7du3uLFi3yolV6xzX9H7qf6jctWrRweagKEN95JRoV0j95XSsMAAAAZBZtZAEAABCRCGQBAAAQkQhkAQAAEJEIZAEAABCRCGQBAAAQkQhkAQAAEJEIZAEAABCRCGQBAAAQkQhkgSjVsWNHGzRoUIanHz9+vMXHx1skuOaaa+zxxx/Pk/XRO2ZuvvlmK1eunBUqVMgWL16cIq9r165to0eP9n/XdJ9++qnlhhEjRliLFi0skqW37f78809/3ucX1113nV100UW5uszQcpYViYmJbj4LFizItnQB2YlAFkDEBdVpWbJkiU2bNs3uvPPObD2hZ9T06dNdoDVlyhTbunWrNWnSxD7++GN79NFHc2X5MKtRo4Y/73M7wM9PQfT8+fPdRdWJXDDFxcXZ3Xffbffdd18OpBA4cQSyAHLMsWPHcj13X3jhBevTp4+ddNJJlhfWrFljVatWtTPPPNOqVKliRYoUcbWzpUqVyrFlqtYsP84rr8TExPjzPppVrFjRSpQoccLzueqqq+z777+3X3/9NVvSBWQnAlkgn9VM3nHHHa52smzZsla5cmUbN26cHTx40K6//noXDNWvX9+++OKLoN/Nnj3b2rZta0WLFnVB1P3332/Hjx/3j9fvr732Whfcafyzzz6bYtlHjx51NS/Vq1e3kiVL2umnn26zZs3KdE3UxIkTrUOHDlasWDF75513bNeuXXbFFVe4+eqk2rRpU3vvvfeCbrkq/WPGjHG/10fzkuXLl1u3bt1cupUXajKwc+fOVNOQlJRkH374ofXs2TMoT9evX2933XWXf/6BvvzyS2vYsKFbxvnnn+9q8gK9/vrrbrzW59RTT7WXXnop1eVrXbT9NmzY4JajmuCs1Dhv3LjRLr30Unf7XEHwhRde6M+TwNvUjz32mFWrVs1OOeWUVOf15JNPurxT2bnxxhvtyJEjKdIcbl7Lli2z8847z4oXL27ly5d3NXsHDhxI8buHH37YBUylS5e2W2+9NSgQ1nrffvvt7lOmTBmrUKGCPfTQQ675RWbKnWq4a9as6cpPr169XJnKTK2o5qfvM2bMsNatW7v56EJj1apV/vlrPVSb7ysjGibalsp/lQ+to7bL9u3bU112nTp13P8tW7Z081EeBHrmmWfcPqg8HTBgQNDFXmb3QeWjapKVN9r3tf1SuxPhK4vKv8CyKZ999pmddtpprozXrVvX5UXg8UPHorPOOsvef//9NPMdyBMegHyjQ4cOXqlSpbxHH33U+/33393/MTExXrdu3bzXXnvNDevfv79Xvnx57+DBg+43mzZt8kqUKOHddttt3sqVK71PPvnEq1Chgjd8+HD/fPWbmjVret988423dOlS75///KdbzsCBA/3T3HTTTd6ZZ57pzZkzx1u9erX39NNPe0WLFnXLlDfffNMrU6ZMqmlft26dohOvdu3a3kcffeStXbvW27Jli0uf5vXLL794a9as8Z5//nm3Tj///LP73d9//+21a9fO69evn7d161b3OX78uLdnzx6vYsWK3tChQ916LVq0yPvHP/7hnXvuuammQdMoDdu2bfMP27Vrl5eQkOA98sgj/vn71ic2Ntbr3LmzN3/+fG/hwoVew4YNvSuvvNL/2wkTJnhVq1b1r4/+L1eunDd+/Piwy9e6aDlanpazY8cO/3YNzOtatWp5zz33nP+70qztJomJiS4dN9xwg9tWK1ascGk65ZRTvKNHj7pp+vbt65100kneNddc4y1fvtx9wpk4caLbhq+//rr322+/eQ8++KDb7s2bN/dPE25eBw4ccOvdu3dvb9myZd6MGTO8OnXquGlDf3fZZZe530yZMsVtrwceeMA/jdZb02jdtXzlp8qqynJGy91PP/3kFS5c2Hvqqae8VatWeWPGjPHi4+MzVBZV5mTmzJnu++mnn+7NmjXL+/XXX72zzz7bLVcOHTrkDRkyxGvcuLG/jGhYUlKS16JFC699+/beggULXFpatWrl1is18+bNc8vSvqb5qPz58qt06dLerbfe6srz559/num8CPXBBx+4eU6bNs1bv36926cC5xdYzlQWlS6V+8CyqWVpHirT2j+/+uortw+PGDEiaFn33XdfmusN5BUCWSAf0YlCJ00fBXQlS5Z0QYaPTkI6Ic2dO9d9V+CgICc5Odk/zdixY10AoRPx/v37vbi4OG/SpEn+8Tq5Fi9e3B9c6SSo4HLz5s1B6enUqZMLJDMTyI4ePTrd9ezRo4cLHALXOzDQEwXxXbp0CRq2ceNGtwwFNOEoGNR6BOZFuMDRtz6alwKGwHyrXLmy/3u9evW8d999N0W6FHinRsvR8gJlJpB9++23U2xPBbDaXl9++aU/KFI6fYFtapROXeAEUjAXGsiGzkvBUNmyZV1A6zN16lQXUPouEvQ7BfW+Cyp5+eWX/eXOt94KygPXRQGRhmW03F1xxRVe9+7dg8YreM5KIKvgMnB9NOzw4cPuuy78AvNFFNQpfRs2bPAPUxCs3ylgzciyA/NZ2137tE+fPn3cumQ0L0I9++yzXoMGDdzFTzhplbPA+T/++ONBw1QGdSETSBcQCnCB/Ca6GxAB+VCzZs2C2vrpFqRux/voNrHs2LHD/b9y5Upr165d0C1z3QbUbeBNmzbZnj173O1e3ab00e3qwNvRuo2s2/INGjQISotudWr5maFbt4E0X/UgMGnSJNu8ebNLi+abXts93eadOXNm2LauaocamlY5fPiwu8Ua2nwgNUpDvXr1/N91y9eXr2qOoeXodny/fv380+iWq26T5xSt9+rVq1O0qVWTAKXHR2VCD+KkRWVDt/sDqawoXwOFzku/a968ubu9HVimkpOT3e14XxnUNIHbUfNWuVPTiFq1arlhZ5xxRtD20DRq2qJykZFyp7TodnjoOuihuhPZt7StRdtbt+bD0bL14Jg+Po0aNXJNPjSuTZs2mVp+48aN3T4dmAblQVb3QbUFV9MBNQdQs5ju3bu7ZjWZaRus8vbDDz+4piU+SofK26FDh/zbV01M9B3IbwhkgXwmNjY26LuCgMBhvqBAQUV2UfChE+zChQuDTrSS2YemAoMfefrpp137V51wFTBpvNqLpvdQkdKkk/JTTz2VYpwvCAmlNpg62Wre6QV5qeW1r/2mrz2o2igHXgRIaB5lJy23VatWrn1xKLVFTS2fT0R2ziuvyl1G5PR+lJnl+9LgW35W8kIBti4svvnmG/v666/ttttuc/ub2pyHLis1Wq7axPbu3TvFOLWZ9dm9e3dQ+QPyCwJZIMLpQaSPPvrIBWC+k7NqWFSjl5CQ4GpfdVL7+eef/TVPqqX9/fff3UNZvgdTVAuj2qmzzz47W9OntOhhmauvvtp914lby1bNlo+CTi0/kB4+0XrpoZSM1jD5uk9asWJFUFdK4eafHtU66uGZtWvXuqe2c4vWWw/MVapUyT1cdKJlQ9tdD/r5/PTTTxn6nR52Uq20L8jVdixcuHBQTb5q81QLrto637wVdAXWYGr5gTTNySef7IK1jJQ73zqEziO7hSsjWrZql/XxrZPK1t9//x1UfkPnI5ktb1ndB5X3uuDTRw+P6YFE1e6qHIXScSDcfqZgWA+RpkUPXiqNQH5DrwVAhFMtjE60elr+t99+c08gDx8+3AYPHuwCDwUWuj1+zz332LfffutOSHriXON8dDtTwZoCHvV5um7dOps3b5498cQTNnXq1BNKn4IW1Rb9+OOP7nbsLbfckuKpbwWrClb0tLl6JVCwq5OyaoHU44H6w9RtdfUwoN4bUgsSVGOkE7O6Cgqd/5w5c1zThrR6PQilmirlwfPPP++CbwUIb775po0aNcpyiraDapYV/H/33XduW+jJdT2NrqYimTFw4EB74403XJqVfpWLjHShpDSoNq5v376uvKgpgsqXeo3wNSsQ1XyrbCm4U9+9mr96KAgsW3rqX2VRwZJ6q1D3aEpXRsud1lvNCPS0/x9//GEvvvhilpoVpEdlRMtXTwcqI7ql37lzZ3cXQWlctGiRS5vSqgvA0CY0ProAUXCpNKqc7927N0PLz8o+qIuN//znP24b6YJrwoQJbtm+Zh3h1lE9N2zbts1dzMqwYcPsrbfecmVdZUP7qHon+Ne//hX0W5XFLl26ZGhdgNxEIAtEOHXVoyBCJz21WVSbSAUXgSci3W5ULY9qbXRybt++vbt9HUjBjk6iQ4YMcbVu6lpJAWRq7QczSulQcNm1a1fXFZH69wx9w5G6HFINnWq5FIwq+FFtqGoBFbTqBKqAQk0S1D4xMFAKddNNN6W4Lf/II4+4IFntYTNze1TzUvdbyhstXwGMggdfF0s5QW0SFXQr33W7V7WCvm6zMltDe9lll7nuru699163vdUNWf/+/TOUBl006EJC7UAvueQS69SpkwsiA2mYLlTOOecct6wLLrjAdQcVSGVKtbbqHk4XJwpiAzvpT6/cqY2tmneoeYrK91dffZUiyMoOF198sWtneu6557oyoqBbdzh0Yajup7SO2nfUHlU15qnR3QNd+Lz66quuDOuCJKMyuw9qX1DeqP2y2v+qicHnn3+eaptatU3WRaVql321q9ov9fIO5au2tfL7ueeeCwqG586d6wJylQMgvymkJ77yOhEAkF0UNCkIULChh4KQM1Srr1vsab0pShcuauKRW29VQ87QRYouIh544AGyGPkONbIAChTdWtWt0sw0IQAQnpqP6G6EXigC5Ec87AWgwAl9mxKArNHDaznRlAPILjQtAAAAQESiaQEAAAAiEoEsAAAAIhKBLAAAACISgSwAAAAiEoEsAAAAIhKBLAAAACISgSwAAAAiEoEsAAAAIhKBLAAAACwS/T8Euy0eUlIBWAAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 700x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "rates = [-0.5, -0.25, -0.1, 0.1, 0.25, 0.5, 1.0]\n",
+    "threshold = 2.0\n",
+    "finals, verdicts = [], []\n",
+    "for r in rates:\n",
+    "    tmpl = core.access({'study': study_region(threshold=threshold)})\n",
+    "    doc = template_document(core, tmpl, {'study/model': model(rate=r)})\n",
+    "    s = Composite({'state': doc}, core=core)\n",
+    "    s.run(4.0)\n",
+    "    finals.append(s.state['study']['level'])\n",
+    "    verdicts.append(s.state['study']['verdict'])\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(7, 4))\n",
+    "colors = ['#2e7d32' if v == 'pass' else '#c62828' for v in verdicts]\n",
+    "ax.bar([str(r) for r in rates], finals, color=colors)\n",
+    "ax.axhline(threshold, ls='--', color='k', lw=1, label=f'threshold = {threshold}')\n",
+    "ax.set_yscale('log')\n",
+    "ax.set_xlabel('model rate (the filler dropped into the site)')\n",
+    "ax.set_ylabel('final level (log)')\n",
+    "ax.set_title('One study template, seven models — verdict follows the filler')\n",
+    "ax.legend()\n",
+    "for x, (f, v) in enumerate(zip(finals, verdicts)):\n",
+    "    ax.text(x, f, v, ha='center', va='bottom', fontsize=8, color=colors[x])\n",
+    "plt.tight_layout(); plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9eb84cb9",
+   "metadata": {},
+   "source": [
+    "## 4. The hole is *face-sorted*: only a conforming model fits\n",
+    "\n",
+    "A site is not a blank — it carries an interface (`_sort`). Filling it with something of\n",
+    "the wrong shape is refused **before** anything is constructed, and the error names the\n",
+    "site. Here a link that outputs `mass` instead of `level` does not meet `MODEL_FACE`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "be9207a7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T22:42:26.493636Z",
+     "iopub.status.busy": "2026-07-31T22:42:26.493569Z",
+     "iopub.status.idle": "2026-07-31T22:42:26.495756Z",
+     "shell.execute_reply": "2026-07-31T22:42:26.495413Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "refused: fill: filler rejected for site 'study/model' at ('study', 'model'): filler does not provide output port 'level' (has ['mass'])\n"
+     ]
+    }
+   ],
+   "source": [
+    "nonconforming = core.access({\n",
+    "    '_type': 'link', '_inputs': {'level': 'float'}, '_outputs': {'mass': 'float'}})  # wrong face\n",
+    "\n",
+    "try:\n",
+    "    template_document(core, core.access({'study': study_region()}),\n",
+    "                      {'study/model': nonconforming})\n",
+    "except ValueError as e:\n",
+    "    print('refused:', e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4b9a9cb9",
+   "metadata": {},
+   "source": [
+    "And a template left **unfilled** is refused too — `template_document` raises *before*\n",
+    "construction, naming the empty hole, so you learn which site is missing rather than\n",
+    "debugging a constructor error:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "c8727f6c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T22:42:26.496857Z",
+     "iopub.status.busy": "2026-07-31T22:42:26.496801Z",
+     "iopub.status.idle": "2026-07-31T22:42:26.498522Z",
+     "shell.execute_reply": "2026-07-31T22:42:26.498174Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "refused: template is not ground — required site(s) left unfilled: 'study/model'\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    template_document(core, core.access({'study': study_region()}), {})   # nothing bound\n",
+    "except ValueError as e:\n",
+    "    print('refused:', e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ea01bf64",
+   "metadata": {},
+   "source": [
+    "## 5. Investigations: one hole per member\n",
+    "\n",
+    "An **investigation template** is the same idea one level up: a document whose members are\n",
+    "studies, each with its own `model` site. Nothing new — it is just a bigger document with\n",
+    "more holes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "5e729675",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T22:42:26.499421Z",
+     "iopub.status.busy": "2026-07-31T22:42:26.499362Z",
+     "iopub.status.idle": "2026-07-31T22:42:26.501286Z",
+     "shell.execute_reply": "2026-07-31T22:42:26.500950Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "('investigation', 'study_A', 'model')\n",
+      "('investigation', 'study_B', 'model')\n",
+      "('investigation', 'study_C', 'model')\n"
+     ]
+    }
+   ],
+   "source": [
+    "investigation = core.access({'investigation': {\n",
+    "    'study_A': study_region(threshold=2.0),\n",
+    "    'study_B': study_region(threshold=2.0),\n",
+    "    'study_C': study_region(threshold=2.0),\n",
+    "}})\n",
+    "\n",
+    "for path in sorted(open_sites(investigation)):\n",
+    "    print(path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "78973df3",
+   "metadata": {},
+   "source": [
+    "### Gating as filling: fill a member to run it, leave it open to skip it\n",
+    "\n",
+    "`investigation_document` fills the members you bind and **prunes** the ones you leave\n",
+    "open — dropping them from the built document and reporting them as `blocked`. This is the\n",
+    "key idea: *gating is not a scheduler decision*. The engine never has to \"decide not to\n",
+    "run\" a member — a member that was not filled simply **is not in the document**.\n",
+    "\n",
+    "(`member_depth=2` says a member sits two levels deep: `investigation / study_X / model`.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "49075b3e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T22:42:26.502275Z",
+     "iopub.status.busy": "2026-07-31T22:42:26.502222Z",
+     "iopub.status.idle": "2026-07-31T22:42:26.507859Z",
+     "shell.execute_reply": "2026-07-31T22:42:26.507578Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "built members:   ['study_A', 'study_B']\n",
+      "blocked members: ['investigation/study_C']\n",
+      "  study_A: level=5.062  verdict=pass\n",
+      "  study_B: level=0.062  verdict=fail\n"
+     ]
+    }
+   ],
+   "source": [
+    "document, blocked = investigation_document(\n",
+    "    core, investigation,\n",
+    "    {\n",
+    "        'investigation/study_A/model': model(rate=0.5),    # grows past threshold -> PASS\n",
+    "        'investigation/study_B/model': model(rate=-0.5),   # decays -> FAIL\n",
+    "        # study_C left unbound on purpose -> pruned\n",
+    "    },\n",
+    "    member_depth=2,\n",
+    ")\n",
+    "\n",
+    "built = list(document['investigation'].keys())\n",
+    "print('built members:  ', built)\n",
+    "print('blocked members:', blocked)\n",
+    "\n",
+    "sim = Composite({'state': document}, core=core)\n",
+    "sim.run(4.0)\n",
+    "for name in built:\n",
+    "    st = sim.state['investigation'][name]\n",
+    "    print(f\"  {name}: level={st['level']:.3f}  verdict={st['verdict']}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "bfdbdba6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T22:42:26.508960Z",
+     "iopub.status.busy": "2026-07-31T22:42:26.508902Z",
+     "iopub.status.idle": "2026-07-31T22:42:26.525958Z",
+     "shell.execute_reply": "2026-07-31T22:42:26.525577Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAl0AAAE1CAYAAADdzVWBAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjYsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvq6yFwwAAAAlwSFlzAAAPYQAAD2EBqD+naQAAL0RJREFUeJzt3Qd4FcXCxvFJgNB7USGAFEG6SlFQQEREERSQalfsYsdyL15F1GsvCFg/QewIioULitgFqSIoIEoJgiDNYOih7Pe8c93czclJck5yMin8f88TI6dsnd19d2Z2Eud5nmcAAACQp+LzdvIAAAAgdAEAADhCTRcAAIADhC4AAAAHCF0AAAAOELoAAAAcIHQBAAA4QOgCAABwgNAFAADgwGEbui699FJz9NFH59v8NW8tAzJ36qmnmubNmxfaTfTrr7+aM844w1SsWNHExcWZ999/37zyyiv2/5OSktKtp358ek+f0WdjJdx888uIESPssmzdujVm04xkuwJIfwxGqkePHubKK6/McLwtWLAg2+/m9XEYFxdnhg4dalzmhW3btpmyZcuaadOm5W3oimZDFwQbNmywheuHH37Il/nPnj3bzn/79u35Mn/kr0suucT8+OOP5sEHHzSvvfaaadOmDbukEJ4P/vOf/5i2bdvak+xRRx1lzjvvPLNs2bI8W06gIJk1a5aZMWOGufPOO/N7UQqMqlWrmiuuuML861//ivq78UX9JHvfffeFPcm+9NJLZsWKFXkeujT/cKFL89YyoGjas2eP+e6778yQIUPsXdiFF15oEhMTzUUXXWTfq1u3bn4vYpESyXbN6nyQmfnz55tzzz3XpKammkcffdTceOON5o8//rCvA4eDxx57zHTt2tU0bNgwvxelQLnmmmvM999/bz7//POovlfcHKZKlCiRr/MvWbJkvs4f/3Xo0CF7QS1VqlRMN8mWLVvs70qVKqV7vVixYvansFm1apWt5SlTpowpiPJqu06ePNmWEd3pH3HEEfa1f/zjH2bfvn25mu6uXbtszRliS9t106ZNpn79+vm+aYvCPt68ebOt6X3++efze1EKnCZNmtjuL2oBPO2009zVdKmts1y5cub33383vXv3tv9fvXp1M2zYMHPw4EH7mf3795sqVaqYyy67LMP3U1JS7AVPn/fphHbvvffaZK1wUrt2bXPHHXdkONF9+umn5pRTTrEXNs23cePG5p///Kd978svv7RNAqL5qlk02E8mXJ8utdPqjrlChQp2mmoeWrx4cYb+NUuWLLHf14GtZT/yyCPN5Zdfbr/vUzPG7bffbv+/Xr16afP3+5yE69O1evVq079/f7utdHE76aSTbIEP0nppOu+8845ttlLtiZZBdyIrV66MuC3/l19+sbUv6m+k/aVqUs/zzLp16+ydvbaB1uuJJ57IMI1I94/f1j5p0iTTtGlTU7p0adO+fXvb5CYvvPCCnYaWX23+mfU3WrhwoenQoYP9vrZluBNAtMv0xhtvmGbNmtnPfvzxx/a9t99+27Ru3dqUL1/ern+LFi3MqFGjMoQP/WS3jf0aF5UBzdMva7npW/Xzzz+bfv362fKhbabmyg8//DDD55YuXWpPAtpeKh8PPPCADQ65oeZRhS7d3cWqlkd9ugYMGGC3tarrb7rpJrN3796I+rbpdW1nX3bbNbvzQWbi4+NzfdPkL9tXX31lrrvuOlOjRg27X7LqWxquz41fdtU3UCd7LYPKsF9+c+rZZ59NOxZq1qxprr/++gy1837/yrw4FmO5PrrZ0XxV/t9888105Slafvl7/PHHzVNPPWWPaa13586dzU8//RT2Oqhzg/o/6RxywQUXZNl/N7SvU7Tn9rlz55ozzzzTnsN1vdByqSkw1LfffmvLvqbVoEEDe96NlK4/Bw4cMKeffnrY93fv3m2uvvpqe/zqOL744otNcnJyRGFuyJAh9kZGy9WqVSszYcKEDJ/TeUvnYJ2L9Tldq7TO2XVx0jlPx+7o0aPTXps+fbrp2LGjDcLaP2effbY9V4byy6Pmp99TpkzJdD7dunUzH330kb12RsyLwvjx4zVlb/78+WmvXXLJJV6pUqW8Zs2aeZdffrn33HPPeeedd5793LPPPpv2Ob1XqVIlb9++femmOWHChHTTPHjwoHfGGWd4ZcqU8W6++WbvhRde8IYOHeoVL17cO/fcc9O+99NPP3kJCQlemzZtvFGjRnnPP/+8N2zYMK9Tp072/T/++MMbOXKknfZVV13lvfbaa/Zn1apVactdt27dtOlpvu3bt/eKFStm5zdmzBivW7duXqtWrew0tO6+xx9/3OvYsaOd/osvvujddNNNXunSpb127dp5hw4dsp9ZvHixN3jwYPvdp556Km3+O3futO9r3loGn5b3iCOO8MqXL+8NHz7ce/LJJ+284+Pjvffeey/tc1988YWd5vHHH++1bt3aTnvEiBF2e2n+2bn33nvt94877ji7fNpHZ599tn1N82zcuLF37bXX2tdPPvlk+/pXX32VbjtFsn9E323ZsqVXu3Zt7+GHH7Y/FStW9OrUqWO3b9OmTb0nnnjCu/vuu+2+7NKlS7rvd+7c2atZs6ZXo0YNO49nnnnGO+WUU+x0X3755RwvU5MmTbzq1at79913nzd27Fhv0aJF3owZM+x7Xbt2ta/pR9Po379/uu9rvwXLTTja99ovmp62sfb7lClT0h1Da9asSbee+vHpvdAyp/Kubadt9sgjj9jtp7IeFxeXrnxs3LjRrlvlypVtuXjssce8Y445xu6H0PlGY8WKFbZc6BjWdFq0aOE9/fTT3tatW6Oell8GNY1evXrZdbnwwgvtaxdddFGW28Gn1zUdX3bbNbvzQWaWLl1qy5H2o39sR8tfNu07Lc/o0aPtsRDuPBS6jULXWeeEo446yrv//vvt9q9fv74t9znZD8H5nH766Xa5VOZ1Dmzbtq2Xmpqa58dirNdn79699pzSvHlzO32V1+uvv977/vvvo56WX/5UTo8++mh73OmcUaVKFXuMqUz5tB9LlizpNWjQwP6/rkevvvpq2HN9Zsd9NOf2zz77zJ4zdc3S+uqzOsb12ty5c9M+t2TJEntt0jn3oYcesttZ1xn/fJCdK664wqtatWqmZVrbRtdClQdtZ12vdF4KHiuh67l79257Di5RooR3yy232O9qGpqeykDQpZdeal8/66yz7Hu69qocqaz69L7m7dP1U+dFXZt92hd67cwzz7Tf1b7UPlX5CJ4zPvnkE7sOKj+6HmpaOu8q34Q7Tl9//XU7/x9//DHbbZm2vLEIXXpNJ7Qgv+AEV0af++ijj9J9rkePHvZA8+lEqJX+5ptv0n1OhVjfnzVrlv23f1HbsmVLpsur5czspB16snv33Xcz7HSdQE477bQM01ChCfXWW2/Zz3399ddpr+mCl9mFLvRA1AlKnw2u944dO7x69erZwqFlCR6YKrTBAKvgGcnO90+yuvD4Dhw44CUmJtpC6V8MJDk52R6wweWMdP+I/q0TUXD9dRLW60ceeaSXkpKS9vo//vGPsBdNvaaTik/rrMCok79/UYh2mfRZXUyDFJwrVKhgt0VWIgldwRO2ykBQTkOXwqBOcLqo+HRi69Chgw1VoeUoeOLdvHmzPXHkJnT59uzZ473xxht2eVRetH8HDhxoQ6tfRrPjl8Fzzjkn3evXXXedfV2hNbPtkNPQld35IDPvv/++vegpiNx6661eTvjLppASWr6iDV26qK5cuTLtNW0rvR68CEVK5ULTU0gK7juFYE1z3LhxeX4sxnJ9Qs2bN8+75ppr0m4UdE3SzZTOa5Hwy5/OgevXr097XceWXldgCL0O3nXXXRmmE23oyu7cruNex3z37t3ThRtdl3S9UGWBr3fv3rZSZO3atWmvLVu2zJbnSEKXymzwOh5apvVeMJw/+uij9vUPPvgg0/V8+umn7WcUWHyahgJkuXLl0q4Ln3/+uf3cjTfemGH+wfUOhq7bbrvNlr9XXnkl3XVUZeDKK69MNw2FZp0Xg6+rPOsmYPv27Wmv+Tfk4Y7T2bNn2/cmTpzoRSpmHenV7BCkajw1l/lU3VutWjUzceLEtNdUDakmwoEDB6a9pqYotZUee+yxtvnB//HbTL/44ot0fWU++OCDXDediKq01c8r+FisqidV1R5KVcw+VV9r+dQUKOpYlxN69LRdu3a2udSn6uqrrrrKVnOHPi2lJpKEhIR021uC2zwrevLCp74waqpS+VWVr0/bWE22wWlGun98qhoPNp+ceOKJ9reeAFMVb+jroctfvHhxW33t0zrr36qeVlNHTpZJ1fBq7gzSuqoPhspjVrQvXA+78Oeff9rOmmqK27FjR9r6qTm7e/fudmgKNe/75UhlUWXJpyp5v6kjt1Tlfv7555uZM2eaNWvW2P5NaubQ0Bhqbn/ooYcinlbosXXDDTekrUNBoCYMbXN1oH/uuefMk08+ma5JU7T9/WMvOzq35LbfmZp51ETka9mypW3WifS4D9I+VH/Gm2++OV0zqpZT0wzt2pAXx2Is1yeUmtS03zZu3Gi7E6hZXs2ZaiZX14rffvstoumo20ytWrXS/q1jS+ercOX02muvzfVyZ3du14MgOuZ1HOoc4G9jnb90vv3666/tNVHdez755BO7/HXq1EmbnvaPym0kNP3KlStn+r6uT8H+0Vp/lZOsjuFp06bZriuDBw9Oe03T0EMqO3futM3w8u6779rmVjVVhwptete1S/tWTZGvv/667Rrk0zldzeWaX7BM6ljUfvTLpMqJtq2+qybbYBNi6PXC52+baIa/iUlHer+tNXRhgm272hG60KqdXW37ar9/7733bH+vYOhSYVq+fHmG6fl0gIu+83//9382PNx11122sPXt29f2ecmsH0ZW1q5dG7ajcLgnNnQR1FNQ6gPkL4/vr7/+inre/vz94BGkA8R/PzhmVfAgCu78SNrTw31fhUz7UcE49PVgX7VI909W8xH18wj3eujyq49JaGfURo0a2d8KPwoY0S6T+qKEUl8b9aU466yz7AlWIUIXXPUfyG/qz6GTivrdZfaIstZRy51ZOVJ4zo6e/gstvzo5ZkZ9XHRC1A2XLtTq2/DII4/YIBaJY445Jt2/dfHVsVsQxhKTu+++2y6jHw7VQVvbX2X1lltusa+pT8igQYMiml64chet0OMp3Lk2Uior4cqGLvgK0P77eXks5nR99ARpkPZJ8GY43I2CjmeFMPUfVgjTtSLc/LMrp/5663wRpGuc31cvN7I7t2sbSzBYhNJxrOusjulwy699HunNTVb9lUKnrYoCXUezOobXrl1rvxd6nQ5e60T941TmFJaz8+qrr9rApv0bDHPB7ZVZZ3eF/OB8M9te4SpU/G0TzZhnMQldkd696eSkTnzq0Kb0rUKrOyJ1ovMpoavTnO4qw/Ev1jrAlOiVUnVHppoq1aJpw+pJo7x8QkwHr4aDUCfp4447zhY0Lbcu0LGodYtEZusXaYe+cN+PZJqR7p/sppnb5Q+KdpnCnZzVuVl3ObozVPnUz/jx423H0HAdPF3yy5QuFpndocbicW4dP6EPu2S2P9S5VidtbSMdf/qcjulgTXG0wnUcD8d/QCev6RjXgy3BEKbgdeutt9paWl1cVMMYaS1iuHIX7TrG8rjJC7E6P2S3Ptr2QSqHmQ02rRCo9/UwiMKaOuurRr9Lly4mllSREO6GP6t9nJPzsH8+0FAOuv6Eo2tSbp+wFXWQz0mgd+3kk0+25+8xY8bY63MwqPnbS/s/3E2kwnJO+dsmtLKiwAwZ0alTJ3uw6OSuZjQ1mQwfPjzD3a6eGFTNVXbpUQVcn9OPDvJ///vfdnoKYqq2jiZ96q5d39PTGMHartCnRrSRP/vsM1vTdc8992RI00HRzj/cuGF6Ys1/vyCIZv/EgsZWCn30Wk9eit9sGatl0h1+r1697I8OVNV+6SZBtRv5OUaN//i7quAze4rIp3ISrixGMiadAl12zatq5vYvYAoguuO///777QXPH1IhUlrOYO2PjjVtd3+/+nf4oU/ShdbARCrasqHP62neIDVfqLZGzWqq1VDQPP74401OaR3DjeOX03WMhn9OUdkIDrGgJkc1HYeWNZfHYnZCy6mCVGhNj64z48aNs83fCiFqHVHLiN8VJFLhjietd6R/0SSrfZyToS385ljV0GR1PlBto4J+Ts8HokoRNfNlRtMOhlfVNqmZTk9wZlXulixZYo/1YEgNvdZpPXUTrJal7Gq7dH5WNwA9DarKD12j/e4r/vbSjXVW28ufbzTbS8dJsJauwA2Oqg2sKl01Q+ikrbvlYNOiKKXq7jHcwKGqKtVBL9oRofzU7yd8/+QQyYjwuuCoqTM4XxWKsWPHhr0LCb0Te/rppzNMM5r5q5DOmzfPDqjp07q++OKL9uDOrE3ZtUj3T6yojAQfcdYFQf/WCUXDO8RqmYJNqH5ZVf8SCd4xRjJkRKzpZKGTidZbJ7TMxgTzy9GcOXNsWQq+r+aU7OiGSCel4E/wcXZdrHRx0zGh5lf1vdDJSCNVRxu4JPTY8h/vVhOvf1HRHaRqtEOHOMiJaI5H0frr5O33MfHLhbo1qAZAfYIUunJDFwQFBF2EfNrHWT2mHitaP91oPPPMM+nOZy+//LJdJj1Snx/HYqTLHvzxa77U51H9tfRvBWMFP+0vbVP9jjZw+UMI+H0mRceWgpxfTiPZxzomtb18U6dOzRDoI6VtrWlqKAuFnMzOB7pW6bqm5Q/2X1PNn8JMJDTEjyoaMutjp+uTrps+Ne+pnGS1bXr06GFrHIP9u/UdHf8Kx+pzK+qOpHKpCo5IakJ1vlbtu9ZPN84qb6JtoHOJKmWCyxq6vVRmlCHUshHsZqGAn9lfoFBfRjVth4b+AjU4qkKWNq76gqgaOjQhapwsNTuqn4hqnlRtqGpYpWC9rsKiTt8jR460J2OdGJRQdfepk7HuPv3O6CqY6iCtsWSUenXSVX+XcH0rdPJUB8nbbrvN3nEr4WsMJD/c+Xdt2nmqsVOq1g5UPxo1Z/qJN8g/Ean2TU2rqqlQYQg3YJ76pb311lu2sKpDoZK9dr6mqzuNnPRTywuR7p9YUZu++gmpj4BqVXSgqhpZB7vfgTMWy6Q7YO1rNU+rDOkuVOVUB2GwjOoOXlz3O1JAUbnWMaMmPN0hq6ZJIX39+vW2dkE0HpJuaHS3p3GvVNa0rfy7y5xS8FB51zGm/jHBjqY5pbJ9zjnn2GXVeqgDrKYd7G6g/fLwww/b39qHOub92pVoRXM+EM1X662AqeYo1WjpPKPjUuVLfSzV+V+v+wE9WjovKLT26dPHHveqadeFS2U9pw/l+OcrXbwUljOjsKT+d7qoaR9oXyhEax+rE7rCS34ci7mhmyfNQ/PXPovmYphVLYqOPXUS1w2YbrAVunWsRUJlV4PsahsrlOqmTWU9+ABBNPzgr2uF1k9dAnQdUjDUNtc1ShUbon2rrjfqjK+aez/c6HuRnA90fVXzmx66UKf5UAqSOidqvfyyo22lspSZq666yoZ11Y4rtKhSQdtHY4xp2/o1VKpBU3nSTYFqn/zuO9988419L9zfW1So1sN1Cnaq4FHg1PbQMaVpnXDCCfaYU9lXEFXXCJVRNUuKHgTSOmsdNPamrgn+9goXcBXIdE2PqlY3FkNGlC1bNqJHnv1HPTVuk9574IEHws5Hj49qHA2NjaFH0jXmkB5N1Rgpf/31V9o4JRqvQ2PH6LFj/dZYOr/88ku6aenRVY2Po3Figo+Lh3tUW8NPnH/++XasLD1KqjFC9Iizvvf222+nfU6PD/fp08c+hqrPaSynDRs2ZHiMXTQuSq1atexjrMFH2sM9Rqwxg/r162enq8d8NTbL1KlT033Gf6x40qRJ6V7P6vH6cPsldKiNzPajHvXVfoh2/4QbPyWroRTCrZc/7wULFtjHibVNtN30SHuo3CyTTJ482T46r8ffVZ40rs3VV19tx70qCENG+OXj4osvtsNtaIwblauePXvaZQ/S2DyanraXPqMyqLGUcjNkhD++XCz4ZVCPrqu863jT/tJ4ThqSIkiPwQ8ZMsQeZ/rcgAED7FAHORkyIqvzQWaSkpLssaGxjbTNVS5UfnQOWLdunS0vGm7l999/j+q8GaRH0jUukMqdxsnTo/SZDRkRruyGnkv0iLw+O2jQIC8SOp6OPfZYu35aT43HFjqsgstjMbMhFiKheYeOBZlTwWNYQ2XouqX10ZhS/rAm2Z0/ffq+jkV9X+MfajtmNmREpOd2jS/Yt29fO46WpqvtpuND18YgjbOo7a/ypeGZNHxHZtfncDS0i4aICVemNW0NP6R9rOEeLrjgAm/btm3pPhvuONy0aZN32WWXedWqVbPLpeFwwh2LGmJF21/lU5/T+Ggas2vhwoVZliMd5zrGNZxNcLglDbOhc4nKr8ZU0zVe+yJIw0dp2A5tU50rNA5iuLywfPlyO++ZM2d60Yj7e6GRCSVl3YVqVF8lYgAoyNTE0rNnT1v7qZrRWFDzth6LDx2JvShTjZ5qQdVhPfgXUw43qlnS/ldtZbgn+w5XN998s615V21dNDVdBaPNqoDw24B9qhZX1aKqJ1UtCQAFnZqY1IQSq8CFw5uaJtXEri41+F8ztpp49eeGon1g5LD9g9fhqH+Ggpc6D6rtXuOI6bFxdcDLbAwYAChIVDMDxJKG0MH/qE9fuD5ekSB0BagTtf7As54s0Ujz6kCpmq5wHfYAAACiQZ8uAAAAB+jTBQAA4EBMmhc1doZGK9b4Gi5GKQcAAHBFAz1o8F2NV5ebcTNjEroUuEL/phYAAEBRsm7dulz9YfOYhC5/BFktjP8Xu/NKhwc75en0cXiZPTz9n5gpCObl4YjdOPy0W7DAFDQakR2IldC/npAXUlJSbOWSn3fyNXQF/0ROXoeuYiXD/wV2ICfyurzmRNm//74nUFTLOEPwoLCW8dx2oaIjPQAAgAOELgAAAAcIXQAAAA4QugAAABwgdAEAADhA6AIAAHCA0AUAAOAAoQsAAMABQhcAAIADhC4AAAAHCF0AAAAOELoAAAAcIHQBAAA4QOgCAABwgNAFAADgAKELAADAAUIXAACAA4QuAAAABwhdAAAADhC6AAAAHCB0AQAAOEDoAgAAcIDQBQAA4AChCwAAwAFCFwAAgAOELgAAAAcIXQAAAA4QugAAABwgdAEAADhA6AIAAHCA0AUAAOAAoQsAAMABQhcAAIADhC4AAAAHCF0AAAAOELoAAAAcIHQBAAA4QOgCAABwgNAFAADgAKELAADAAUIXAACAA4QuAAAABwhdAAAADhC6AAAAHCB0AQAAOEDoAgAAcIDQBQAA4AChCwAAwAFCFwAAgAOELgAAAAcIXQAAAA4QugAAABwgdAEAADhA6AIAAHCA0AUAAOAAoQsAAMABQhcAAIADhC4AAAAHCF0AAAAOELoAAAAcIHQBAAA4QOgCAABwgNAFAADgAKELAADAAUIXAACAA4QuAAAABwhdAAAADhC6AAAAHCB0AQAAOEDoAgAAcIDQBQAA4AChCwAAwAFCFwAAgAOELgAAAAcIXQAAAA4QugAAABwgdAEAADhA6AIAAHCA0AUAAOAAoQsAAMABQhcAAIADhC4AAAAHCF0AAAAOELoAAAAcIHQBAAA4QOgCAABwgNAFAADgAKELAADAAUIXAACAA4QuAAAABwhdAAAADhC6AAAAHCB0AQAAOEDoAgAAcIDQBQAA4AChCwAAwAFCFwAAgAOELgAAAAcIXQAAAA4QugAAABwgdAEAADhA6AIAAHCA0AUAAOAAoQsAAMABQhcAAIADhC4AAAAHCF0AAAAOELoAAAAcIHQBAAA4QOgCAABwgNAFAADgAKELAADAAUIXAACAA8VdzAQAIlV32DBTrVcvU6JaNRMXH2++79rV7NuwIcvvVO/d2zR86CH7/981aWJ/N50wwVRs185snjLFrPrnP9kByJV+/fqZ8uXLm0WLFpkffvgh7Gcuu+wy+/ubb74xK1eujNkWP+6448zxxx9vduzYYSZPnmxiqVy5cqZ///55stzIiNAFoMCocvrppuaQIfb/d69caQ7u2mUO7d+f7ff2JyebHYsXO1hCAMg5QheAAqN0w4b2d+rmzWZxr14Rf2/7V1/ZHwAoyAhdBdC0Wz4ytSrXNOO+ecWUSShtzmpxpomPL2amLZluHpv+hNl/cL+5qdsNpnPjjqZ6+RqmdEJpk7wr2cxZNdeM+nS02bpzq51O1XJVzW3dbzHt6rc1FUtXMCl7UszqLWvMhFmvmW9/nWXi4+LN0K7Xme7Nu5nq5aubvfv3mvXJv5tPfpphPwO45DcHSkKNGqb98uX2/5MefthUP/dcU/Koo0x82bLm4I4dJmXhQvPbk0+avUlJmTYvAnkhPj7etGvXzjRo0MD+/6pVq8y8efPMoUOHwn6+UqVK5oQTTjBHHHGEKVGihNm9e7dZs2aNbaI8ePBg2ufq1atnmjZtaipXrmzi4uJMSkqKmT9/vtkQpmm9WLFi5owzzjBHHnmk/dzHH39sdu3aZerXr582Dc/zzKZNm8zChQvNn3/+mfZdfeekk06yTaXbtm0zS5YsoaA4REf6AuyCkwab7s27mx17d5jypcqZge36m5u6DbXvdWjY3gauTSmbzLo/15lq5aqac47vaUad/0Ta94f3vMuc3eosG9xWbl5l9h88YNoc3do0T2xm3x/UboAZ0ukyc2TFI03StrVm+56/zDFHNDQdG52Sb+uMw9eeVavMvj/+sP9/KDXVNhfqp0KbNqZUnTomdetWs3fNGlO8QgVTtVs303TcOBOXkJDfi43DjEKNAtf+/ftNQkKCadKkiWndunXYz1asWNH07NnT1K1b1wYl9clSH6qWLVuarl27pn2uWbNm5tRTTzU1atSwYUmfUyhSYAuloKfv+oFr+vTpNnA1b97cdO7c2VSvXt3+OzU11SQmJpoePXrY5ZDSpUub008/PS2UlSxZ0s4X7lDTVYD98dcfZtDzF5rdqbvNQ/0eND1anmkGthtgnv/iJTP83XvMqi2r7IEjfU7obUb0/pdpntjcJFZONOuT15s6VevY9x746CFbSybVylUz5UqVs/9fp2pt+/uDRR+ZkR8+YP9ftWb1q9XLpzXG4WzNyJFm/7ZtpvbQoSZ1yxbz06BB9vXSDRqYvbfcYrwDB+y/K7ZvbwOXar7Kn3CCSZkzJ5+XHIcT1VR9+OGH5sCBA6ZTp042gCl4hetcr3Cl2i0FtClTptgwpNB24oknmlq1atngtGXLFttJXjZv3mxmzJhhP1+8eHEbkkIDl0KSvvvXX3/ZGi4tjwKdOtvL999/bxYvXmxry84++2wbwrQc6iR/7LHH2uVRrdzUqVPN9u3b7bz97yLvEboKsK9/+cYGLvn4x09s6EoonmDqVq1j6lU/2tzfd4Q5umpdU6ZkmXTfq16hmg1dX6342tZc3d9nhLm2y9UmaWuSWZC00Exe8N7f0//Whrjz2vQxHRudbNZu+838uP4n8+6CKfmyvkA4JWvWNPXvu8+UadzYFCtTxj7R6FMzJODSunXrbOASNRMqdCn0+LVJQdWqVbO/1cynwCWrV6+2oct/X9NSEJLly5fbwCV6XTVeQWXLlrU/+owfuEQ1V/401JSpnyDVoPmfEwU2BS5JSkoidDlE6CqEEkokmPv73GfvepJ3bTert6w2pRPKmAY16tv3i8UVs79HzxxrfvhtsW2KbFijgTmh7vGmU+OOpk29NuaG128ys1d+ZwY9f4Hp1ux00/jIRubYoxqbtvXamHOO62l6jupt9qTuyec1xeGuZGKiaTxmjIlPSDAHdu40u5YuNXHFipmyTZva94MBDCjqFMR03lfAUo3ZggULMnxGYUpNi0H79u1zuJTICqGrAFPfqrGfP2/Djzq7S+qBVNOuXlt74Em/sQNtx/nLO15qO9cHHV/nOFuz9c0v39p/n9n8DPPIgIdM67r/rcpWLZg64I/57Nm0jvef3zHDVCtfzdagLd/4s+M1BtIr26SJDVyy/Morzc4ffjBVe/QwjZ74X99FwKXatWvbsboUgNT5XdQhXrVHobZu3Wr7ZakTfZkyZWzNlDq7B99PTk62NVcKUmr+++233+y0/ebFYG3Xnj17bNPhKaecYlq0aGHD1I8//min4X9n/fr1tgO+r0qVKvZ10efUv0y1cvrRMuvfcIfQVYDVKF/DPsm4a98uU7tKon3tnfmTzeJ1/3vaZPL1E03y7mRTpex/q42DFMKa1Wpq/vhrk9m5b6ep93dfrV82/Wp/n9G8m7mi4+VmU8pmOw11qBeFPDVPAvlNY3WpL1dc8eKmyYsvmtSNG+2gqUB+UXjSYKKqTapQoYJ97eeff05rFgzSk4EKNQpUffv2tU2MfjPk77//bv74+8ERhTg9EalwNmDAAPs5daRX/6xly5alm+avv/5qmxjVF6tNmzZm79699jX1KdO/1aFeYVCv63OlSpWy01d/MS2nOu1reXr16mXno479cIe6+QLsjTlvmf8snmYqlCpvdu7daSbNn2yHhNDQEE/NGGU2p2w2pUqUNElbksyDHz2c4fsa+mHphmWmXMmy5pgaDe1TkNOXfGzumjTcvv990iIza+VsEx8XZ5sf40ycmbt6nrnutRvMjr0782GNgfT0tOLKu+82e9etM/HqkJycbH4dNozNhHyjEKRhIvTkn4KXgoyGZQhHNUnqsL527VpbG6aQtnPnThvGPvvss7TPLV261Hz55Zc2GKkVQ59TDZff7yqUAtaKFSvs/3fo0MEGO9V4ff3117ZjvpZN01Dw0vJp/n5NmearGi/NR0FR34E7cZ7/+Fsu6LFVv6rST/55pdU94R/NLYrjdD33xQvm+S9ezO/FKdIWjwx/ssxPjDOFWPLHOytIxo8fn9+LgCLksr///FJeilXOoaYLAADAAUIXAACAA3SkL4B6PBX535wDAACFAzVdAAAADhC6AAAAHCB0AQAAOEDoAgAAcIDQBQAA4AChCwAAwAFCFwAAgAOELgAAAAcIXQAAAA4QugAAABwgdAEAADhA6AIAAHCA0AUAAOAAoQsAAMABQhcAAIADhC4AAAAHCF0AAAAOELoAAAAcIHQBAAA4QOgCAABwgNAFAADgAKELAADAAUIXAACAA4QuAAAABwhdAAAADhC6AAAAHCB0AQAAOEDoAgAAcIDQBQAA4AChCwAAwAFCFwAAgAOELgAAAAcIXQAAAA4QugAAABwgdAEAADhA6AIAAHCA0AUAAOAAoQsAAMABQhcAAIADhC4AAAAHCF0AAACELgAAgKKBmi4AAAAHCF0AAAAOELoAAAAcIHQBAAA4QOgCAABwgNAFAADgAKELAADAAUIXAACAA4QuAAAABwhdAAAADhC6AAAAHCB0AQAAOEDoAgAAcIDQBQAA4AChCwAAwAFCFwAAgAOELgAAAAcIXQAAAA4QugAAABwgdAEAADhA6AIAAHCA0AUAAOAAoQsAAMABQhcAAIADhC4AAAAHCF0AAAAOELoAAAAcIHQBAAA4QOgCAABwgNAFAADgAKELAADAAUIXAACAA4QuAAAABwhdAAAADhC6AAAAHCB0AQAAOEDoAgAAcIDQBQAA4AChCwAAwAFCFwAAgAOELgAAAAcIXQAAAA4QugAAABwgdAEAADhA6AIAAHCA0AUAAOAAoQsAAMABQhcAAIADhC4AAAAHCF0AAAAOELoAAAAcIHQBAAA4QOgCAABwgNAFAADgAKELAADAAUIXAACAA4QuAAAABwhdAAAADhC6AAAAHCB0AQAAOEDoAgAAcIDQBQAA4AChCwAAwAFCFwAAgAOELgAAAAcIXQAAAA4QugAAABwgdAEAADhA6AIAAHCA0AUAAOBA8VhMxPM8+zslJcXktYP7Dub5PHD4cFFmo7XrIGUcRbuM79mzJ78XAUVIioMy7s/Dzzs5FefldgrGmPXr15vatWvndjIAAAAF1rp160xiYmL+hq5Dhw6ZDRs2mPLly5u4uLjcTg4xSOQKwSocFSpUYHuiyKGMo6ijjBcsiko7duwwNWvWNPHx8fnbvKgFyE3yQ95Q4CJ0oSijjKOoo4wXHBUrVsz1NOhIDwAA4AChCwAAwAFCVxFUsmRJc++999rfQFFEGUdRRxkvmmLSkR4AAABZo6YLAADAAUIXAACAA4QuAAAABwhdAAAADhC6iqBXXnnFVKpUKb8XA8gzlHEUdZTxoonQVUBceumlpnfv3qYg6969uylWrJiZP39+fi8KCqGCWsaTkpLsny/zfxISEkzDhg3NAw88kOs/bovDS0Et4753333XnHrqqXZk9XLlypmWLVuakSNHmj///DO/F+2wQehCRH777Tcze/ZsM3ToUDNu3Di2GoqcmTNnmo0bN5pff/3V3HfffebBBx+krKPIGD58uBk4cKBp27atmT59uvnpp5/ME088YRYvXmxee+21/F68w4fG6YI7kyZN8po3b+6VKlXKq1Klite1a1dv2LBhup1O9/PFF1/YH/1/cnJy2vcXLVpkX1uzZk3aa+PHj/dq167tlS5d2uvdu7f3+OOPexUrVrTv6XNxcXHe/Pnz0y3HU0895dWpU8c7ePBgRMs9YsQIb9CgQd7y5cvttHfv3h2zbYKipbCVcX1f89N8g7Tc1113XYy2CoqSwlbG586da+f39NNPh30/uGzIW4QuhzZs2OAVL17ce/LJJ+1BtGTJEm/s2LHejh07vAEDBnhnnnmmt3HjRvuzb9++iA7WOXPmePHx8d4jjzzirVixwhs1apRXqVKltINVunXrluHi0bJlS++ee+6JaLkPHTrk1a1b15s6dar9d+vWrb1XX301RlsFRUlhLOPhQpcubprHhAkTYrRlUFQUxjJ+4403euXKlfNSU1Njui0QPUKXQwsXLrQHWlJSUob3LrnkEu/cc89N91okB+vgwYO9Hj16pPvewIED0x2sEydO9CpXruzt3bs3bTl01xS8y8rKjBkzvOrVq3v79+9Pu7vq3LlzVOuOw0NhLON+6FINQ9myZb0SJUrYf1911VU52AIo6gpjGT/rrLNsQEP+o0+XQ61atTJdu3Y1LVq0MP379zcvvfSSSU5OztU0ly9fbk488cR0r7Vv3z7dv9WxUx3gp0yZkvZUTJcuXczRRx8d0TzUh0t9AYoXL27/PXjwYDNr1iyzatWqXC07ip7CWsZl4sSJ5ocffrB9XN555x3zwQcfmLvuuitXy46ipzCWcR4IKTgIXQ7pgPn0009tJ8amTZua0aNHm8aNG5s1a9aE3znx8RkOmP3790c9Xz2NdfHFF5vx48eb1NRU8+abb5rLL788ou/qqRYd5M8++6wNXfqpVauWOXDgAJ2MUSTKuK927dr2qcUmTZrYi+nNN99sOxrv3bs36uVB0VUYy3ijRo3M6tWrczRfxBahyzE9kn7yySfbp6MWLVpkDySFGv0+ePBgus9Wr17d/tYTVT7diQfpAjF37tx0r82ZMyfDfK+44gr7dJbCkwJT3759I1reN954wyQmJtq7f83b/9HFSHdaocsMFLYyntXFVdPRBQ4ozGX8/PPPNzt37rTfC2f79u3sYFfyu33zcKLOkg8++KDtpLt27VrvnXfe8RISErxp06bZ1/UUys8//+xt2bLFdnjUj55m6d+/v/fLL7/YjuyNGzdO1xfgu+++sx0wH3vsMfuZ0aNHZ+iA6evQoYOd3zXXXBPxMrdq1cq78847M7y+fft2Oy2/cz1QWMu436dr5syZtvPzunXr7PLWqlXL69KlCzsWhb6Myx133OEVK1bMu/32273Zs2fbPmkq8/369cv0qUbEHqHLoWXLlnndu3e3ndJLlizpNWrUyB5csnnzZvt0ip4w8R81lm+//dZr0aKFfTS5Y8eO9lHl0EeNX375ZS8xMdF2BO7Vq1e6R42D9Dl9d968eREt74IFC7L8vDpn9unTJ4dbA0VRYSvjwdDl/+jCpHldeeWVdpmBwl7Gg53xO3Xq5JUvX94+NKLO9SNHjmTICIfi9B9n1WrIV/fff7+ZNGmSWbJkCXsCRRJlHEUdZbxwo0/XYUBt+Rp9eMyYMeaGG27I78UBYo4yjqKOMl40ELoOA/rTPa1bt7Z/cyv0aZdrrrnG/g2ucD96DygMKOMo6ijjRQPNi4e5zZs3m5SUlLDvVahQwdSoUcP5MgGxRBlHUUcZLzwIXQAAAA7QvAgAAOAAoQsAAMABQhcAAIADhC4AAAAHCF0AAAAOELoAAAAcIHQBAACYvPf/uxhnFkWXB+AAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 600x320 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Visualize the three members: two built (with verdicts), one pruned.\n",
+    "names = ['study_A', 'study_B', 'study_C']\n",
+    "status = {}\n",
+    "for n in names:\n",
+    "    if n in built:\n",
+    "        status[n] = sim.state['investigation'][n]['verdict']\n",
+    "    else:\n",
+    "        status[n] = 'blocked'\n",
+    "cmap = {'pass': '#2e7d32', 'fail': '#c62828', 'blocked': '#9e9e9e'}\n",
+    "fig, ax = plt.subplots(figsize=(6, 3.2))\n",
+    "ax.bar(names, [1, 1, 1], color=[cmap[status[n]] for n in names])\n",
+    "for x, n in enumerate(names):\n",
+    "    ax.text(x, 0.5, status[n], ha='center', va='center', color='white', fontweight='bold')\n",
+    "ax.set_yticks([]); ax.set_ylim(0, 1)\n",
+    "ax.set_title('Investigation members: filled -> built & run, open -> pruned (blocked)')\n",
+    "plt.tight_layout(); plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19f914e5",
+   "metadata": {},
+   "source": [
+    "## 6. Filling is incremental\n",
+    "\n",
+    "You do not have to fill everything at once. `fill_template` binds the sites you give it\n",
+    "and leaves the rest open — the result is *still a template*, ready for the next round of\n",
+    "filling. Groundness is what separates \"keep filling\" from \"ready to run\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "e7f2fc0f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T22:42:26.527049Z",
+     "iopub.status.busy": "2026-07-31T22:42:26.526985Z",
+     "iopub.status.idle": "2026-07-31T22:42:26.529625Z",
+     "shell.execute_reply": "2026-07-31T22:42:26.529268Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "after filling A only:\n",
+      "  still open: [('investigation', 'study_B', 'model'), ('investigation', 'study_C', 'model')]\n",
+      "  ground?    False   <- B and C still open\n",
+      "after filling B and C:\n",
+      "  still open: []\n",
+      "  ground?    True   <- now runnable\n"
+     ]
+    }
+   ],
+   "source": [
+    "partial = fill_template(core, investigation, {'investigation/study_A/model': model(1.5)})\n",
+    "print('after filling A only:')\n",
+    "print('  still open:', sorted(open_sites(partial)))\n",
+    "print('  ground?   ', is_ground_document(partial), '  <- B and C still open')\n",
+    "\n",
+    "whole = fill_template(core, partial, {\n",
+    "    'investigation/study_B/model': model(0.5),\n",
+    "    'investigation/study_C/model': model(1.2)})\n",
+    "print('after filling B and C:')\n",
+    "print('  still open:', open_sites(whole))\n",
+    "print('  ground?   ', is_ground_document(whole), '  <- now runnable')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae2a3f2f",
+   "metadata": {},
+   "source": [
+    "## 7. Templates on disk: `*.template.yaml`\n",
+    "\n",
+    "A template is authorable as a file. `save_template` writes a document with its sites\n",
+    "intact; `load_template` reads it back to *exactly* the same template (bigraph-schema's\n",
+    "`_sort` round-trip means a site's interface and default survive the file). A **study**\n",
+    "and an **investigation** template are the *same on-disk shape* — a document with sites —\n",
+    "so one loader reads both; the caller picks `template_document` (study) or\n",
+    "`investigation_document` (investigation)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "54a61966",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-31T22:42:26.530648Z",
+     "iopub.status.busy": "2026-07-31T22:42:26.530578Z",
+     "iopub.status.idle": "2026-07-31T22:42:26.536216Z",
+     "shell.execute_reply": "2026-07-31T22:42:26.535814Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- growth_study.template.yaml ---\n",
+      "study:\n",
+      "  level: 1.0\n",
+      "  model:\n",
+      "    _sort:\n",
+      "      _inputs:\n",
+      "        level: float\n",
+      "      _outputs:\n",
+      "        level: float\n",
+      "      _type: link\n",
+      "    _type: site\n",
+      "  report:\n",
+      "    _type: step\n",
+      "    address: local:ReportCard\n",
+      "    config:\n",
+      "      threshold: 2.0\n",
+      "    inputs:\n",
+      "      level:\n",
+      "      - level\n",
+      "    outputs:\n",
+      "      verdict:\n",
+      "      - verdict\n",
+      "    priority: 0.0\n",
+      "  verdict: string\n",
+      "\n",
+      "reloaded open sites: [('study', 'model')]\n",
+      "reloaded template runs -> verdict: pass\n"
+     ]
+    }
+   ],
+   "source": [
+    "import tempfile, os\n",
+    "from process_bigraph.templates import save_template, load_template\n",
+    "\n",
+    "tmpdir = tempfile.mkdtemp()\n",
+    "path = os.path.join(tmpdir, 'growth_study.template.yaml')\n",
+    "\n",
+    "save_template(core.access({'study': study_region(threshold=2.0)}), path, core)\n",
+    "print('--- growth_study.template.yaml ---')\n",
+    "print(open(path).read())\n",
+    "\n",
+    "reloaded = load_template(path, core)\n",
+    "print('reloaded open sites:', open_sites(reloaded))\n",
+    "doc = template_document(core, reloaded, {'study/model': model(rate=0.5)})\n",
+    "s = Composite({'state': doc}, core=core); s.run(4.0)\n",
+    "print('reloaded template runs -> verdict:', s.state['study']['verdict'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a0d2d3a7",
+   "metadata": {},
+   "source": [
+    "## 8. Where this goes next\n",
+    "\n",
+    "Filling a *model* site is the base case. The same fill/groundness law powers the rest of\n",
+    "the framework:\n",
+    "\n",
+    "- **Pull-or-compute (`trigger`).** A cached study result is simply a **filled `results`\n",
+    "  site**: an open results site means the study computes, a filled one means it does not\n",
+    "  and its consumers read the cached handle. `trigger(document, target)` walks a member's\n",
+    "  prerequisites and fills each from a content-addressed artifact if present (**pull**) or\n",
+    "  computes it (**compute**) — the same fill/prune law, on the results axis. This is how\n",
+    "  you rerun one downstream study without rerunning an expensive upstream one (e.g. reuse a\n",
+    "  ParCa fit). See the\n",
+    "  [partial-graph-trigger design](https://github.com/vivarium-collective/process-bigraph/blob/main/docs/superpowers/specs/2026-07-31-partial-graph-trigger-pull-or-compute-design.md).\n",
+    "- **Authoring in the Vivarium Workbench.** On disk in a workspace, a study is a\n",
+    "  `studies/<slug>/study.yaml` (a `composite` + `config` + `inputs`) and an investigation\n",
+    "  is `investigations/<name>/spec.yaml` listing member studies. The Workbench converts\n",
+    "  those specs into exactly the template documents above and runs `trigger` over them.\n",
+    "- **The whole map.** [`doc/architecture.md`](https://github.com/vivarium-collective/process-bigraph/blob/main/doc/architecture.md)\n",
+    "  — one object (a document), one operation (fill), one law (groundness) — and the eight\n",
+    "  invariants everything else follows from.\n",
+    "\n",
+    "### Recap\n",
+    "\n",
+    "| concept | in code |\n",
+    "|---|---|\n",
+    "| a hole | `{'_type': 'site', '_sort': FACE}` written in place |\n",
+    "| what fits a hole | anything matching the site's `_sort` (face-checked) |\n",
+    "| runnable? | `is_ground_document(doc)` — no required site left open |\n",
+    "| fill a study | `template_document(core, tmpl, {'path/to/site': filler})` |\n",
+    "| fill an investigation | `investigation_document(core, tmpl, bindings, member_depth=...)` |\n",
+    "| gating | fill a member to build it; leave it open to prune it |\n",
+    "| on disk | `*.template.yaml` via `save_template` / `load_template` |"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Adds **Tutorial 4** (`notebooks/tutorial_4.ipynb`), an executable notebook teaching study & investigation **templates** — the framework's central move: a study and an investigation are the *same kind of thing* as a composite (a bigraph document), and filling their open **sites** turns them into a runnable `Composite`.

## What it covers
1. A **study template** — a fixed analysis network (`ReportCard` flush) with the *model* left as a face-sorted `site`.
2. **Filling** the hole (`template_document`) → a `Composite` that constructs and runs; reusability across a sweep of models.
3. The hole is **face-sorted** — a non-conforming filler is refused *before* construction, naming the site; an unfilled template is refused too.
4. **Investigation templates** — one hole per member study.
5. **Gating as filling** (`investigation_document`) — a filled member runs, an unfilled one is *pruned* (blocked), so the engine never decides "not to run" anything.
6. **Incremental** filling and the groundness run-gate.
7. **On-disk** `*.template.yaml` round-trip (`save_template` / `load_template`).
8. Where it goes next — pull-or-compute (`trigger`), the Workbench authoring layer, `doc/architecture.md`.

## Verification
- Every code cell was **executed** (`jupyter nbconvert --execute`); committed outputs and both matplotlib figures are real. 0 error cells.
- Runs against `process_bigraph.templates` on current `main` (bigraph-schema 1.4.5).
- Added to the README **Learning Path**; `publish_tutorial_notebooks.yml` picks up `notebooks/tutorial_*.ipynb` automatically and regenerates the index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)