### PR TITLE
feat: absorb the composite + visualization substrate from viva_superpowers

### DIFF
--- a/process_bigraph/__init__.py
+++ b/process_bigraph/__init__.py
@@ -31,6 +31,8 @@ from process_bigraph.composite_generator import (  # noqa: F401
     composite_generator, discover_generators, build_generator,
     install_default_emitters, emitter_defaults,
 )
+from process_bigraph.composite_discovery import discover_all  # noqa: F401
+from process_bigraph.config_helpers import normalize_config_list  # noqa: F401
 
 
 import pprint

--- a/process_bigraph/__init__.py
+++ b/process_bigraph/__init__.py
@@ -26,6 +26,7 @@ from process_bigraph.composite_spec import (  # noqa: F401
 from process_bigraph.bundle import load_bundle  # noqa: F401
 from process_bigraph.emitter import Emitter, gather_emitter_results, generate_emitter_state  # noqa: F401
 from process_bigraph.types import StepLink, ProcessLink, CompositeLink  # noqa: F401
+from process_bigraph import core_introspection  # noqa: F401
 
 
 import pprint

--- a/process_bigraph/__init__.py
+++ b/process_bigraph/__init__.py
@@ -27,6 +27,10 @@ from process_bigraph.bundle import load_bundle  # noqa: F401
 from process_bigraph.emitter import Emitter, gather_emitter_results, generate_emitter_state  # noqa: F401
 from process_bigraph.types import StepLink, ProcessLink, CompositeLink  # noqa: F401
 from process_bigraph import core_introspection  # noqa: F401
+from process_bigraph.composite_generator import (  # noqa: F401
+    composite_generator, discover_generators, build_generator,
+    install_default_emitters, emitter_defaults,
+)
 
 
 import pprint

--- a/process_bigraph/__init__.py
+++ b/process_bigraph/__init__.py
@@ -33,6 +33,7 @@ from process_bigraph.composite_generator import (  # noqa: F401
 )
 from process_bigraph.composite_discovery import discover_all  # noqa: F401
 from process_bigraph.config_helpers import normalize_config_list  # noqa: F401
+from process_bigraph.visualization import Visualization, as_visualization, render_results  # noqa: F401
 
 
 import pprint

--- a/process_bigraph/composite_discovery.py
+++ b/process_bigraph/composite_discovery.py
@@ -1,0 +1,135 @@
+"""Discover composite specs across installed bigraph-schema-dependent packages.
+
+A composite spec is any file matching *.composite.yaml or *.composite.json inside
+an installed package whose distribution declares bigraph-schema as a requirement.
+"""
+from __future__ import annotations
+import importlib
+import importlib.metadata
+import sys
+from pathlib import Path
+
+from process_bigraph.composite_spec import CompositeSpec
+
+
+_GLOB_PATTERNS = ("*.composite.yaml", "*.composite.yml", "*.composite.json")
+
+
+def _is_bigraph_schema_lib(dist) -> bool:
+    if dist.metadata["Name"] == "bigraph-schema":
+        return True
+    reqs = dist.requires or []
+    return any("bigraph-schema" in r for r in reqs)
+
+
+def discover_composites(extra_search_paths: list[Path] | None = None) -> dict[str, dict]:
+    """Walk installed bigraph-schema-dependent packages + optional extra dirs.
+
+    Returns {composite_id: spec_dict}, where composite_id is a stable identifier
+    of the form '<package>.<file-stem>' or '<package>.<sub.path>.<file-stem>'.
+
+    extra_search_paths: additional directories to scan (e.g. workspace-local
+    composites/ dirs).
+    """
+    specs: dict[str, dict] = {}
+
+    # 1. Installed packages.
+    for dist in importlib.metadata.distributions():
+        if not _is_bigraph_schema_lib(dist):
+            continue
+        # Find every importable package this distribution declares.
+        top_level = dist.read_text("top_level.txt") or ""
+        for pkg_name in top_level.strip().splitlines():
+            if not pkg_name:
+                continue
+            try:
+                mod = importlib.import_module(pkg_name)
+            except ImportError:
+                continue
+            if not getattr(mod, "__file__", None):
+                continue
+            pkg_root = Path(mod.__file__).parent
+            for pattern in _GLOB_PATTERNS:
+                for path in pkg_root.rglob(pattern):
+                    spec_id = _make_spec_id(pkg_name, pkg_root, path)
+                    try:
+                        # Delegate parsing + validation to the unified engine;
+                        # to_dict() serialises to a plain dict for downstream.
+                        specs[spec_id] = CompositeSpec.from_file(path).to_dict()
+                    except Exception as e:
+                        # Skip malformed specs; log to stderr
+                        print(f"warning: skipping {path}: {e}", file=sys.stderr)
+
+    # 2. Extra paths (e.g. workspace-local).
+    for extra in (extra_search_paths or []):
+        if not extra.is_dir():
+            continue
+        for pattern in _GLOB_PATTERNS:
+            for path in extra.rglob(pattern):
+                spec_id = _make_spec_id("local", extra, path)
+                try:
+                    specs[spec_id] = CompositeSpec.from_file(path).to_dict()
+                except Exception as e:
+                    print(f"warning: skipping {path}: {e}", file=sys.stderr)
+
+    return specs
+
+
+def discover_all(
+    extra_search_paths: list[Path] | None = None,
+    extra_packages: list[str] | None = None,
+) -> dict[str, dict]:
+    """Return both static specs and composite generators, tagged with ``kind``.
+
+    Spec entries get ``kind: spec`` and pass through the existing spec
+    payload. Generator entries get ``kind: generator`` and a compact dict
+    {name, description, parameters, module} so dashboards can render them
+    without holding a reference to the live function object.
+
+    Discovery imports the host packages of every generator (see
+    :func:`process_bigraph.composite_generator.discover_generators`). If
+    you need the no-import safety property, call ``discover_composites``
+    directly.
+    """
+    # Deferred: discover_generators triggers package imports as a
+    # side-effect. Keeping it local ensures that cost is paid only when
+    # discover_all is explicitly called.
+    from process_bigraph.composite_generator import discover_generators
+
+    specs = discover_composites(extra_search_paths=extra_search_paths)
+    out: dict[str, dict] = {
+        sid: {"kind": "spec", **s} for sid, s in specs.items()
+    }
+    for gid, entry in discover_generators(
+            extra_packages=extra_packages).items():
+        if gid in out:
+            import warnings
+            warnings.warn(
+                f"discover_all: generator {gid!r} collides with a spec of "
+                "the same id; generator wins. Rename one to avoid ambiguity.",
+                stacklevel=2,
+            )
+        out[gid] = {
+            "kind": "generator",
+            "name": entry.name,
+            "description": entry.description,
+            "parameters": entry.parameters,
+            "visualizations": list(entry.visualizations),
+            "emitters": list(entry.emitters),
+            "module": entry.module,
+            "default_n_steps": entry.default_n_steps,
+        }
+    return out
+
+
+def _make_spec_id(pkg_name: str, pkg_root: Path, file_path: Path) -> str:
+    """Stable identifier for a composite spec: 'pkg.subdir.subdir.stem'."""
+    rel = file_path.relative_to(pkg_root)
+    # file_path stem strips both .yaml/.json AND the .composite part if .composite.yaml
+    stem = file_path.name
+    for suffix in (".composite.yaml", ".composite.yml", ".composite.json"):
+        if stem.endswith(suffix):
+            stem = stem[:-len(suffix)]
+            break
+    parts = [pkg_name] + list(rel.parts[:-1]) + [stem]
+    return ".".join(parts)

--- a/process_bigraph/composite_generator.py
+++ b/process_bigraph/composite_generator.py
@@ -1,0 +1,594 @@
+"""Composite generator convention — decorator + registry.
+
+Sibling to the *.composite.{yaml,json} static-spec convention. A composite
+generator is a Python function `(core=None, **kwargs) -> dict` that builds
+a process-bigraph document; the decorator records it in a module-level
+registry so discovery can enumerate generators without callers having to
+maintain a separate list.
+
+This module is now a thin shim over ``process_bigraph.composite_spec``, which
+is the single source of truth for the registry.  The ``GeneratorEntry``
+dataclass and helpers (``emitter_defaults``, ``install_default_emitters``,
+``apply_core_extensions``) are preserved unchanged so the dashboard keeps
+working on the same attribute surface.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from process_bigraph import composite_spec as _cs
+
+
+@dataclass
+class GeneratorEntry:
+    """One registered composite-generator function."""
+
+    id: str                           # "<dotted_module>.<name>"
+    name: str
+    description: str
+    parameters: dict[str, dict]       # {name: {type, default, description?, choices?}}
+    # Each parameter is a {type, default, description?} dict. A string-typed
+    # parameter may additionally declare ``choices: [..]`` (a list of allowed
+    # string values); the dashboard / bigraph-loom Configure form renders such
+    # a parameter as a dropdown instead of a free-text input. ``choices`` is
+    # passed through to the config_schema verbatim (see composite_discovery's
+    # ``discover_all``), so no special handling is needed beyond declaring it.
+    func: Callable[..., dict]
+    module: str
+    default_n_steps: int | None = None  # framework-owned runtime knob; UI pre-fill
+    # Canonical visualizations that ship with this composite. Each entry is
+    # a Study-spec visualization dict ({name, address, config, ...}). When
+    # a Study is built on top of this composite the dashboard merges these
+    # defaults into its visualizations list; Studies can still declare extras.
+    visualizations: list[dict] = field(default_factory=list)
+    # Emitter(s) this composite ships as its default observation sink. Each
+    # entry is a lightweight ``{address, config, paths?}`` dict: ``address`` is
+    # the registered emitter link (e.g. ``"local:ParquetEmitter"``), ``config``
+    # is the base config the workspace merges into the emitter step, and the
+    # optional ``paths`` lists dotted observable store-paths to wire. Unlike a
+    # full process-node spec, the emit-schema + topology are left for the
+    # generator/runner to compute — this declaration only selects which
+    # emitter(s) to install and with what base config. Parallel to
+    # ``visualizations``: when present, a workspace that builds this composite
+    # standalone (no dashboard observable-injection) uses these as its default
+    # emitter set, so e.g. a parquet sink travels with the generator instead of
+    # being toggled by external override globals. See ``emitter_defaults``.
+    emitters: list[dict] = field(default_factory=list)
+    # Callables ``(core) -> core | None`` that register the custom types /
+    # processes this generator's document references but that a bare
+    # ``build_core()`` doesn't know about. v2ecoli friction #16 (2026-05-19):
+    # the dashboard runs each composite in a subprocess that calls the
+    # workspace's ``build_core()``; when a composite uses types registered by
+    # a *different* package (e.g. ``map[pymunk_agent]`` from ``viva_munk``),
+    # the subprocess core never gets those registrations and the Composite
+    # build dies with "cannot resolve types … pymunk_agent". Declaring the
+    # package's ``register_*`` functions here lets the runner apply them to
+    # the right core. See ``apply_core_extensions``.
+    core_extensions: list[Callable[[Any], Any]] = field(default_factory=list)
+
+
+def _entry_for(spec) -> GeneratorEntry:
+    """Adapt a process-bigraph CompositeSpec to the GeneratorEntry the dashboard reads."""
+    return GeneratorEntry(
+        id=spec.id,
+        name=spec.name,
+        description=spec.description,
+        parameters=spec.parameters,
+        func=(spec.builder if callable(spec.builder)
+              else (_cs._resolve_builder(spec.builder, spec.module) if spec.builder else None)),
+        module=spec.module,
+        default_n_steps=spec.default_n_steps,
+        visualizations=spec.visualizations,
+        emitters=spec.emitters,
+        core_extensions=spec.core_extensions,
+    )
+
+
+class _RegistryView:
+    """Live view over the process-bigraph CompositeSpec registry.
+
+    Returns ``GeneratorEntry`` objects so the dashboard's attribute surface
+    (``.id``, ``.name``, ``.func``, …) is preserved.  Caches entries by
+    spec-id so identity (``is``) comparisons survive across separate
+    ``__getitem__`` calls — required by the ``_composite_generator_entry is
+    entry`` sidecar test.
+    """
+
+    def __init__(self) -> None:
+        self._cache: dict[str, GeneratorEntry] = {}
+
+    def _entry(self, spec_id: str) -> GeneratorEntry | None:
+        s = _cs.get(spec_id)
+        if s is None:
+            return None
+        if spec_id not in self._cache:
+            self._cache[spec_id] = _entry_for(s)
+        return self._cache[spec_id]
+
+    def get(self, k: str, default=None):
+        e = self._entry(k)
+        return e if e is not None else default
+
+    def __getitem__(self, k: str) -> GeneratorEntry:
+        e = self._entry(k)
+        if e is None:
+            raise KeyError(k)
+        return e
+
+    def __contains__(self, k: object) -> bool:
+        return _cs.get(str(k)) is not None
+
+    def values(self):
+        return [self._entry(sid) for sid in _cs.all_specs()]
+
+    def items(self):
+        return [(sid, self._entry(sid)) for sid in _cs.all_specs()]
+
+    def __iter__(self):
+        return iter(_cs.all_specs())
+
+    def keys(self):
+        return list(_cs.all_specs().keys())
+
+    def __bool__(self) -> bool:
+        return bool(_cs.all_specs())
+
+    def __setitem__(self, key, entry):
+        # v2ecoli registers "clean alias" composites via
+        #   _REGISTRY[clean_id] = dataclasses.replace(orig, id=clean_id)
+        # where `orig` is a GeneratorEntry from this view. Translate the assigned
+        # entry into a CompositeSpec registered under `key` in the unified registry.
+        import dataclasses as _dc
+        # invalidate any cached GeneratorEntry for this key before re-registering
+        if hasattr(self, "_cache"):
+            self._cache.pop(key, None)
+        if isinstance(entry, _cs.CompositeSpec):
+            spec = entry if entry.id == key else _dc.replace(entry, id=key)
+        else:  # a GeneratorEntry (or replace()-d copy of one)
+            spec = _cs.CompositeSpec(
+                id=key,
+                name=entry.name,
+                description=entry.description,
+                parameters=dict(entry.parameters or {}),
+                builder=getattr(entry, "func", None),
+                module=getattr(entry, "module", ""),
+                default_n_steps=getattr(entry, "default_n_steps", None),
+                visualizations=list(getattr(entry, "visualizations", []) or []),
+                emitters=list(getattr(entry, "emitters", []) or []),
+                core_extensions=list(getattr(entry, "core_extensions", []) or []),
+            )
+        _cs.register(spec)
+
+    def __len__(self):
+        return len(_cs.all_specs())
+
+    def clear(self) -> None:
+        """Clear the cache AND the backing process-bigraph registry."""
+        self._cache.clear()
+        _cs.clear_registry()
+
+
+# Process-level registry.  Backed by process_bigraph.composite_spec._REGISTRY;
+# populated by @composite_generator on import.
+_REGISTRY: _RegistryView = _RegistryView()
+
+
+def composite_generator(
+    *,
+    name: str,
+    description: str = "",
+    parameters: dict[str, dict] | None = None,
+    visualizations: list[dict] | None = None,
+    emitters: list[dict] | None = None,
+    default_n_steps: int | None = None,
+    core_extensions: list[Callable[[Any], Any]] | None = None,
+    default_state_ref: str | None = None,
+) -> Callable[[Callable[..., dict]], Callable[..., dict]]:
+    """Decorator: register a doc-building function.
+
+    The wrapped function must accept ``(core=None, **kwargs) -> dict`` and
+    return a process-bigraph state document (or a {state, schema} envelope).
+
+    Delegates registration to ``process_bigraph.composite_spec`` so that the
+    process-bigraph registry is the single source of truth.  The
+    ``GeneratorEntry`` view (read by the dashboard) is built lazily from the
+    registered ``CompositeSpec`` on first access via ``_REGISTRY``.
+
+    `parameters` declares each kwarg in the same shape that *.composite.yaml
+    uses, so the dashboard's parameter-form code is shared across both
+    conventions.  Parameter ``type`` values are normalised to canonical
+    vocabulary (``int``→``integer``, ``float``→``float``, etc.) by
+    ``CompositeSpec.__post_init__``.
+
+    `visualizations` declares the canonical visualization set that ships with
+    this composite. Each entry is a Study-spec visualization dict
+    (``{name, address, config, ...}``). The dashboard merges these defaults
+    into a Study's visualizations list when the Study is built on this
+    composite, so callers get the v2ecoli simulation report (or whatever the
+    composite author considers canonical) without having to hand-author them
+    in every Study spec.
+
+    `emitters` (optional) declares the default observation sink(s) this
+    composite ships with. Each entry is a lightweight
+    ``{"address": "local:ParquetEmitter", "config": {...}, "paths": [...]}``
+    dict — ``address`` selects the registered emitter link, ``config`` is the
+    base config merged into the emitter step, and the optional ``paths`` lists
+    dotted observable store-paths to wire. The emit-schema and topology are
+    NOT part of this declaration; the generator/runner computes them. This is
+    the standalone analogue of the dashboard's run-time observable injection:
+    when a workspace builds the composite outside the Investigations flow, it
+    reads these defaults (via :func:`emitter_defaults`) so the composite still
+    has a sink. External override mechanisms a workspace may keep (e.g.
+    v2ecoli's ``set_parquet_emitter_override``) take precedence; the declared
+    default fills in when none is set. Example::
+
+        @composite_generator(
+            name="baseline",
+            emitters=[{
+                "address": "local:ParquetEmitter",
+                "config": {"out_dir": "out/parquet"},
+            }],
+        )
+        def baseline(core=None): ...
+
+    `default_n_steps` (optional) is a UI hint for the Composite Explorer's
+    ``steps`` pre-fill. It is NOT a composite-builder kwarg — runtime knobs
+    are framework-owned and live next to the generator entry.
+
+    `default_state_ref` (optional) path to a pre-computed default-state
+    artifact relative to the workspace root.  When present, ``CompositeSpec``
+    can serve the state without re-running the builder.
+
+    `core_extensions` (optional) is a list of callables ``(core) -> core | None``
+    that register the custom types/processes this generator's document
+    references but that a bare ``build_core()`` doesn't provide. Declare a
+    package's ``register_*`` functions here so the dashboard's subprocess
+    runner can apply them to the core it actually runs against — see
+    ``apply_core_extensions`` and v2ecoli friction #16. Example::
+
+        from viva_munk import register_pymunk_types, register_processes
+
+        @composite_generator(
+            name="attachment",
+            core_extensions=[register_pymunk_types, register_processes],
+        )
+        def attachment(core=None): ...
+    """
+    # Validate emitters at decoration time (not first use) so malformed
+    # declarations fail loudly on import — same guarantee as before.
+    validated_emitters = _validate_emitters(emitters, name)
+
+    def decorate(fn: Callable[..., dict]) -> Callable[..., dict]:
+        # Register with process-bigraph as the single source of truth.
+        _cs.composite_spec(
+            name=name,
+            description=description,
+            parameters=parameters,
+            visualizations=visualizations,
+            emitters=validated_emitters,
+            default_n_steps=default_n_steps,
+            core_extensions=core_extensions,
+            default_state_ref=default_state_ref,
+        )(fn)
+        # Build + cache the GeneratorEntry NOW so that identity comparisons
+        # (``fn._composite_generator_entry is _REGISTRY[spec_id]``) hold.
+        spec_id = f"{fn.__module__}.{name}"
+        entry = _REGISTRY[spec_id]          # creates + caches the GeneratorEntry
+        fn._composite_generator_entry = entry   # introspection sidecar
+        return fn
+
+    return decorate
+
+
+def _validate_emitters(emitters: list[dict] | None, name: str) -> list[dict]:
+    """Normalise + sanity-check the decorator's ``emitters`` declaration.
+
+    Each entry must be a dict with a non-empty string ``address``. ``config``,
+    when present, must be a dict; ``paths``, when present, must be a list of
+    strings. We validate at decoration time (not first use) so a malformed
+    declaration fails loudly on import — the same place a bad ``parameters``
+    block would. Returns a fresh list of copied dicts so later mutation of the
+    caller's literal can't leak into the registry.
+    """
+    out: list[dict] = []
+    for i, em in enumerate(emitters or []):
+        where = f"{name!r} emitters[{i}]"
+        if not isinstance(em, dict):
+            raise ValueError(f"{where}: each emitter must be a dict, got {type(em).__name__}")
+        address = em.get("address")
+        if not isinstance(address, str) or not address:
+            raise ValueError(f"{where}: 'address' must be a non-empty string")
+        config = em.get("config", {})
+        if not isinstance(config, dict):
+            raise ValueError(f"{where}: 'config' must be a dict")
+        paths = em.get("paths")
+        if paths is not None and not (
+            isinstance(paths, list) and all(isinstance(p, str) for p in paths)
+        ):
+            raise ValueError(f"{where}: 'paths' must be a list of strings")
+        out.append(dict(em))
+    return out
+
+
+def emitter_defaults(fn_or_entry: Any) -> list[dict]:
+    """Return the declared default emitter(s) for a generator OR static spec.
+
+    Accepts a decorated generator function (reads its
+    ``_composite_generator_entry`` sidecar), a :class:`GeneratorEntry`, or a
+    parsed static composite-spec ``dict`` (reads its top-level ``emitters:``
+    key — the static-spec analogue of the decorator's ``emitters=``). Returns
+    the (possibly empty) ``emitters`` list — a workspace builds the composite's
+    default sink from this when it isn't running under the dashboard's
+    observable-injection flow. Returns ``[]`` for anything that declares none,
+    so callers can use it unconditionally.
+    """
+    if isinstance(fn_or_entry, dict):  # parsed static composite spec
+        return list(fn_or_entry.get("emitters") or [])
+    entry = getattr(fn_or_entry, "_composite_generator_entry", fn_or_entry)
+    return list(getattr(entry, "emitters", []) or [])
+
+
+def _emitter_node_from_decl(decl: dict, *, run_id: str | None = None,
+                            out_dir: Any = None, registered=None,
+                            fallback: str = "local:RAMEmitter") -> dict:
+    """Materialise one ``emitters=`` declaration into a process-bigraph step node.
+
+    The declaration is the lightweight ``{address, config?, paths?}`` form; the
+    emit-schema + topology are computed here (they depend on the composite's
+    shape, so they aren't part of the declaration). Each ``paths`` entry (slash-
+    or dot-joined) becomes one ``config.emit`` column wired to that store;
+    ``global_time`` is always emitted so trajectories have a time axis and the
+    Step re-fires every tick. When the declared ``address`` isn't in
+    ``registered`` (the core's link registry), it degrades to ``fallback`` so
+    the composite still builds — the convention's RAMEmitter safety net.
+    """
+    address = decl.get("address") or fallback
+    name = address.split(":", 1)[-1]
+    if registered is not None and name not in registered:
+        address = fallback
+        name = address.split(":", 1)[-1]
+
+    emit_schema: dict = {}
+    inputs: dict = {}
+    for p in decl.get("paths") or []:
+        parts = [seg for seg in str(p).replace(".", "/").split("/") if seg]
+        if not parts:
+            continue
+        key = "_".join(parts)
+        emit_schema[key] = "node"
+        inputs[key] = parts
+    if "global_time" not in inputs:
+        inputs["global_time"] = ["global_time"]
+        emit_schema["global_time"] = "node"
+
+    config = dict(decl.get("config") or {})
+    config["emit"] = emit_schema
+    # Run-specific layering for hive-partitioned parquet sinks: a per-run out_dir
+    # + experiment_id partition. Applied to any *ParquetEmitter (the generic
+    # ParquetEmitter and workspace variants like DataFrameParquetEmitter), which
+    # understand these keys; other sinks keep their declared base config.
+    if name.endswith("ParquetEmitter"):
+        if out_dir is not None:
+            config["out_dir"] = str(out_dir)
+        if run_id is not None:
+            config.setdefault("partitioning_keys", ["experiment_id"])
+            md = dict(config.get("metadata") or {})
+            md.setdefault("experiment_id", run_id)
+            config["metadata"] = md
+
+    return {"_type": "step", "address": address, "config": config, "inputs": inputs}
+
+
+def install_default_emitters(state: dict, source: Any, *, run_id: str | None = None,
+                             out_dir: Any = None, core: Any = None) -> dict:
+    """Return a copy of ``state`` with the composite's declared default
+    emitter(s) installed as ``emitter`` / ``emitter_<i>`` step nodes.
+
+    ``source`` is a generator fn/entry or a parsed static-spec dict — whatever
+    :func:`emitter_defaults` understands. This is the convention's install step:
+    a composite built outside the dashboard's observable-injection flow still
+    gets its declared sink. Resolution order (declared → RAMEmitter fallback) is
+    handled per-node by :func:`_emitter_node_from_decl`; external overrides are
+    layered by the caller before this call.
+
+    ``run_id`` / ``out_dir`` are run-specific parquet parameters (ignored by
+    non-parquet sinks). ``core`` (when given) lets the installer degrade an
+    unregistered declared address to RAMEmitter. Returns ``state`` unchanged
+    when nothing is declared, so callers can invoke it unconditionally.
+    """
+    decls = emitter_defaults(source)
+    if not decls:
+        return dict(state)
+    registered = getattr(core, "link_registry", None) if core is not None else None
+    new_state = dict(state)
+    for i, decl in enumerate(decls):
+        if not isinstance(decl, dict):
+            continue
+        key = "emitter" if i == 0 else f"emitter_{i}"
+        new_state[key] = _emitter_node_from_decl(
+            decl, run_id=run_id, out_dir=out_dir, registered=registered)
+    return new_state
+
+
+def apply_core_extensions(entry: GeneratorEntry, core: Any) -> Any:
+    """Run ``entry.core_extensions`` against ``core``; return the final core.
+
+    Each extension is a callable ``(core) -> core | None`` that registers
+    custom types/processes (e.g. ``viva_munk.register_pymunk_types``). By the
+    ``register_types`` convention an extension may return a (possibly new)
+    core; when it returns ``None`` we keep the one we passed in.
+
+    Failures are **not** swallowed. A missing registration is exactly the
+    kind of silent gap v2ecoli friction #16 is about — letting the exception
+    propagate surfaces it (with the offending function name) instead of
+    deferring to a cryptic "cannot resolve types" error at Composite-build
+    time.
+    """
+    for ext in entry.core_extensions or []:
+        result = ext(core)
+        if result is not None:
+            core = result
+    return core
+
+
+def build_generator(entry, overrides=None, core=None):
+    """Delegate to the CompositeSpec document. ``entry`` may be a CompositeSpec,
+    a GeneratorEntry (has ``.id``/``.func``), or a registered id's entry.
+
+    Unknown override keys raise ``ValueError`` so dashboards / callers can't
+    silently smuggle in parameters that the generator doesn't declare.
+    (``CompositeSpec._merged_params`` raises ``KeyError`` for unknown keys; we
+    intercept here so callers always get ``ValueError``.)
+    """
+    # Validate overrides before delegating so callers always get ValueError
+    # (not KeyError from _merged_params) for unknown parameters.
+    overrides = overrides or {}
+    params = getattr(entry, "parameters", {}) or {}
+    unknown = set(overrides) - set(params)
+    if unknown:
+        raise ValueError(
+            f"unknown parameter(s) for {getattr(entry, 'id', '?')}: {sorted(unknown)}"
+        )
+    if isinstance(entry, _cs.CompositeSpec):
+        spec = entry
+    else:
+        spec = _cs.get(getattr(entry, "id", None))
+        if spec is None and callable(getattr(entry, "func", None)):
+            # out-of-registry GeneratorEntry (e.g. registry cleared after decoration):
+            # rebuild a transient spec from it so we preserve "build from the entry".
+            spec = _cs.CompositeSpec(
+                id=entry.id, name=entry.name, builder=entry.func,
+                parameters=entry.parameters, module=entry.module,
+            )
+    if spec is None:
+        raise ValueError(
+            f"build_generator: no registered composite for "
+            f"{getattr(entry, 'id', entry)!r}")
+    return spec.to_document(overrides, core=core)
+
+
+def _import_bigraph_packages(extra_packages: list[str] | None = None) -> None:
+    """Walk installed bigraph-schema-dependent packages and import them so
+    that ``@composite_generator`` decorators fire and register their specs.
+
+    This is the distribution-walking body extracted from ``discover_generators``
+    so it can be called independently (e.g. from ``composite_spec.discover_specs``
+    via the shim's ``discover_generators``).
+    """
+    import importlib
+    import importlib.metadata as md
+
+    extra_packages = extra_packages or []
+    targets: set[str] = set(extra_packages)
+
+    for dist in md.distributions():
+        deps = dist.requires or []
+        if not any("bigraph-schema" in (d or "") for d in deps):
+            continue
+        # Find the importable top-level packages for this distribution.
+        # Prefer top_level.txt when present (wheel installs); fall back to
+        # the normalised package name (hyphens → underscores) for editable
+        # installs built with hatchling / PEP 660, which omit top_level.txt.
+        top_level_txt = dist.read_text("top_level.txt") or ""
+        mods_from_txt = [
+            line.strip()
+            for line in top_level_txt.splitlines()
+            if line.strip() and not line.strip().startswith("_")
+        ]
+        if mods_from_txt:
+            targets.update(mods_from_txt)
+        else:
+            dist_name = dist.metadata.get("Name") or ""
+            fallback = dist_name.replace("-", "_")
+            if fallback and not fallback.startswith("_"):
+                targets.add(fallback)
+
+    import pkgutil
+    import warnings
+
+    for mod_name in sorted(targets):
+        try:
+            top = importlib.import_module(mod_name)
+        except Exception as e:  # noqa: BLE001 — skip any unimportable package
+            warnings.warn(
+                f"discover_generators: skipping {mod_name!r}: "
+                f"{type(e).__name__}: {e}",
+                stacklevel=2,
+            )
+            continue
+        # mem3dg-readdy friction #22: @composite_generator decorators
+        # only fire when their containing module is imported. Importing
+        # the top-level package alone misses subpackages like
+        # `pbg_<ws>/composites/__init__.py` unless the top-level
+        # __init__.py eagerly does `from . import composites`. Walk the
+        # subpackage tree so workspaces don't have to remember.
+        pkg_path = getattr(top, "__path__", None)
+        if not pkg_path:
+            continue  # single-file module — nothing to walk
+        # pkgutil.walk_packages imports each subpackage during descent;
+        # without `onerror`, any subpackage that raises at top level
+        # (e.g. ecoli.analysis.antibiotics_colony's data-file probe)
+        # would abort the whole walk. Swallow + warn via the same path
+        # the per-import try/except below uses.
+        def _walk_onerror(name, _e=None):
+            warnings.warn(
+                f"discover_generators: skipping subpackage {name!r} "
+                f"(walk failed during import)",
+                stacklevel=2,
+            )
+        for finder, sub_name, is_pkg in pkgutil.walk_packages(
+            pkg_path, prefix=mod_name + ".", onerror=_walk_onerror,
+        ):
+            # v2ecoli friction #4: skip subpaths that look like CLI scripts
+            # (e.g. `<pkg>.scripts.compare_runs`). Discovery should walk the
+            # library, not the CLI tool layer — and CLI scripts commonly
+            # have module-level `sys.exit()` / argparse / etc. that crash
+            # under import.
+            tail = sub_name.split(".")
+            if any(seg == "scripts" for seg in tail):
+                continue
+            try:
+                importlib.import_module(sub_name)
+            except SystemExit as e:  # noqa: BLE001
+                # `sys.exit(N)` at module level is NOT a subclass of
+                # Exception; without this branch it would propagate out of
+                # discover_generators and crash the dashboard. v2ecoli's
+                # `scripts/compare-runs.py` had a top-level sys.exit(0)
+                # that took the whole subprocess down before this catch.
+                warnings.warn(
+                    f"discover_generators: subpackage {sub_name!r} called "
+                    f"sys.exit({e.code!r}) at import time; skipping. "
+                    "Wrap top-level CLI logic in `if __name__ == \"__main__\":`.",
+                    stacklevel=2,
+                )
+            except Exception as e:  # noqa: BLE001
+                warnings.warn(
+                    f"discover_generators: skipping subpackage {sub_name!r}: "
+                    f"{type(e).__name__}: {e}",
+                    stacklevel=2,
+                )
+
+
+def discover_generators(
+    extra_packages: list[str] | None = None,
+) -> dict[str, GeneratorEntry]:
+    """Discover composite generators from installed packages.
+
+    Walks every installed distribution that depends on ``bigraph-schema``,
+    imports each top-level package so its ``@composite_generator`` decorators
+    fire, then returns whatever generator-kind specs ended up in the
+    process-bigraph registry as ``GeneratorEntry`` views.
+
+    Unlike ``discover_composites`` (file-glob; imports only to resolve
+    package paths, not to run decorator side-effects), this MUST import
+    the host packages so the decorators fire. Subsequent calls return the
+    same registry; there is no automatic invalidation. Hot-reload callers
+    can ``_REGISTRY.clear()`` before re-importing.
+    """
+    _import_bigraph_packages(extra_packages)
+    return {
+        sid: _entry_for(s)
+        for sid, s in _cs.all_specs().items()
+        if s.kind == "generator"
+    }

--- a/process_bigraph/composite_generator.py
+++ b/process_bigraph/composite_generator.py
@@ -526,48 +526,70 @@ def _import_bigraph_packages(extra_packages: list[str] | None = None) -> None:
         pkg_path = getattr(top, "__path__", None)
         if not pkg_path:
             continue  # single-file module — nothing to walk
-        # pkgutil.walk_packages imports each subpackage during descent;
-        # without `onerror`, any subpackage that raises at top level
-        # (e.g. ecoli.analysis.antibiotics_colony's data-file probe)
-        # would abort the whole walk. Swallow + warn via the same path
-        # the per-import try/except below uses.
-        def _walk_onerror(name, _e=None):
-            warnings.warn(
-                f"discover_generators: skipping subpackage {name!r} "
-                f"(walk failed during import)",
-                stacklevel=2,
-            )
-        for finder, sub_name, is_pkg in pkgutil.walk_packages(
-            pkg_path, prefix=mod_name + ".", onerror=_walk_onerror,
-        ):
-            # v2ecoli friction #4: skip subpaths that look like CLI scripts
-            # (e.g. `<pkg>.scripts.compare_runs`). Discovery should walk the
-            # library, not the CLI tool layer — and CLI scripts commonly
-            # have module-level `sys.exit()` / argparse / etc. that crash
-            # under import.
-            tail = sub_name.split(".")
-            if any(seg == "scripts" for seg in tail):
-                continue
-            try:
-                importlib.import_module(sub_name)
-            except SystemExit as e:  # noqa: BLE001
-                # `sys.exit(N)` at module level is NOT a subclass of
-                # Exception; without this branch it would propagate out of
-                # discover_generators and crash the dashboard. v2ecoli's
-                # `scripts/compare-runs.py` had a top-level sys.exit(0)
-                # that took the whole subprocess down before this catch.
-                warnings.warn(
-                    f"discover_generators: subpackage {sub_name!r} called "
-                    f"sys.exit({e.code!r}) at import time; skipping. "
-                    "Wrap top-level CLI logic in `if __name__ == \"__main__\":`.",
-                    stacklevel=2,
-                )
-            except Exception as e:  # noqa: BLE001
-                warnings.warn(
-                    f"discover_generators: skipping subpackage {sub_name!r}: "
-                    f"{type(e).__name__}: {e}",
-                    stacklevel=2,
-                )
+
+        # v2ecoli friction #4: skip subpaths that look like CLI scripts
+        # (e.g. `<pkg>.scripts.compare_runs`). Discovery should walk the
+        # library, not the CLI tool layer — and CLI scripts commonly have
+        # module-level `sys.exit()` / argparse / etc. that crash under
+        # import.
+        #
+        # Also skip `tests` subpackages. process-bigraph itself declares
+        # `bigraph-schema` as a dependency, so its own distribution is
+        # always one of `_import_bigraph_packages`'s walk targets — and in
+        # this repo (unlike viva-superpowers, whose tests/ sits *outside*
+        # the viva-superpowers/ package) tests live *inside* the package at
+        # `process_bigraph/tests/`. Without this skip, every call to
+        # `discover_generators()` — from any test, in any installed package
+        # that colocates tests this way — would import the whole test suite
+        # as a side effect: firing module-level decorators (registry
+        # pollution) and running expensive/stateful test-only code (e.g.
+        # subprocess-driven fixtures) purely as a byproduct of composite
+        # discovery.
+        #
+        # This has to be a pre-descent filter, not a post-hoc skip of
+        # pkgutil.walk_packages's yielded items: walk_packages auto-imports
+        # (and recurses into) every package-like entry it finds *before*
+        # a caller's loop body gets a chance to react, so a `continue` on
+        # the yielded `<pkg>.tests` item does not stop it from already
+        # having imported `<pkg>.tests` and descended into e.g.
+        # `<pkg>.tests.fixtures.some_pkg`. Walking the tree ourselves lets
+        # us drop an excluded subpackage before it (or anything beneath it)
+        # is ever imported.
+        _SKIP_SEGMENTS = ("scripts", "tests")
+
+        def _walk(path, prefix):
+            for _finder, name, is_pkg in pkgutil.iter_modules(path, prefix=prefix):
+                if name.rsplit(".", 1)[-1] in _SKIP_SEGMENTS:
+                    continue
+                try:
+                    mod = importlib.import_module(name)
+                except SystemExit as e:  # noqa: BLE001
+                    # `sys.exit(N)` at module level is NOT a subclass of
+                    # Exception; without this branch it would propagate out
+                    # of discover_generators and crash the dashboard.
+                    # v2ecoli's `scripts/compare-runs.py` had a top-level
+                    # sys.exit(0) that took the whole subprocess down before
+                    # this catch.
+                    warnings.warn(
+                        f"discover_generators: subpackage {name!r} called "
+                        f"sys.exit({e.code!r}) at import time; skipping. "
+                        "Wrap top-level CLI logic in `if __name__ == \"__main__\":`.",
+                        stacklevel=2,
+                    )
+                    continue
+                except Exception as e:  # noqa: BLE001
+                    warnings.warn(
+                        f"discover_generators: skipping subpackage {name!r}: "
+                        f"{type(e).__name__}: {e}",
+                        stacklevel=2,
+                    )
+                    continue
+                if is_pkg:
+                    sub_path = getattr(mod, "__path__", None)
+                    if sub_path:
+                        _walk(sub_path, name + ".")
+
+        _walk(pkg_path, mod_name + ".")
 
 
 def discover_generators(

--- a/process_bigraph/config_helpers.py
+++ b/process_bigraph/config_helpers.py
@@ -1,0 +1,98 @@
+"""Config-value normalizers for process ``initialize()`` / ``__init__`` bodies.
+
+v2ecoli friction #3 (2026-05-19): a config value declared as a 2-element
+range — e.g. ``band: [0.2, 0.5]`` in a composite/study yaml — does not always
+arrive in the process as a list. ``bigraph-schema``'s ``node`` type (and JSON
+round-trips through the dashboard's subprocess runner) rewrap it into a dict
+with integer or string keys, and some authors hand-write the explicit-key
+form. So ``initialize()`` ended up needing to tolerate three shapes:
+
+1. ``[low, high]``                       — yaml-native list/tuple
+2. ``{0: low, 1: high}`` / ``{"0": low, "1": high}`` — bigraph-schema rewrap
+3. ``{"low": ..., "high": ...}``         — explicit-key form
+
+Re-deriving that tolerance in every process is the boilerplate this helper
+removes. Import it instead of hand-rolling ``isinstance(band, dict)`` ladders.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+def normalize_config_list(
+    value: Any,
+    *,
+    key_names: tuple[str, ...] = ("low", "high"),
+    length: int | None = None,
+) -> list:
+    """Coerce a range-ish config value into a plain ordered ``list``.
+
+    Accepts the three shapes a ``[low, high]``-style value can arrive in
+    (see the module docstring) and returns a list in canonical order.
+
+    - ``key_names`` names the explicit-key form's keys, in order. Defaults to
+      ``("low", "high")``; pass e.g. ``("min", "max")`` or
+      ``("x", "y", "z")`` to match your schema.
+    - ``length`` (optional) asserts the result has exactly this many
+      elements; raises ``ValueError`` otherwise. When omitted, the length
+      is whatever the input implies.
+
+    Ordering rules:
+    - list / tuple → returned as a list, order preserved.
+    - dict with the ``key_names`` keys → ordered by ``key_names``.
+    - dict with integer-or-numeric-string keys (``0``/``"0"``/...) → ordered
+      by numeric key value.
+    - a scalar → wrapped as a single-element list (so callers can treat a
+      bare ``0.3`` and ``[0.3]`` uniformly).
+
+    Raises ``ValueError`` on a dict whose keys match neither convention, or
+    when ``length`` is given and doesn't match.
+    """
+    if value is None:
+        result: list = []
+    elif isinstance(value, (list, tuple)):
+        result = list(value)
+    elif isinstance(value, dict):
+        result = _from_dict(value, key_names)
+    else:
+        # Scalar — treat as a one-element range.
+        result = [value]
+
+    if length is not None and len(result) != length:
+        raise ValueError(
+            f"normalize_config_list: expected {length} element(s), "
+            f"got {len(result)} from {value!r}"
+        )
+    return result
+
+
+def _from_dict(value: dict, key_names: tuple[str, ...]) -> list:
+    # Explicit-key form: every declared key present.
+    if all(k in value for k in key_names):
+        return [value[k] for k in key_names]
+
+    # Numeric-key form: keys are ints or numeric strings ("0", "1", ...).
+    numeric: list[tuple[int, Any]] = []
+    for k, v in value.items():
+        idx = _as_index(k)
+        if idx is None:
+            raise ValueError(
+                f"normalize_config_list: dict key {k!r} is neither one of "
+                f"{key_names} nor a numeric index; value={value!r}"
+            )
+        numeric.append((idx, v))
+    numeric.sort(key=lambda pair: pair[0])
+    return [v for _, v in numeric]
+
+
+def _as_index(key: Any) -> int | None:
+    if isinstance(key, bool):  # bool is an int subclass — exclude it
+        return None
+    if isinstance(key, int):
+        return key
+    if isinstance(key, str):
+        try:
+            return int(key)
+        except ValueError:
+            return None
+    return None

--- a/process_bigraph/core_introspection.py
+++ b/process_bigraph/core_introspection.py
@@ -1,0 +1,44 @@
+"""Helpers to introspect a process-bigraph core's registries.
+
+These adapt to whatever public API the running version of process-bigraph
+exposes (list_processes / registered_links / etc.) — they fail loudly if
+no introspection method is available.
+"""
+from __future__ import annotations
+from typing import Any
+
+
+_PROCESS_ATTRS = ("list_processes", "registered_links", "_links")
+_TYPE_ATTRS = ("list_types", "_types", "registered_types")
+
+
+def _try(core: Any, *attrs: str) -> list[str] | None:
+    for a in attrs:
+        m = getattr(core, a, None)
+        if callable(m):
+            return list(m())
+        if isinstance(m, dict):
+            return list(m.keys())
+    return None
+
+
+def list_processes(core: Any) -> list[str]:
+    res = _try(core, *_PROCESS_ATTRS)
+    if res is None:
+        raise RuntimeError(
+            f"core has no inspectable process registry (tried: {', '.join(_PROCESS_ATTRS)})"
+        )
+    return sorted(res)
+
+
+def list_types(core: Any) -> list[str]:
+    res = _try(core, *_TYPE_ATTRS)
+    if res is None:
+        raise RuntimeError(
+            f"core has no inspectable type registry (tried: {', '.join(_TYPE_ATTRS)})"
+        )
+    return sorted(res)
+
+
+def registry_snapshot(core: Any) -> dict:
+    return {"processes": list_processes(core), "types": list_types(core)}

--- a/process_bigraph/tests/conftest.py
+++ b/process_bigraph/tests/conftest.py
@@ -1,0 +1,19 @@
+"""Keep pytest from collecting fixture packages as test modules.
+
+pytest.ini sets ``python_files = *.py`` (broader than the usual
+``test_*.py``), so any ``.py`` file under this tree is a collection
+candidate by default — including ``fixtures/fake_generator_pkg/`` files
+like ``composites.py``, whose ``@composite_generator`` decorator has a
+real side effect (registering into the shared process_bigraph.composite_spec
+registry). If pytest's own collection import fires that decorator, the
+resulting registration can outlive collection in ``sys.modules`` — so a
+LATER test's explicit ``importlib.import_module("fake_generator_pkg")``
+(e.g. in ``discover_generators()``) becomes a no-op cache hit that never
+re-fires the decorator, while an unrelated test's registry-clearing
+fixture can still wipe the collection-time registration first. The net
+effect is a full-suite-only flaky failure that never reproduces when the
+affected test file is run in isolation. Excluding `fixtures/` from
+collection removes the root cause: fixture packages are data for tests
+to install/import explicitly, never test modules themselves.
+"""
+collect_ignore = ["fixtures"]

--- a/process_bigraph/tests/fixtures/fake_generator_pkg/fake_generator_pkg/__init__.py
+++ b/process_bigraph/tests/fixtures/fake_generator_pkg/fake_generator_pkg/__init__.py
@@ -1,0 +1,1 @@
+from . import composites  # noqa: F401  -- import so decorators fire

--- a/process_bigraph/tests/fixtures/fake_generator_pkg/fake_generator_pkg/composites.py
+++ b/process_bigraph/tests/fixtures/fake_generator_pkg/fake_generator_pkg/composites.py
@@ -1,0 +1,10 @@
+from process_bigraph.composite_generator import composite_generator
+
+
+@composite_generator(
+    name="demo",
+    description="A fake generator used only by tests.",
+    parameters={"x": {"type": "int", "default": 7}},
+)
+def demo(core=None, *, x=7):
+    return {"x": x}

--- a/process_bigraph/tests/fixtures/fake_generator_pkg/pyproject.toml
+++ b/process_bigraph/tests/fixtures/fake_generator_pkg/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "fake-generator-pkg"
+version = "0.0.1"
+requires-python = ">=3.10"
+dependencies = ["bigraph-schema"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["fake_generator_pkg"]

--- a/process_bigraph/tests/test_composite_discovery.py
+++ b/process_bigraph/tests/test_composite_discovery.py
@@ -1,4 +1,4 @@
-"""Tests for process_bigraph.composite_discovery (moved from viva_superpowers)."""
+"""Tests for process_bigraph.composite_discovery (moved from viva-superpowers)."""
 from pathlib import Path
 
 import pytest

--- a/process_bigraph/tests/test_composite_discovery.py
+++ b/process_bigraph/tests/test_composite_discovery.py
@@ -1,0 +1,111 @@
+"""Tests for process_bigraph.composite_discovery (moved from viva_superpowers)."""
+from pathlib import Path
+
+import pytest
+
+from process_bigraph.composite_discovery import (
+    discover_composites, discover_all, _make_spec_id,
+)
+from process_bigraph import composite_spec as cs
+
+
+def test_discover_composites_finds_workspace_local_specs(tmp_path):
+    """extra_search_paths lets a workspace-local composite dir be discovered
+    without it belonging to any installed bigraph-schema-dependent package."""
+    (tmp_path / "local.composite.yaml").write_text(
+        "name: increase-demo\nstate: {a: 1}\n", encoding="utf-8"
+    )
+    specs = discover_composites(extra_search_paths=[tmp_path])
+    assert any(spec_id.endswith("local") for spec_id in specs), (
+        f"workspace-local fixture not found: {list(specs.keys())}"
+    )
+
+
+def test_discover_composites_skips_malformed_spec(tmp_path, capsys):
+    """A malformed spec file is skipped (with a stderr warning), not fatal."""
+    (tmp_path / "broken.composite.yaml").write_text(
+        "not: [valid, - yaml: :", encoding="utf-8"
+    )
+    (tmp_path / "good.composite.yaml").write_text(
+        "name: good\nstate: {a: 1}\n", encoding="utf-8"
+    )
+    specs = discover_composites(extra_search_paths=[tmp_path])
+    assert any(spec_id.endswith("good") for spec_id in specs)
+    assert not any(spec_id.endswith("broken") for spec_id in specs)
+
+
+def test_discover_composites_ignores_non_directory_extra_path(tmp_path):
+    """A non-existent / non-directory extra search path is silently skipped."""
+    missing = tmp_path / "does-not-exist"
+    specs = discover_composites(extra_search_paths=[missing])
+    assert specs == {} or isinstance(specs, dict)
+
+
+def test_make_spec_id_strips_composite_suffix(tmp_path):
+    pkg_root = tmp_path / "pkg"
+    sub = pkg_root / "sub"
+    sub.mkdir(parents=True)
+    file_path = sub / "baseline.composite.yaml"
+    file_path.write_text("name: baseline\nstate: {}\n", encoding="utf-8")
+    spec_id = _make_spec_id("mypkg", pkg_root, file_path)
+    assert spec_id == "mypkg.sub.baseline"
+
+
+def test_discover_all_tags_spec_kind(tmp_path):
+    (tmp_path / "baseline.composite.yaml").write_text(
+        "name: baseline\nstate: {}\n", encoding="utf-8"
+    )
+    cs.clear_registry()
+    merged = discover_all(extra_search_paths=[tmp_path])
+    spec_entries = {k: v for k, v in merged.items() if k.endswith(".baseline")}
+    assert spec_entries, f"expected a .baseline spec entry, got {list(merged.keys())}"
+    for entry in spec_entries.values():
+        assert entry["kind"] == "spec"
+
+
+def test_discover_all_includes_generator_entries(tmp_path):
+    """Generator entries surface via discover_all, tagged 'generator', with
+    the framework-owned fields (visualizations/emitters/default_n_steps)
+    always present."""
+    from process_bigraph.composite_generator import composite_generator, _REGISTRY
+    cs.clear_registry()
+
+    @composite_generator(name="collide", description="", parameters={})
+    def collide(core=None):
+        return {"state": {}}
+
+    gen_id = f"{collide.__module__}.collide"
+    merged = discover_all(extra_search_paths=[])
+    assert gen_id in merged
+    assert merged[gen_id]["kind"] == "generator"
+    assert merged[gen_id]["name"] == "collide"
+    assert merged[gen_id]["visualizations"] == []
+    assert merged[gen_id]["emitters"] == []
+    assert "default_n_steps" in merged[gen_id]
+    _REGISTRY.clear()
+
+
+def test_discover_all_warns_on_spec_generator_id_collision(monkeypatch, tmp_path):
+    """When a static spec and a generator share an id, the generator entry
+    wins and a collision warning fires (discover_all's own merge logic,
+    independent of what discover_composites/discover_generators return)."""
+    from process_bigraph.composite_generator import composite_generator, _REGISTRY
+    cs.clear_registry()
+
+    @composite_generator(name="collide2", description="", parameters={})
+    def collide2(core=None):
+        return {"state": {}}
+
+    gen_id = f"{collide2.__module__}.collide2"
+
+    def fake_discover_composites(extra_search_paths=None):
+        return {gen_id: {"name": "fake-spec", "state": {}}}
+
+    monkeypatch.setattr(
+        "process_bigraph.composite_discovery.discover_composites",
+        fake_discover_composites,
+    )
+    with pytest.warns(UserWarning, match="collides"):
+        merged = discover_all(extra_search_paths=[])
+    assert merged[gen_id]["kind"] == "generator"
+    _REGISTRY.clear()

--- a/process_bigraph/tests/test_composite_generator.py
+++ b/process_bigraph/tests/test_composite_generator.py
@@ -1,0 +1,650 @@
+"""Tests for process_bigraph.composite_generator (moved from viva_superpowers)."""
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from process_bigraph.composite_generator import (
+    build_generator, composite_generator, GeneratorEntry, _REGISTRY,
+    apply_core_extensions, emitter_defaults,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_registry():
+    """Each test starts with an empty registry."""
+    _REGISTRY.clear()
+    yield
+    _REGISTRY.clear()
+
+
+def test_decorator_registers_function():
+    @composite_generator(
+        name="my-composite",
+        description="A test composite.",
+        parameters={"rate": {"type": "float", "default": 1.0}},
+    )
+    def builder(core=None, *, rate=1.0):
+        return {"stores": {"level": rate}}
+
+    # Function is registered with its module-qualified id
+    entry_id = f"{builder.__module__}.my-composite"
+    assert entry_id in _REGISTRY
+    entry = _REGISTRY[entry_id]
+    assert isinstance(entry, GeneratorEntry)
+    assert entry.name == "my-composite"
+    assert entry.description == "A test composite."
+    assert entry.parameters == {"rate": {"type": "float", "default": 1.0}}
+    assert entry.func is builder
+    # Wrapped function is unchanged-ish: callable with same signature
+    assert builder(rate=2.0) == {"stores": {"level": 2.0}}
+    # Sidecar on the function for introspection
+    assert builder._composite_generator_entry is entry
+
+
+def test_decorator_accepts_default_n_steps():
+    @composite_generator(
+        name="dn", description="", parameters={}, default_n_steps=200,
+    )
+    def builder(core=None):
+        return {}
+
+    entry = _REGISTRY[f"{builder.__module__}.dn"]
+    assert entry.default_n_steps == 200
+
+
+def test_decorator_default_n_steps_optional():
+    @composite_generator(name="dn-opt", description="", parameters={})
+    def builder(core=None):
+        return {}
+
+    entry = _REGISTRY[f"{builder.__module__}.dn-opt"]
+    assert entry.default_n_steps is None
+
+
+def test_decorator_core_extensions_default_empty():
+    @composite_generator(name="ce-default", description="", parameters={})
+    def builder(core=None):
+        return {}
+
+    entry = _REGISTRY[f"{builder.__module__}.ce-default"]
+    assert entry.core_extensions == []
+
+
+def test_decorator_stores_core_extensions():
+    """v2ecoli friction #16: a generator can declare register_* callables so
+    the subprocess runner can register the package's types on the core it
+    actually builds against."""
+    def register_pymunk_types(core):
+        core.setdefault("types", []).append("pymunk_agent")
+        return core
+
+    def register_processes(core):
+        core.setdefault("procs", []).append("Attachment")
+        return core
+
+    @composite_generator(
+        name="ce-stored", description="", parameters={},
+        core_extensions=[register_pymunk_types, register_processes],
+    )
+    def builder(core=None):
+        return {}
+
+    entry = _REGISTRY[f"{builder.__module__}.ce-stored"]
+    assert entry.core_extensions == [register_pymunk_types, register_processes]
+
+
+def test_apply_core_extensions_runs_each_in_order():
+    calls = []
+
+    def ext_a(core):
+        calls.append("a")
+        core["a"] = True
+        return core
+
+    def ext_b(core):
+        calls.append("b")
+        core["b"] = True
+        return core
+
+    entry = GeneratorEntry(
+        id="x.y", name="y", description="", parameters={},
+        func=lambda core=None: {}, module="x",
+        core_extensions=[ext_a, ext_b],
+    )
+    core = {}
+    out = apply_core_extensions(entry, core)
+    assert calls == ["a", "b"]
+    assert out == {"a": True, "b": True}
+
+
+def test_apply_core_extensions_threads_replacement_core():
+    """An extension that returns a NEW core (not the one passed in) should
+    have that replacement threaded to the next extension and returned."""
+    sentinel_a = {"id": "a"}
+    sentinel_b = {"id": "b"}
+
+    def ext_replaces(core):
+        return sentinel_b
+
+    def ext_observes(core):
+        assert core is sentinel_b  # got the replacement, not the original
+        return None  # returning None keeps the current core
+
+    entry = GeneratorEntry(
+        id="x.y", name="y", description="", parameters={},
+        func=lambda core=None: {}, module="x",
+        core_extensions=[ext_replaces, ext_observes],
+    )
+    out = apply_core_extensions(entry, sentinel_a)
+    assert out is sentinel_b
+
+
+def test_apply_core_extensions_none_return_keeps_core():
+    def ext_inplace(core):
+        core["touched"] = True
+        return None  # mutate-in-place convention
+
+    entry = GeneratorEntry(
+        id="x.y", name="y", description="", parameters={},
+        func=lambda core=None: {}, module="x",
+        core_extensions=[ext_inplace],
+    )
+    core = {}
+    out = apply_core_extensions(entry, core)
+    assert out is core
+    assert core == {"touched": True}
+
+
+def test_apply_core_extensions_does_not_swallow_failures():
+    """A missing/broken registration must surface, not be silently skipped —
+    otherwise the Composite build fails later with a cryptic type error."""
+    def ext_boom(core):
+        raise RuntimeError("register_pymunk_types blew up")
+
+    entry = GeneratorEntry(
+        id="x.y", name="y", description="", parameters={},
+        func=lambda core=None: {}, module="x",
+        core_extensions=[ext_boom],
+    )
+    with pytest.raises(RuntimeError, match="register_pymunk_types blew up"):
+        apply_core_extensions(entry, {})
+
+
+def test_apply_core_extensions_empty_is_noop():
+    entry = GeneratorEntry(
+        id="x.y", name="y", description="", parameters={},
+        func=lambda core=None: {}, module="x",
+    )
+    core = {"unchanged": True}
+    assert apply_core_extensions(entry, core) is core
+
+
+def test_decorator_accepts_visualizations():
+    """``visualizations`` ships canonical Study-spec viz entries with the
+    composite; dashboards can merge them into a Study without the author
+    having to hand-author each."""
+    viz_list = [
+        {
+            "name": "level-trace",
+            "address": "local:TimeSeriesPlot",
+            "config": {"observable": "level"},
+        },
+        {
+            "name": "topology",
+            "address": "local:NetworkVisualization",
+            "config": {},
+        },
+    ]
+
+    @composite_generator(
+        name="vz",
+        description="",
+        parameters={},
+        visualizations=viz_list,
+    )
+    def builder(core=None):
+        return {}
+
+    entry = _REGISTRY[f"{builder.__module__}.vz"]
+    assert entry.visualizations == viz_list
+    # Defensive copy — mutating the caller's list shouldn't change the entry.
+    viz_list.append({"name": "intruder"})
+    assert len(entry.visualizations) == 2
+
+
+def test_decorator_visualizations_optional():
+    @composite_generator(name="vz-opt", description="", parameters={})
+    def builder(core=None):
+        return {}
+
+    entry = _REGISTRY[f"{builder.__module__}.vz-opt"]
+    assert entry.visualizations == []
+
+
+def test_decorator_accepts_emitters():
+    """``emitters`` ships the composite's default observation sink(s) — a
+    lightweight {address, config, paths} selection, parallel to
+    ``visualizations``."""
+    emitters = [
+        {
+            "address": "local:ParquetEmitter",
+            "config": {"out_dir": "out/parquet"},
+            "paths": ["stores.x"],
+        },
+    ]
+
+    @composite_generator(name="em", description="", parameters={}, emitters=emitters)
+    def builder(core=None):
+        return {"stores": {"x": 0.0}}
+
+    entry = _REGISTRY[f"{builder.__module__}.em"]
+    assert entry.emitters == emitters
+    # Defensive copy — mutating the caller's list/dict shouldn't reach the entry.
+    emitters.append({"address": "local:SQLiteEmitter"})
+    assert len(entry.emitters) == 1
+    emitters_inner = entry.emitters[0]
+    assert emitters_inner["config"]["out_dir"] == "out/parquet"
+
+
+def test_decorator_emitters_optional():
+    @composite_generator(name="em-opt", description="", parameters={})
+    def builder(core=None):
+        return {}
+
+    entry = _REGISTRY[f"{builder.__module__}.em-opt"]
+    assert entry.emitters == []
+
+
+def test_emitter_defaults_accessor_reads_function_and_entry():
+    emitters = [{"address": "local:ParquetEmitter", "config": {"out_dir": "d"}}]
+
+    @composite_generator(name="em-acc", description="", parameters={}, emitters=emitters)
+    def builder(core=None):
+        return {}
+
+    # From the decorated function (sidecar) and from the entry directly.
+    assert emitter_defaults(builder) == emitters
+    entry = _REGISTRY[f"{builder.__module__}.em-acc"]
+    assert emitter_defaults(entry) == emitters
+    # Non-generators yield [] so callers can use it unconditionally.
+    assert emitter_defaults(object()) == []
+    assert emitter_defaults(lambda: None) == []
+
+
+@pytest.mark.parametrize(
+    "bad, match",
+    [
+        ([{"config": {}}], "address"),                       # missing address
+        ([{"address": ""}], "address"),                      # empty address
+        ([{"address": 1}], "address"),                       # non-string address
+        ([{"address": "local:X", "config": []}], "config"),  # config not a dict
+        ([{"address": "local:X", "paths": "a.b"}], "paths"),  # paths not a list
+        ([{"address": "local:X", "paths": [1]}], "paths"),    # paths not strings
+        (["not-a-dict"], "must be a dict"),                  # entry not a dict
+    ],
+)
+def test_decorator_emitters_validation(bad, match):
+    with pytest.raises(ValueError, match=match):
+        @composite_generator(name="em-bad", description="", parameters={}, emitters=bad)
+        def builder(core=None):
+            return {}
+
+
+def _make_entry(parameters, body):
+    @composite_generator(name="t", description="", parameters=parameters)
+    def _fn(core=None, **kw):
+        return body(**kw)
+    entry_id = f"{_fn.__module__}.t"
+    return _REGISTRY[entry_id]
+
+
+def test_build_generator_applies_defaults():
+    entry = _make_entry(
+        {"rate": {"type": "float", "default": 0.25}},
+        lambda **kw: {"got": kw},
+    )
+    assert build_generator(entry) == {"got": {"rate": 0.25}}
+
+
+def test_build_generator_applies_overrides():
+    entry = _make_entry(
+        {"rate": {"type": "float", "default": 0.25}},
+        lambda **kw: {"got": kw},
+    )
+    assert build_generator(entry, overrides={"rate": 9.0}) == {"got": {"rate": 9.0}}
+
+
+def test_build_generator_rejects_unknown_overrides():
+    entry = _make_entry(
+        {"rate": {"type": "float", "default": 0.25}},
+        lambda **kw: {"got": kw},
+    )
+    with pytest.raises(ValueError, match="bogus"):
+        build_generator(entry, overrides={"bogus": 1})
+
+
+def test_build_generator_passes_core_when_present():
+    seen = {}
+
+    @composite_generator(name="t2", description="", parameters={})
+    def builder(core=None):
+        seen["core"] = core
+        return {}
+
+    entry = _REGISTRY[f"{builder.__module__}.t2"]
+    sentinel = object()
+    build_generator(entry, core=sentinel)
+    assert seen["core"] is sentinel
+
+
+FIXTURE_PKG = Path(__file__).parent / "fixtures" / "fake_generator_pkg"
+
+
+def _install_cmd(action: str, target: str) -> list[str]:
+    """Build a pip install/uninstall command that targets ``sys.executable``.
+
+    Prefers ``uv pip --python <sys.executable>`` because it (a) pins the
+    target interpreter explicitly — bare ``uv pip`` would otherwise pick
+    the project's ``.venv`` instead of the pyenv interpreter that's
+    actually running pytest — and (b) doesn't require pip to be present
+    in the target env, which matters in CI where ``uv venv`` creates a
+    pip-less ``.venv``.
+
+    Falls back to ``sys.executable -m pip`` when ``uv`` isn't on PATH,
+    for contributors who run tests without uv installed.
+    """
+    if shutil.which("uv"):
+        if action == "install":
+            return ["uv", "pip", "install", "--python", sys.executable,
+                    "-q", "-e", target]
+        return ["uv", "pip", "uninstall", "--python", sys.executable, target]
+    if action == "install":
+        return [sys.executable, "-m", "pip", "install", "-q", "-e", target]
+    return [sys.executable, "-m", "pip", "uninstall", "-q", "-y", target]
+
+
+@pytest.fixture
+def installed_fake_pkg():
+    """Install the fixture package into the running test interpreter's env.
+
+    Uses ``uv pip install --python sys.executable`` so the install lands
+    in the same environment that runs the test, regardless of whether
+    that env has pip available (CI's ``uv venv`` does not) and regardless
+    of whether ``uv``'s default target ``.venv`` differs from
+    ``sys.executable`` (e.g. running under pyenv locally). Falls back to
+    ``sys.executable -m pip`` if uv is not installed.
+
+    Also patches ``sys.path`` directly so the editable ``.pth`` file
+    added by hatchling takes effect inside the already-running process
+    (``site`` only processes ``.pth`` files at startup).
+    """
+    subprocess.run(_install_cmd("install", str(FIXTURE_PKG)), check=True)
+    # Editable installs write a .pth file that is only processed at Python
+    # startup. Manually add the package root so importlib can find it now.
+    pkg_root = str(FIXTURE_PKG)
+    inserted = pkg_root not in sys.path
+    if inserted:
+        sys.path.insert(0, pkg_root)
+    import importlib
+    importlib.invalidate_caches()
+    yield
+    # Teardown: remove from sys.path and evict from sys.modules so subsequent
+    # tests (or re-runs) don't see stale state.
+    if inserted and pkg_root in sys.path:
+        sys.path.remove(pkg_root)
+    for mod_name in list(sys.modules):
+        if mod_name == "fake_generator_pkg" or mod_name.startswith("fake_generator_pkg."):
+            del sys.modules[mod_name]
+    importlib.invalidate_caches()
+    subprocess.run(_install_cmd("uninstall", "fake-generator-pkg"), check=True)
+
+
+def test_discover_generators_finds_decorated_function_in_installed_pkg(
+        installed_fake_pkg):
+    from process_bigraph.composite_generator import discover_generators
+    # Discovery must import the package — it can't rely on the test having
+    # already done so.
+    found = discover_generators()
+    expected_id = "fake_generator_pkg.composites.demo"
+    assert expected_id in found
+    entry = found[expected_id]
+    assert entry.name == "demo"
+    # "int" is normalised to "integer" by CompositeSpec.__post_init__
+    assert entry.parameters == {"x": {"type": "integer", "default": 7}}
+
+
+def test_discover_all_merges_specs_and_generators(tmp_path, installed_fake_pkg):
+    # Create a tiny static spec in a tmp dir so discover_composites picks it up
+    spec_file = tmp_path / "baseline.composite.yaml"
+    spec_file.write_text("name: baseline\nstate: {}\n")
+
+    from process_bigraph.composite_discovery import discover_all
+    _REGISTRY.clear()
+    merged = discover_all(extra_search_paths=[tmp_path])
+
+    # Spec entry tagged spec
+    spec_keys = [k for k, v in merged.items() if v.get("kind") == "spec"]
+    assert any(k.endswith(".baseline") for k in spec_keys)
+
+    # Generator entry tagged generator
+    gen_id = "fake_generator_pkg.composites.demo"
+    assert gen_id in merged
+    assert merged[gen_id]["kind"] == "generator"
+    assert merged[gen_id]["name"] == "demo"
+    # default_n_steps is always propagated (None when the generator omits it).
+    assert "default_n_steps" in merged[gen_id]
+    # visualizations is always propagated as a list (empty when the generator
+    # omits it) so dashboard callers can rely on the key existing.
+    assert merged[gen_id].get("visualizations") == []
+    # emitters likewise — the default observation sink(s) travel with the entry.
+    assert merged[gen_id].get("emitters") == []
+
+
+# ---------------------------------------------------------------------------
+# Slice H / friction #22: subpackage @composite_generator decorators are
+# discovered even when the top-level __init__.py doesn't eagerly import
+# the subpackage.
+# ---------------------------------------------------------------------------
+
+
+def test_discover_generators_walks_subpackages_without_eager_import(tmp_path):
+    """A workspace package that ships its generators in
+    `<pkg>/composites/__init__.py` should have those decorators fire on
+    discovery — even when `<pkg>/__init__.py` doesn't do
+    `from . import composites`. Before the walk_packages fix, the
+    subpackage was invisible to discover_generators() and the dashboard
+    Run handler would silently reject the composite as "not in registry."
+    """
+    import sys
+    import importlib
+    from process_bigraph.composite_generator import (
+        _REGISTRY, discover_generators,
+    )
+
+    # Build a minimal package on disk:
+    #   tmp/_walkpkg_demo/__init__.py          (NO eager subpackage import)
+    #   tmp/_walkpkg_demo/composites/__init__.py  (@composite_generator decorator)
+    pkg_dir = tmp_path / "_walkpkg_demo"
+    sub_dir = pkg_dir / "composites"
+    sub_dir.mkdir(parents=True)
+    (pkg_dir / "__init__.py").write_text(
+        '"""Top-level package with NO eager subpackage import — the walk\n'
+        'should pick up the subpackage decorators anyway."""\n'
+    )
+    (sub_dir / "__init__.py").write_text(
+        "from process_bigraph.composite_generator import composite_generator\n"
+        "\n"
+        "@composite_generator(name='walkpkg_demo_baseline')\n"
+        "def walkpkg_demo_baseline():\n"
+        "    return {'state': {'x': 1.0}}\n"
+    )
+
+    sys.path.insert(0, str(tmp_path))
+    _REGISTRY.clear()
+    try:
+        # Without the walk_packages fix, this returns {} because importing
+        # `_walkpkg_demo` alone doesn't fire decorators in `_walkpkg_demo.composites`.
+        found = discover_generators(extra_packages=["_walkpkg_demo"])
+        # The expected entry id is "<pkg>.composites.<name>"; the @composite_generator
+        # decorator builds it from func.__module__ + entry.name.
+        matching = [eid for eid in found if eid.endswith(".walkpkg_demo_baseline")]
+        assert matching, (
+            f"discover_generators didn't find the subpackage decorator. "
+            f"Got: {sorted(found.keys())}"
+        )
+    finally:
+        sys.path.remove(str(tmp_path))
+        for k in list(sys.modules):
+            if k == "_walkpkg_demo" or k.startswith("_walkpkg_demo."):
+                del sys.modules[k]
+        _REGISTRY.clear()
+        importlib.invalidate_caches()
+
+
+def test_discover_generators_traps_sys_exit_from_imported_subpackage(tmp_path):
+    """v2ecoli friction #4: a subpackage that calls sys.exit() at module
+    level (typical for CLI scripts without `if __name__ == "__main__":`)
+    used to take the whole subprocess down. Now it warns + continues."""
+    import sys
+    import importlib
+    from process_bigraph.composite_generator import (
+        _REGISTRY, discover_generators,
+    )
+
+    # Build a pkg whose subpackage exits at import time.
+    pkg_dir = tmp_path / "_exiter_demo"
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text(
+        '"""Top-level package; subpackage below sys.exits at import."""\n'
+    )
+    (pkg_dir / "ill_behaved.py").write_text(
+        "import sys\n"
+        "sys.exit(0)\n"   # this used to kill the discovery subprocess
+    )
+
+    sys.path.insert(0, str(tmp_path))
+    _REGISTRY.clear()
+    try:
+        # Must NOT raise SystemExit — the trap converts it to a warning.
+        found = discover_generators(extra_packages=["_exiter_demo"])
+        # The badly-behaved subpackage is skipped; nothing registers.
+        assert all(not k.startswith("_exiter_demo.") for k in found.keys())
+    finally:
+        sys.path.remove(str(tmp_path))
+        for k in list(sys.modules):
+            if k == "_exiter_demo" or k.startswith("_exiter_demo."):
+                del sys.modules[k]
+        _REGISTRY.clear()
+        importlib.invalidate_caches()
+
+
+def test_composite_generator_registers_into_process_bigraph_registry():
+    from process_bigraph import composite_spec as cs
+    from process_bigraph.composite_generator import composite_generator, build_generator
+    cs.clear_registry()
+
+    @composite_generator(name="shimdemo", parameters={"seed": {"type": "int", "default": 1}})
+    def shimdemo(core=None, *, seed=1):
+        return {"state": {"s": seed}}
+
+    spec_id = f"{shimdemo.__module__}.shimdemo"
+    spec = cs.get(spec_id)
+    assert spec is not None and spec.parameters["seed"]["type"] == "integer"
+    # build_generator delegates to the spec's document
+    assert build_generator(spec, overrides={"seed": 3}) == {"state": {"s": 3}}
+
+
+def test_build_generator_descriptive_error_for_unregistered_id():
+    from process_bigraph import composite_spec as cs
+    from process_bigraph.composite_generator import build_generator, GeneratorEntry
+    cs.clear_registry()
+    ge = GeneratorEntry(id="missing.x", name="x", description="", parameters={},
+                        func=None, module="missing")
+    import pytest
+    with pytest.raises(ValueError, match="no registered composite"):
+        build_generator(ge)
+
+
+def test_registry_view_supports_clean_alias_assignment():
+    import dataclasses
+    from process_bigraph import composite_spec as cs
+    from process_bigraph.composite_generator import composite_generator, _REGISTRY
+    cs.clear_registry()
+
+    @composite_generator(name="aliasme", parameters={"seed": {"type": "int", "default": 0}})
+    def aliasme(core=None, *, seed=0):
+        return {"state": {"s": seed}}
+
+    full_id = f"{aliasme.__module__}.aliasme"
+    orig = _REGISTRY[full_id]                       # GeneratorEntry from the view
+    _REGISTRY["aliasme"] = dataclasses.replace(orig, id="aliasme")  # the v2ecoli pattern
+    assert "aliasme" in _REGISTRY
+    assert _REGISTRY["aliasme"].id == "aliasme"
+    assert cs.get("aliasme") is not None and cs.get("aliasme").kind == "generator"
+    assert len(_REGISTRY) >= 2                      # exercises __len__
+
+
+def test_registry_view_dict_conversion_works():
+    """M2: _RegistryView.keys() enables dict(_REGISTRY) to work."""
+    from process_bigraph import composite_spec as cs
+    from process_bigraph.composite_generator import composite_generator, _REGISTRY
+    cs.clear_registry()
+    @composite_generator(name="dictme", parameters={})
+    def dictme(core=None):
+        return {"state": {}}
+    d = dict(_REGISTRY)            # requires keys()
+    assert f"{dictme.__module__}.dictme" in d
+
+
+def test_discover_generators_skips_scripts_subpackage(tmp_path):
+    """v2ecoli friction #4: a `scripts/` subpackage holds CLI tools, not
+    library code; discovery should skip it entirely to avoid importing
+    argparse-driven modules that crash under bare import."""
+    import sys
+    import importlib
+    from process_bigraph.composite_generator import (
+        _REGISTRY, discover_generators, composite_generator,
+    )
+
+    pkg_dir = tmp_path / "_libscripts_demo"
+    scripts_dir = pkg_dir / "scripts"
+    scripts_dir.mkdir(parents=True)
+    (pkg_dir / "__init__.py").write_text("")
+    # A generator in the LIBRARY half — must be discovered.
+    (pkg_dir / "lib_module.py").write_text(
+        "from process_bigraph.composite_generator import composite_generator\n"
+        "\n"
+        "@composite_generator(name='libscripts_demo_baseline')\n"
+        "def libscripts_demo_baseline():\n"
+        "    return {'state': {}}\n"
+    )
+    # A would-be generator in scripts/ — must be SKIPPED even though it's
+    # otherwise valid.
+    (scripts_dir / "__init__.py").write_text("")
+    (scripts_dir / "would_register.py").write_text(
+        "from process_bigraph.composite_generator import composite_generator\n"
+        "\n"
+        "@composite_generator(name='libscripts_demo_should_be_skipped')\n"
+        "def libscripts_demo_should_be_skipped():\n"
+        "    return {'state': {}}\n"
+    )
+
+    sys.path.insert(0, str(tmp_path))
+    _REGISTRY.clear()
+    try:
+        found = discover_generators(extra_packages=["_libscripts_demo"])
+        libs = [k for k in found if "libscripts_demo" in k]
+        # Library generator landed.
+        assert any("baseline" in k for k in libs)
+        # scripts/ generator did not.
+        assert not any("should_be_skipped" in k for k in libs)
+    finally:
+        sys.path.remove(str(tmp_path))
+        for k in list(sys.modules):
+            if k == "_libscripts_demo" or k.startswith("_libscripts_demo."):
+                del sys.modules[k]
+        _REGISTRY.clear()
+        importlib.invalidate_caches()

--- a/process_bigraph/tests/test_composite_generator.py
+++ b/process_bigraph/tests/test_composite_generator.py
@@ -1,4 +1,4 @@
-"""Tests for process_bigraph.composite_generator (moved from viva_superpowers)."""
+"""Tests for process_bigraph.composite_generator (moved from viva-superpowers)."""
 import shutil
 import subprocess
 import sys
@@ -648,3 +648,86 @@ def test_discover_generators_skips_scripts_subpackage(tmp_path):
                 del sys.modules[k]
         _REGISTRY.clear()
         importlib.invalidate_caches()
+
+
+def test_discover_generators_skips_tests_subpackage_before_import(tmp_path):
+    """process-bigraph itself declares `bigraph-schema` as a dependency, so
+    its own distribution is always a walk target — and (unlike
+    viva-superpowers, whose tests/ sits *outside* the package) this repo
+    keeps tests *inside* the package at process_bigraph/tests/. A naive
+    walk would import the whole test suite (and anything nested under
+    tests/fixtures/) as an uncontrolled side effect of composite discovery.
+
+    This mirrors test_discover_generators_skips_scripts_subpackage, but for
+    a `tests/` subpackage, and additionally proves the skip happens BEFORE
+    any import is attempted (not just a post-hoc skip of an already-walked
+    entry) by nesting a decorator-bearing module two levels under tests/ —
+    exactly the shape of tests/fixtures/fake_generator_pkg/fake_generator_pkg/.
+    """
+    import sys
+    import importlib
+    from process_bigraph.composite_generator import (
+        _REGISTRY, discover_generators, composite_generator,
+    )
+
+    pkg_dir = tmp_path / "_libtests_demo"
+    tests_dir = pkg_dir / "tests"
+    nested_dir = tests_dir / "fixtures" / "would_be_pkg"
+    nested_dir.mkdir(parents=True)
+    (pkg_dir / "__init__.py").write_text("")
+    # A generator in the LIBRARY half — must be discovered.
+    (pkg_dir / "lib_module.py").write_text(
+        "from process_bigraph.composite_generator import composite_generator\n"
+        "\n"
+        "@composite_generator(name='libtests_demo_baseline')\n"
+        "def libtests_demo_baseline():\n"
+        "    return {'state': {}}\n"
+    )
+    # A would-be generator nested under tests/ — must be SKIPPED, and the
+    # skip must happen before any of these modules are ever imported.
+    (tests_dir / "__init__.py").write_text(
+        "raise RuntimeError('tests/__init__.py must never be imported by discovery')\n"
+    )
+    (nested_dir / "__init__.py").write_text(
+        "from process_bigraph.composite_generator import composite_generator\n"
+        "\n"
+        "@composite_generator(name='libtests_demo_should_be_skipped')\n"
+        "def libtests_demo_should_be_skipped():\n"
+        "    return {'state': {}}\n"
+    )
+
+    sys.path.insert(0, str(tmp_path))
+    _REGISTRY.clear()
+    try:
+        # Must not raise — proves tests/__init__.py (which raises on import)
+        # was never imported, i.e. the skip happens before descent, not
+        # merely after pkgutil has already recursed into it.
+        found = discover_generators(extra_packages=["_libtests_demo"])
+        libs = [k for k in found if "libtests_demo" in k]
+        assert any("baseline" in k for k in libs)
+        assert not any("should_be_skipped" in k for k in libs)
+        assert "_libtests_demo.tests" not in sys.modules
+        assert "_libtests_demo.tests.fixtures.would_be_pkg" not in sys.modules
+    finally:
+        sys.path.remove(str(tmp_path))
+        for k in list(sys.modules):
+            if k == "_libtests_demo" or k.startswith("_libtests_demo."):
+                del sys.modules[k]
+        _REGISTRY.clear()
+        importlib.invalidate_caches()
+
+
+def test_discover_generators_does_not_walk_process_bigraph_own_tests():
+    """Regression for a full-suite-only flaky failure: discover_generators()
+    walks every installed bigraph-schema-dependent distribution, and
+    process-bigraph's own distribution always qualifies (it declares
+    bigraph-schema as a dependency). In an editable/dev install, that
+    self-walk would otherwise recurse into process_bigraph/tests/ — this
+    asserts none of process-bigraph's own test modules end up registered
+    as discovered generators."""
+    from process_bigraph.composite_generator import discover_generators
+    found = discover_generators()
+    assert not any("process_bigraph.tests" in sid for sid in found), (
+        f"discover_generators walked into process_bigraph's own test suite: "
+        f"{[sid for sid in found if 'process_bigraph.tests' in sid]}"
+    )

--- a/process_bigraph/tests/test_config_helpers.py
+++ b/process_bigraph/tests/test_config_helpers.py
@@ -1,0 +1,73 @@
+"""Tests for process_bigraph.config_helpers.normalize_config_list (moved from
+viva_superpowers; v2ecoli #3)."""
+import pytest
+
+from process_bigraph.config_helpers import normalize_config_list
+
+
+def test_list_passthrough():
+    assert normalize_config_list([0.2, 0.5]) == [0.2, 0.5]
+
+
+def test_tuple_becomes_list():
+    assert normalize_config_list((0.2, 0.5)) == [0.2, 0.5]
+
+
+def test_int_keyed_dict_ordered_by_index():
+    """bigraph-schema rewrap: {0: low, 1: high}."""
+    assert normalize_config_list({0: 0.2, 1: 0.5}) == [0.2, 0.5]
+    # Out-of-order keys still sort by index.
+    assert normalize_config_list({1: 0.5, 0: 0.2}) == [0.2, 0.5]
+
+
+def test_string_keyed_dict_ordered_by_index():
+    """JSON round-trip stringifies the int keys: {"0": low, "1": high}."""
+    assert normalize_config_list({"0": 0.2, "1": 0.5}) == [0.2, 0.5]
+    assert normalize_config_list({"1": 0.5, "0": 0.2}) == [0.2, 0.5]
+
+
+def test_explicit_key_form_default_low_high():
+    assert normalize_config_list({"low": 0.2, "high": 0.5}) == [0.2, 0.5]
+    # Order follows key_names, not dict insertion order.
+    assert normalize_config_list({"high": 0.5, "low": 0.2}) == [0.2, 0.5]
+
+
+def test_explicit_key_form_custom_names():
+    assert normalize_config_list(
+        {"min": 1, "max": 9}, key_names=("min", "max")
+    ) == [1, 9]
+    assert normalize_config_list(
+        {"x": 1, "y": 2, "z": 3}, key_names=("x", "y", "z")
+    ) == [1, 2, 3]
+
+
+def test_scalar_wrapped_as_single_element():
+    assert normalize_config_list(0.3) == [0.3]
+
+
+def test_none_is_empty_list():
+    assert normalize_config_list(None) == []
+
+
+def test_length_assertion_passes():
+    assert normalize_config_list([0.2, 0.5], length=2) == [0.2, 0.5]
+
+
+def test_length_assertion_fails():
+    with pytest.raises(ValueError, match="expected 2 element"):
+        normalize_config_list([0.2, 0.5, 0.9], length=2)
+
+
+def test_unrecognized_dict_keys_raise():
+    with pytest.raises(ValueError, match="neither one of"):
+        normalize_config_list({"lo": 0.2, "hi": 0.5})
+
+
+def test_bool_keys_are_not_treated_as_index():
+    """`True`/`False` are int subclasses; they must not be read as 1/0."""
+    with pytest.raises(ValueError):
+        normalize_config_list({True: 0.5, False: 0.2})
+
+
+def test_three_element_numeric_dict():
+    assert normalize_config_list({0: "a", 1: "b", 2: "c"}) == ["a", "b", "c"]

--- a/process_bigraph/tests/test_config_helpers.py
+++ b/process_bigraph/tests/test_config_helpers.py
@@ -1,5 +1,5 @@
 """Tests for process_bigraph.config_helpers.normalize_config_list (moved from
-viva_superpowers; v2ecoli #3)."""
+viva-superpowers; v2ecoli #3)."""
 import pytest
 
 from process_bigraph.config_helpers import normalize_config_list

--- a/process_bigraph/tests/test_core_introspection.py
+++ b/process_bigraph/tests/test_core_introspection.py
@@ -1,4 +1,4 @@
-"""Tests for process_bigraph.core_introspection (moved from viva_superpowers)."""
+"""Tests for process_bigraph.core_introspection (moved from viva-superpowers)."""
 import pytest
 
 from process_bigraph.core_introspection import (

--- a/process_bigraph/tests/test_core_introspection.py
+++ b/process_bigraph/tests/test_core_introspection.py
@@ -1,0 +1,66 @@
+"""Tests for process_bigraph.core_introspection (moved from viva_superpowers)."""
+import pytest
+
+from process_bigraph.core_introspection import (
+    list_processes, list_types, registry_snapshot,
+)
+
+
+class FakeCore:
+    """Exercises the callable-method probe path of `_try`."""
+
+    def __init__(self):
+        self._links = {"ProcA": object(), "StepB": object()}
+        self._types = {"my_type": {"_inherit": "float", "_default": 0.0}}
+
+    def list_processes(self):
+        return list(self._links.keys())
+
+    def list_types(self):
+        return list(self._types.keys())
+
+    def access(self, name):
+        return self._types.get(name, {})
+
+
+class DictOnlyCore:
+    """Exercises the dict-attribute fallback path of `_try` (no callable methods)."""
+
+    _links = {"P": object()}
+    _types = {"T": {}}
+
+
+class EmptyCore:
+    """No registry attributes — must raise RuntimeError."""
+
+
+def test_list_processes_returns_registered():
+    assert sorted(list_processes(FakeCore())) == ["ProcA", "StepB"]
+
+
+def test_list_types_returns_registered():
+    assert "my_type" in list_types(FakeCore())
+
+
+def test_registry_snapshot_is_stable_dict():
+    snap = registry_snapshot(FakeCore())
+    assert "processes" in snap and "types" in snap
+    assert sorted(snap["processes"]) == ["ProcA", "StepB"]
+    assert sorted(snap["types"]) == ["my_type"]
+
+
+def test_dict_only_core_processes():
+    """Fallback path: only `_links` dict attribute, no callable methods."""
+    assert list_processes(DictOnlyCore()) == ["P"]
+
+
+def test_dict_only_core_types():
+    assert list_types(DictOnlyCore()) == ["T"]
+
+
+def test_empty_core_raises_runtime_error():
+    """Loud failure when no registry attributes exist — message names probed attrs."""
+    with pytest.raises(RuntimeError, match="list_processes"):
+        list_processes(EmptyCore())
+    with pytest.raises(RuntimeError, match="list_types"):
+        list_types(EmptyCore())

--- a/process_bigraph/tests/test_render_results.py
+++ b/process_bigraph/tests/test_render_results.py
@@ -1,4 +1,4 @@
-"""Tests for process_bigraph.visualization.render_results (moved from viva_superpowers).
+"""Tests for process_bigraph.visualization.render_results (moved from viva-superpowers).
 
 Mirrors the shape of ``process_bigraph.emitter.gather_emitter_results``:
 returns a path-keyed dict whose values are the per-viz ``{'html': str}`` dicts.

--- a/process_bigraph/tests/test_render_results.py
+++ b/process_bigraph/tests/test_render_results.py
@@ -1,0 +1,181 @@
+"""Tests for process_bigraph.visualization.render_results (moved from viva_superpowers).
+
+Mirrors the shape of ``process_bigraph.emitter.gather_emitter_results``:
+returns a path-keyed dict whose values are the per-viz ``{'html': str}`` dicts.
+
+Covers both code paths:
+
+- legacy vizes (subclass overrides ``update``) — end-of-run mode reads the
+  last value the runtime wrote to the html port; replay mode calls
+  ``instance.update(results)``.
+- new-style vizes (subclass implements ``accumulate`` + ``render``) —
+  end-of-run mode calls ``instance.render()``; replay mode accumulates then
+  renders.
+"""
+from __future__ import annotations
+
+from process_bigraph import Composite, allocate_core
+
+from process_bigraph.visualization import (
+    Visualization,
+    as_visualization,
+    render_results,
+)
+
+
+# --- legacy viz fixtures (as_visualization → overrides update) -------------
+@as_visualization(inputs={'k': 'string'}, name='_RR_EchoViz')
+def update__rr_echo_viz(state):
+    return {'html': '<x>' + state.get('k', '') + '</x>'}
+
+
+@as_visualization(inputs={'k': 'string'}, name='_RR_LabelViz')
+def update__rr_label_viz(state):
+    return {'html': '<label>' + state.get('k', '') + '</label>'}
+
+
+# --- new-style viz fixture (accumulate + render) ---------------------------
+class _RR_CountViz(Visualization):
+    """Counts ticks via accumulate(); renders the final count once."""
+
+    def inputs(self):
+        return {'k': 'string'}
+
+    def accumulate(self, state):
+        self._n = getattr(self, '_n', 0) + 1
+        self._last = state.get('k', '')
+
+    def render(self):
+        return f'<count n="{self._n}">{self._last}</count>'
+
+
+_RR_CountViz.__pb_kind__ = 'visualization'
+_RR_CountViz.__pb_aliases__ = ['_RR_CountViz']
+
+
+def _make_core():
+    core = allocate_core()
+    core.register_link('_RR_EchoViz', update__rr_echo_viz)
+    core.register_link('_RR_LabelViz', update__rr_label_viz)
+    core.register_link('_RR_CountViz', _RR_CountViz)
+    return core
+
+
+def _state_with_echo():
+    return {
+        'k_store': 'streamed',
+        'viz1': {
+            '_type': 'step',
+            'address': 'local:_RR_EchoViz',
+            'config': {},
+            'inputs': {'k': ['k_store']},
+            'outputs': {'html': ['viz_html_store']},
+        },
+        'viz_html_store': '',
+    }
+
+
+def _state_with_counter():
+    return {
+        'k_store': 'tick',
+        'viz_count': {
+            '_type': 'step',
+            'address': 'local:_RR_CountViz',
+            'config': {},  # default render_mode='end'
+            'inputs': {'k': ['k_store']},
+            'outputs': {'html': ['count_html']},
+        },
+        'count_html': '',
+    }
+
+
+# ---------------------------------------------------------------------------
+# replay mode
+
+
+def test_render_results_replay_mode_legacy():
+    """Replay mode on a legacy viz calls ``update(results)`` directly."""
+    composite = Composite({'state': _state_with_echo()}, core=_make_core())
+    out = render_results(composite, results={'k': 'replay'})
+    assert ('viz1',) in out
+    assert 'replay' in out[('viz1',)]['html']
+    # Replay does not depend on the wired store being populated.
+    assert composite.state['viz_html_store'] == ''
+
+
+def test_render_results_replay_mode_new_style():
+    """Replay mode on a new-style viz accumulates the provided state then
+    renders. The wired store stays untouched."""
+    composite = Composite({'state': _state_with_counter()}, core=_make_core())
+    out = render_results(composite, results={'k': 'replayed'})
+    assert ('viz_count',) in out
+    html = out[('viz_count',)]['html']
+    assert 'replayed' in html and 'n="1"' in html
+
+
+# ---------------------------------------------------------------------------
+# end-of-run mode
+
+
+def test_render_results_finds_nothing_when_no_viz():
+    """A composite with no Visualization instances returns an empty dict."""
+    core = _make_core()
+    state = {'k_store': 'hello'}
+    composite = Composite({'state': state}, core=core)
+    out = render_results(composite)
+    assert out == {}
+
+
+def test_render_results_end_mode_legacy_reads_html_port():
+    """For legacy vizes, end-mode returns whatever the runtime wrote to the
+    wired html store."""
+    core = _make_core()
+    state = {
+        'k_store': 'streamed',
+        'viz_a': {
+            '_type': 'step',
+            'address': 'local:_RR_EchoViz',
+            'config': {},
+            'inputs': {'k': ['k_store']},
+            'outputs': {'html': ['viz_a_html']},
+        },
+        'viz_a_html': '',
+        'viz_b': {
+            '_type': 'step',
+            'address': 'local:_RR_LabelViz',
+            'config': {},
+            'inputs': {'k': ['k_store']},
+            'outputs': {'html': ['viz_b_html']},
+        },
+        'viz_b_html': '',
+    }
+    composite = Composite({'state': state}, core=core)
+    composite.run(1)
+    out = render_results(composite)
+    assert set(out.keys()) == {('viz_a',), ('viz_b',)}
+    assert '<x>streamed</x>' == out[('viz_a',)]['html']
+    assert '<label>streamed</label>' == out[('viz_b',)]['html']
+
+
+def test_render_results_end_mode_new_style_calls_render():
+    """For new-style vizes, end-mode invokes ``instance.render()`` once.
+
+    Critically: during the run the html port stays empty (because the
+    baseclass returns ``{'html': ''}`` in 'end' mode), so render_results is
+    the only way to materialize the final HTML — and it does so without
+    re-running the simulation.
+
+    We don't pin the exact number of accumulate() calls: bigraph schedules
+    Steps independently of simulation time, so ``composite.run(N)`` doesn't
+    map 1:1 to N update ticks. The contract under test is that render()
+    fires once at the end with state from the accumulator buffer.
+    """
+    composite = Composite({'state': _state_with_counter()}, core=_make_core())
+    composite.run(5)
+    # Per-tick output to the wired html store stayed empty.
+    assert composite.state['count_html'] == ''
+    out = render_results(composite)
+    assert ('viz_count',) in out
+    html = out[('viz_count',)]['html']
+    # render() was called once and produced HTML from the accumulated state.
+    assert html.startswith('<count n="') and 'tick' in html

--- a/process_bigraph/tests/test_visualization.py
+++ b/process_bigraph/tests/test_visualization.py
@@ -1,4 +1,4 @@
-"""Tests for process_bigraph.visualization.Visualization (moved from viva_superpowers).
+"""Tests for process_bigraph.visualization.Visualization (moved from viva-superpowers).
 
 The baseclass now orchestrates accumulate/render with ``render_mode='end'``
 as the default. Subclasses MAY override ``update(state)`` directly to keep

--- a/process_bigraph/tests/test_visualization.py
+++ b/process_bigraph/tests/test_visualization.py
@@ -1,0 +1,323 @@
+"""Tests for process_bigraph.visualization.Visualization (moved from viva_superpowers).
+
+The baseclass now orchestrates accumulate/render with ``render_mode='end'``
+as the default. Subclasses MAY override ``update(state)`` directly to keep
+the legacy streaming contract; both paths are exercised here.
+"""
+import pytest
+
+from process_bigraph import Step
+from process_bigraph.visualization import Visualization, as_visualization
+
+
+# --- legacy subclass: overrides update() directly --------------------------
+
+class _Echo(Visualization):
+    """Legacy-style subclass that echoes the input as html each tick."""
+
+    def inputs(self):
+        return {'msg': 'string'}
+
+    def update(self, state):
+        return {'html': '<p>' + state.get('msg', '') + '</p>'}
+
+
+# --- new-style subclass: implements accumulate + render --------------------
+
+class _Counter(Visualization):
+    """New-style subclass that accumulates a count then renders at end."""
+
+    def inputs(self):
+        return {'msg': 'string'}
+
+    def accumulate(self, state):
+        self._n = getattr(self, '_n', 0) + 1
+        self._last_msg = state.get('msg', '')
+
+    def render(self):
+        return f'<p>n={self._n}, last={self._last_msg}</p>'
+
+
+def _make(cls):
+    """Helper: instantiate without running through bigraph wiring."""
+    return object.__new__(cls)
+
+
+# ---------------------------------------------------------------------------
+# baseclass shape
+
+
+def test_visualization_is_step_subclass():
+    assert issubclass(Visualization, Step)
+
+
+def test_visualization_outputs_default_html():
+    inst = _make(Visualization)
+    assert inst.outputs() == {'html': 'string'}
+
+
+def test_visualization_inputs_default_empty():
+    inst = _make(Visualization)
+    assert inst.inputs() == {}
+
+
+def test_visualization_marker_classmethod():
+    assert _Echo.is_visualization() is True
+    assert _Counter.is_visualization() is True
+
+
+def test_render_mode_in_config_schema():
+    """Default render_mode must be 'end' so test-suite-style runs don't
+    pay the per-tick render cost."""
+    assert Visualization.config_schema['render_mode']['_default'] == 'end'
+    assert Visualization.config_schema['sample_every']['_default'] == 1
+
+
+# ---------------------------------------------------------------------------
+# legacy contract: subclass.update() overrides orchestrator
+
+
+def test_legacy_subclass_update_returns_html_dict():
+    inst = _make(_Echo)
+    out = inst.update({'msg': 'hello'})
+    assert out == {'html': '<p>hello</p>'}
+
+
+# ---------------------------------------------------------------------------
+# new-style contract: baseclass.update() orchestrates accumulate + render
+
+
+def test_new_style_end_mode_accumulates_silently():
+    """In default ('end') mode, update() accumulates but emits empty html."""
+    inst = _make(_Counter)
+    inst.config = {}
+    assert inst.update({'msg': 'a'}) == {'html': ''}
+    assert inst.update({'msg': 'b'}) == {'html': ''}
+    assert inst.update({'msg': 'c'}) == {'html': ''}
+    # Accumulation happened across all three ticks.
+    assert inst.render() == '<p>n=3, last=c</p>'
+
+
+def test_new_style_stream_mode_renders_each_tick():
+    """``render_mode='stream'`` keeps the legacy per-tick HTML behavior."""
+    inst = _make(_Counter)
+    inst.config = {'render_mode': 'stream'}
+    assert inst.update({'msg': 'a'}) == {'html': '<p>n=1, last=a</p>'}
+    assert inst.update({'msg': 'b'}) == {'html': '<p>n=2, last=b</p>'}
+
+
+def test_new_style_sample_every_skips_intermediate_ticks():
+    """``sample_every=N`` accumulates only every Nth tick."""
+    inst = _make(_Counter)
+    inst.config = {'sample_every': 3}
+    for msg in ['t0', 't1', 't2', 't3', 't4', 't5', 't6']:
+        inst.update({'msg': msg})
+    # Ticks 0, 3, 6 were accumulated → n == 3, last == 't6'.
+    assert inst.render() == '<p>n=3, last=t6</p>'
+
+
+def test_new_style_default_accumulate_snapshots_last_state():
+    """The baseclass default ``accumulate`` stashes the latest state on
+    ``_last_state`` so stateless renderers don't need their own buffer."""
+
+    class _SnapOnly(Visualization):
+        def render(self):
+            return f'<p>{self._last_state.get("msg")}</p>'
+
+    inst = _make(_SnapOnly)
+    inst.config = {}
+    inst.update({'msg': 'a'})
+    inst.update({'msg': 'b'})
+    assert inst.render() == '<p>b</p>'
+
+
+def test_new_style_missing_render_raises():
+    """New-style subclass that forgets ``render()`` blows up only when the
+    orchestrator actually tries to render — i.e. in stream mode or via
+    render_results."""
+
+    class _NoRender(Visualization):
+        def accumulate(self, state):
+            pass
+
+    inst = _make(_NoRender)
+    inst.config = {}  # 'end' mode — accumulate-only, never calls render()
+    assert inst.update({}) == {'html': ''}
+
+    # Stream mode triggers render() and surfaces the NotImplementedError.
+    inst.config = {'render_mode': 'stream'}
+    with pytest.raises(NotImplementedError, match='render'):
+        inst.update({})
+
+
+# ---------------------------------------------------------------------------
+# as_visualization decorator — legacy-style by definition
+
+
+def test_as_visualization_synthesizes_subclass():
+    @as_visualization(inputs={'x': 'list[float]'}, name='MyViz', demo={'x': [1.0, 2.0]})
+    def update_my_viz(state):
+        return {'html': '<p>x=' + str(state['x']) + '</p>'}
+
+    assert issubclass(update_my_viz, Visualization)
+    assert update_my_viz.__name__ == 'MyViz'
+    assert update_my_viz.__pb_kind__ == 'visualization'
+    assert 'MyViz' in update_my_viz.__pb_aliases__
+    inst = _make(update_my_viz)
+    assert inst.inputs() == {'x': 'list[float]'}
+    assert inst.outputs() == {'html': 'string'}
+    assert inst.update({'x': [1.0, 2.0]}) == {'html': '<p>x=[1.0, 2.0]</p>'}
+
+
+def test_as_visualization_demo_dict():
+    @as_visualization(inputs={'x': 'list[float]'},
+                      demo={'x': [3.0, 4.0]})
+    def update_demo_dict(state):
+        return {'html': str(state['x'])}
+
+    assert update_demo_dict.demo() == {'x': [3.0, 4.0]}
+
+
+def test_as_visualization_demo_callable():
+    @as_visualization(inputs={'x': 'list[float]'},
+                      demo=lambda: {'x': [5.0, 6.0]})
+    def update_demo_callable(state):
+        return {'html': str(state['x'])}
+
+    assert update_demo_callable.demo() == {'x': [5.0, 6.0]}
+
+
+def test_as_visualization_function_name_validation():
+    with pytest.raises(AssertionError, match='update_'):
+        @as_visualization(inputs={})
+        def bad_name(state):
+            return {'html': ''}
+
+
+def test_as_visualization_default_name_from_function():
+    @as_visualization(inputs={'x': 'list[float]'})
+    def update_inferred_name(state):
+        return {'html': ''}
+
+    assert update_inferred_name.__name__ == 'inferred_name'
+    assert 'inferred_name' in update_inferred_name.__pb_aliases__
+
+
+def test_as_visualization_aliases():
+    @as_visualization(inputs={}, name='Primary', aliases=['alt1', 'alt2'])
+    def update_aliased(state):
+        return {'html': ''}
+
+    assert 'Primary' in update_aliased.__pb_aliases__
+    assert 'alt1' in update_aliased.__pb_aliases__
+    assert 'alt2' in update_aliased.__pb_aliases__
+
+
+# ----------------------------------------------------------------------------
+# F4 — as_visualization is deprecated in favor of subclassing
+# ----------------------------------------------------------------------------
+
+
+def test_as_visualization_emits_deprecation_warning():
+    """The decorator continues to work but warns at decoration time so
+    authors are nudged toward the canonical subclass form."""
+    import warnings
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+
+        @as_visualization(inputs={'x': 'list[float]'}, name='_F4_TestViz')
+        def update__f4_test_viz(state):
+            return {'html': '<x>' + str(state['x']) + '</x>'}
+
+    dep = [w for w in captured if issubclass(w.category, DeprecationWarning)]
+    assert dep, "expected a DeprecationWarning from as_visualization"
+    msg = str(dep[0].message)
+    assert "deprecated" in msg.lower()
+    assert "subclass Visualization" in msg
+    # The decorated class is still a real Visualization subclass with the
+    # pb-discovery markers; instantiation requires a core (not the point
+    # of this test — covered by the older test_as_visualization_synthesizes_subclass).
+    assert update__f4_test_viz.__name__ == '_F4_TestViz'
+    assert update__f4_test_viz.__pb_kind__ == 'visualization'
+    assert '_F4_TestViz' in update__f4_test_viz.__pb_aliases__
+    assert issubclass(update__f4_test_viz, Visualization)
+
+
+def test_visualization_subclass_does_not_warn():
+    """The canonical subclass path produces no DeprecationWarning. Anchors
+    the recommended pattern as the silent one — workspaces that adopt it
+    don't see migration nudges."""
+    import warnings
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+
+        class _F4_CanonicalViz(Visualization):
+            def inputs(self):
+                return {'x': 'list[float]'}
+
+            def update(self, state):
+                return {'html': '<x>' + str(state.get('x', [])) + '</x>'}
+
+    dep = [w for w in captured if issubclass(w.category, DeprecationWarning)]
+    assert not dep, f"subclass form must be silent; got {[str(w.message) for w in dep]}"
+
+
+# ---------------------------------------------------------------------------
+# stable_div_id helper (mem3dg-readdy friction #28)
+#
+# The method only reads `type(self).__name__` and `self.config`; it doesn't
+# touch any process_bigraph machinery. Instantiating a real Visualization
+# requires a `core` (process_bigraph framework requirement) which is heavy
+# for a pure-string test. Call the method against a minimal duck object
+# instead — same code path, no framework dependency.
+# ---------------------------------------------------------------------------
+
+
+def _div_id(name: str, config: dict | None, *parts: str) -> str:
+    """Invoke Visualization.stable_div_id against a duck object whose
+    class name is `name` (set via dynamic class creation so the formatted
+    prefix is deterministic)."""
+    cls = type(name, (object,), {})
+    obj = cls()
+    if config is not None:
+        obj.config = config
+    return Visualization.stable_div_id(obj, *parts)
+
+
+def test_stable_div_id_is_deterministic_per_class_and_title():
+    """Two duck objects with the same class name + title produce the SAME
+    div_id — the whole point. The friction #28 case used id(self), which
+    is CPython's object address; stable_div_id is content-addressed."""
+    a = _div_id("DivIDViz", {"title": "growth"})
+    b = _div_id("DivIDViz", {"title": "growth"})
+    assert a == b
+    # Format: lowercased-classname-8hex.
+    import re
+    assert re.fullmatch(r"dividviz-[0-9a-f]{8}", a)
+
+
+def test_stable_div_id_differs_by_title():
+    """Same class, different config title → different ids. A workspace
+    shipping two instances of one Viz class with distinct titles (e.g.
+    'baseline' vs 'variant') gets two distinct DOM ids without manual
+    discriminators."""
+    a = _div_id("DivIDViz", {"title": "baseline"})
+    b = _div_id("DivIDViz", {"title": "variant"})
+    assert a != b
+
+
+def test_stable_div_id_accepts_extra_discriminator_parts():
+    """Callers can pass extra `parts` (e.g. a per-run id) to disambiguate
+    further. Distinct parts → distinct ids; repeated parts → same id."""
+    p1 = _div_id("DivIDViz", {"title": "x"}, "run-1")
+    p2 = _div_id("DivIDViz", {"title": "x"}, "run-2")
+    p1_again = _div_id("DivIDViz", {"title": "x"}, "run-1")
+    assert p1 != p2
+    assert p1 == p1_again
+
+
+def test_stable_div_id_handles_missing_config():
+    """A subclass that doesn't set self.config (e.g. mid-init) shouldn't
+    crash — the helper falls back to empty title."""
+    result = _div_id("NoConfigViz", config=None)
+    assert result.startswith("noconfigviz-")

--- a/process_bigraph/tests/test_visualization_units.py
+++ b/process_bigraph/tests/test_visualization_units.py
@@ -1,0 +1,46 @@
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from process_bigraph.visualization import Visualization
+
+
+def teardown_function():
+    Visualization.units_resolver = None     # never leak state across tests
+
+
+def test_finalize_figure_appends_unit():
+    Visualization.units_resolver = lambda path: "fg" if path == "mass" else None
+    fig, ax = plt.subplots()
+    ax.set_ylabel("Mass")
+    ax.set_xlabel("Time (min)")
+    Visualization.finalize_figure(fig, [(ax, "y", "mass"), (ax, "x", "time")])
+    assert ax.get_ylabel() == "Mass (fg)"
+    assert ax.get_xlabel() == "Time (min)"      # no resolver hit -> unchanged
+    plt.close(fig)
+
+
+def test_finalize_figure_idempotent():
+    Visualization.units_resolver = lambda path: "fg"
+    fig, ax = plt.subplots()
+    ax.set_ylabel("Mass (fg)")
+    Visualization.finalize_figure(fig, [(ax, "y", "mass")])
+    assert ax.get_ylabel() == "Mass (fg)"
+    plt.close(fig)
+
+
+def test_no_resolver_is_noop():
+    Visualization.units_resolver = None
+    fig, ax = plt.subplots()
+    ax.set_ylabel("Mass")
+    Visualization.finalize_figure(fig, [(ax, "y", "mass")])
+    assert ax.get_ylabel() == "Mass"
+    plt.close(fig)
+
+
+def test_figure_to_html_returns_img_tag():
+    Visualization.units_resolver = lambda path: "fg"
+    fig, ax = plt.subplots()
+    ax.plot([0, 1], [0, 1]); ax.set_ylabel("Mass")
+    html = Visualization.figure_to_html(fig, [(ax, "y", "mass")])
+    assert html.startswith('<img src="data:image/png;base64,')
+    assert html.rstrip().endswith("/>")

--- a/process_bigraph/tests/test_visualizations.py
+++ b/process_bigraph/tests/test_visualizations.py
@@ -1,0 +1,92 @@
+"""Tests for the 5 default Visualization classes (v2: update(state))."""
+from process_bigraph.visualizations import TimeSeriesPlot
+
+
+def _trajectory_state():
+    """One run's trajectory of ``observable`` and ``time``."""
+    return {
+        'observable': [1.0, 2.0, 4.0, 8.0],
+        'time': [0.0, 1.0, 2.0, 3.0],
+    }
+
+
+def _multi_run_state():
+    """Two runs' trajectories — orchestrator passes list-of-lists for sweeps."""
+    return {
+        'observable': [[1.0, 2.0, 4.0], [3.0, 6.0, 12.0]],
+        'time': [[0.0, 1.0, 2.0], [0.0, 1.0, 2.0]],
+        '_run_labels': ['rate=1.0', 'rate=3.0'],
+    }
+
+
+def test_time_series_plot_single_run():
+    inst = object.__new__(TimeSeriesPlot)
+    inst.config = {'title': 'Test'}
+    html = inst.update(_trajectory_state())
+    assert 'html' in html
+    assert 'Plotly.newPlot' in html['html']
+    assert 'Test' in html['html']
+
+
+def test_time_series_plot_multi_run():
+    inst = object.__new__(TimeSeriesPlot)
+    inst.config = {'title': ''}
+    html = inst.update(_multi_run_state())
+    assert 'Plotly.newPlot' in html['html']
+    assert 'rate=1.0' in html['html']
+    assert 'rate=3.0' in html['html']
+
+
+from process_bigraph.visualizations import ParamVsObservable
+
+
+def test_param_vs_observable():
+    inst = object.__new__(ParamVsObservable)
+    inst.config = {'title': 'Sweep'}
+    state = {
+        'sweep_param_values': [0.1, 0.5, 1.0],
+        'reduced_observable':  [3.0, 7.5, 15.0],
+    }
+    out = inst.update(state)
+    assert 'html' in out
+    assert 'Plotly.newPlot' in out['html']
+    assert '15' in out['html']
+
+
+from process_bigraph.visualizations import Distribution
+
+
+def test_distribution_histogram():
+    inst = object.__new__(Distribution)
+    inst.config = {'title': 'Hist'}
+    state = {'samples': [10.0, 10.3, 10.6, 10.9, 11.2]}
+    out = inst.update(state)
+    assert 'Plotly.newPlot' in out['html']
+    assert 'histogram' in out['html'].lower()
+
+
+from process_bigraph.visualizations import PhaseSpace
+
+
+def test_phase_space():
+    inst = object.__new__(PhaseSpace)
+    inst.config = {'title': 'XY'}
+    state = {'x': [0.0, 1.0, 2.0, 3.0], 'y': [0.0, 1.0, 4.0, 9.0]}
+    out = inst.update(state)
+    assert 'Plotly.newPlot' in out['html']
+
+
+from process_bigraph.visualizations import Heatmap
+
+
+def test_heatmap():
+    inst = object.__new__(Heatmap)
+    inst.config = {'title': 'Grid'}
+    state = {
+        'x_params': [1.0, 2.0, 3.0],
+        'y_params': [10.0, 20.0],
+        'z_values': [[10.0, 20.0, 30.0], [20.0, 40.0, 60.0]],
+    }
+    out = inst.update(state)
+    assert 'Plotly.newPlot' in out['html']
+    assert 'heatmap' in out['html'].lower()

--- a/process_bigraph/visualization.py
+++ b/process_bigraph/visualization.py
@@ -1,0 +1,393 @@
+"""Visualization Step base class — accumulate during the run, render at the end.
+
+Visualization is a process_bigraph.Step. Subclasses declare typed input ports
+via ``inputs()`` and produce HTML by implementing two hooks:
+
+- ``accumulate(state)``: called each tick (or every Nth tick in 'sample' mode)
+  with the current per-step state. Subclasses mutate their own buffers here.
+- ``render() -> str``: builds the final HTML from the accumulated buffers.
+
+The baseclass ``update(state)`` orchestrates these based on the
+``render_mode`` config:
+
+- ``'end'`` (default): accumulate each tick, return ``{'html': ''}`` from
+  every ``update()`` call. The dashboard / test harness calls
+  :func:`render_results` after the run to materialize the HTML once.
+- ``'stream'``: accumulate AND render every tick. Use when the runtime is
+  short (dashboard's Composite Explorer Run tab) and per-tick HTML is wanted.
+- ``'sample'``: accumulate only every ``sample_every`` ticks, defer rendering
+  to end-of-run (same as ``'end'`` but cheaper accumulation).
+
+Subclasses that need the old per-tick streaming contract can still override
+``update(state)`` directly — the baseclass detects this and skips the
+orchestrator. This keeps every existing Visualization subclass working
+unchanged.
+
+Discovery: Visualization extends Step extends Edge, so subclasses are
+auto-discovered via ``bigraph_schema.package.discover`` and registered in
+``core.link_registry``.
+
+This module also exposes :func:`render_results`, the visualization analogue
+of ``process_bigraph.emitter.gather_emitter_results``: it walks a Composite's
+state for Visualization instances and returns a path-keyed dict of their
+rendered HTML, calling ``render()`` once per viz.
+"""
+from __future__ import annotations
+from typing import Any
+
+from process_bigraph import Step
+
+
+class Visualization(Step):
+    """Base class for renderable Visualization Steps.
+
+    New-style contract:
+      - override ``accumulate(state)`` to buffer per-tick state
+      - override ``render() -> str`` to build the final HTML
+      - leave ``update(state)`` to the baseclass orchestrator
+
+    Legacy contract (still supported):
+      - override ``update(state) -> {'html': str}`` directly; the orchestrator
+        steps aside.
+    """
+
+    config_schema = {
+        'title': {'_type': 'string', '_default': ''},
+        # New-style controls. Ignored when a subclass overrides update().
+        'render_mode':  {'_type': 'string',  '_default': 'end'},
+        'sample_every': {'_type': 'integer', '_default': 1},
+    }
+
+    # Pluggable units resolver: a callable ``path -> unit_str | None``.
+    # Workspaces (e.g. v2ecoli) assign this; left None elsewhere -> no-op.
+    units_resolver = None
+
+    @classmethod
+    def resolve_unit(cls, path):
+        """Resolve the unit for an observable path via the pluggable resolver."""
+        resolver = cls.units_resolver
+        if resolver is None or not path:
+            return None
+        try:
+            return resolver(path) or None
+        except Exception:
+            return None
+
+    @staticmethod
+    def _append_unit(label, unit):
+        """Append ``(unit)`` to a label, idempotently. None unit -> unchanged."""
+        if not unit:
+            return label
+        text = (label or "").rstrip()
+        if text.endswith(f"({unit})"):
+            return text
+        return f"{text} ({unit})".strip()
+
+    @classmethod
+    def finalize_figure(cls, fig, axis_units=()):
+        """Append schema units to matplotlib axis labels in-place.
+
+        ``axis_units`` is an iterable of ``(ax, which, path)`` where ``which`` is
+        ``'x'`` or ``'y'`` and ``path`` is the observable dotted path that axis
+        displays. Axes whose path has no unit are left unchanged. Returns ``fig``.
+        """
+        for ax, which, path in axis_units:
+            unit = cls.resolve_unit(path)
+            if not unit:
+                continue
+            if which == "y" and hasattr(ax, "set_ylabel"):
+                ax.set_ylabel(cls._append_unit(ax.get_ylabel(), unit))
+            elif which == "x" and hasattr(ax, "set_xlabel"):
+                ax.set_xlabel(cls._append_unit(ax.get_xlabel(), unit))
+        return fig
+
+    @classmethod
+    def figure_to_html(cls, fig, axis_units=(), *, dpi=150, close=True):
+        """Finalize axis units, then serialize a matplotlib figure to an <img>.
+
+        One-stop replacement for per-viz ``_fig_to_b64`` + manual <img> wrapping.
+        """
+        import base64
+        import io
+        cls.finalize_figure(fig, axis_units)
+        buf = io.BytesIO()
+        fig.savefig(buf, format="png", dpi=dpi, bbox_inches="tight")
+        buf.seek(0)
+        b64 = base64.b64encode(buf.read()).decode("ascii")
+        if close:
+            try:
+                import matplotlib.pyplot as plt
+                plt.close(fig)
+            except Exception:
+                pass
+        return f'<img src="data:image/png;base64,{b64}" style="max-width:100%"/>'
+
+    def inputs(self) -> dict[str, Any]:
+        """Typed input ports — keys are port names; values are bigraph-schema
+        type strings. Subclasses override.
+        """
+        return {}
+
+    def outputs(self) -> dict[str, Any]:
+        """All visualizations expose a single ``html`` string port."""
+        return {'html': 'string'}
+
+    def accumulate(self, state: dict) -> None:
+        """New-style hook: buffer per-tick state into ``self`` for later render.
+
+        Default implementation snapshots the latest state on ``self._last_state``,
+        which is enough for stateless renderers that only need the most recent
+        frame. Override for genuine history accumulation.
+        """
+        self._last_state = state
+
+    def render(self) -> str:
+        """New-style hook: produce the final HTML from accumulated buffers.
+
+        Subclasses MUST implement this (or override ``update(state)`` directly
+        for the legacy streaming contract).
+        """
+        raise NotImplementedError(
+            f'{type(self).__name__}: implement render() (and optionally '
+            f'accumulate(state)), or override update(state) directly.'
+        )
+
+    def update(self, state: dict) -> dict:
+        """Default orchestrator. Subclasses MAY override directly (legacy).
+
+        New-style subclasses leave this alone; the baseclass calls
+        ``accumulate(state)`` per tick and only emits HTML in
+        ``render_mode='stream'``. End-of-run rendering happens via
+        :func:`render_results`.
+        """
+        cfg = getattr(self, 'config', None) or {}
+        sample_every = max(1, int(cfg.get('sample_every', 1) or 1))
+        tick = getattr(self, '_tick', -1) + 1
+        self._tick = tick
+        if tick % sample_every == 0:
+            self.accumulate(state)
+        mode = cfg.get('render_mode', 'end') or 'end'
+        if mode == 'stream':
+            return {'html': self.render()}
+        return {'html': ''}
+
+    def stable_div_id(self, *parts: str) -> str:
+        """Stable, collision-resistant DOM id for the rendered HTML container.
+
+        Use this instead of ``id(self)`` when building Plotly / Vega div ids
+        (mem3dg-readdy friction #28 — ``id(self)`` happens to be the
+        CPython object address and can collide when two viz instances on the
+        same page get the same address after GC reuses an id slot).
+
+        Hashes the class name plus the config title plus any extra ``parts``
+        the caller passes in (e.g. a per-instance discriminator). Returns
+        an 8-char hex suffix prefixed with the lowercased class name so the
+        id is human-debuggable in devtools::
+
+            <div id="couplingtrace-3f9c1ab8">
+
+        Pure stdlib; safe to call from ``__init__`` or ``render``.
+        """
+        import hashlib
+        cls_name = type(self).__name__.lower()
+        cfg = getattr(self, 'config', None) or {}
+        title = str(cfg.get('title') or '')
+        payload = "|".join([type(self).__name__, title, *parts]).encode("utf-8")
+        digest = hashlib.sha1(payload).hexdigest()[:8]
+        return f"{cls_name}-{digest}"
+
+    @classmethod
+    def is_visualization(cls) -> bool:
+        """Marker for dashboard filtering: distinguishes viz Steps from Emitters."""
+        return True
+
+
+def _is_new_style(instance) -> bool:
+    """True iff the subclass relies on the baseclass orchestrator.
+
+    A subclass is "new-style" when it does NOT override ``update`` itself —
+    i.e. the orchestrator owns the per-tick path and ``render()`` is the
+    single source of HTML.
+    """
+    return type(instance).update is Visualization.update
+
+
+def as_visualization(inputs, name=None, demo=None, aliases=None):
+    """**Deprecated** — prefer subclassing ``Visualization`` directly.
+
+    Decorator: convert an ``update_*`` pure function into a Visualization subclass.
+    The function must be named ``update_<viz_name>`` and accept
+    ``state: dict`` -> ``{'html': str}``.
+
+    Why deprecated (F4 of the framework cleanup):
+
+    - Every shipped Visualization in ``process_bigraph.visualizations.*`` and
+      every Visualization in real workspaces (v2ecoli) uses explicit
+      subclassing. The decorator path is only exercised by tests.
+    - The decorator registers TWO names per class (PascalCase from ``name``
+      AND the snake_case ``update_<x>`` suffix), forcing the workspace lint
+      to grep for both forms when resolving ``local:Foo`` addresses.
+    - Subclassing makes the input/output contract explicit at the class
+      definition site instead of buried in decorator kwargs, which is
+      easier to read and to extend (accumulate/render new-style).
+
+    Migration::
+
+        # before
+        @as_visualization(inputs={'x': 'list[float]'}, name='MyViz')
+        def update_my_viz(state):
+            return {'html': '<x>' + str(state['x']) + '</x>'}
+
+        # after
+        class MyViz(Visualization):
+            def inputs(self):
+                return {'x': 'list[float]'}
+
+            def update(self, state):
+                return {'html': '<x>' + str(state['x']) + '</x>'}
+
+    The decorator continues to work for back-compat — existing call sites
+    don't need to migrate immediately. A DeprecationWarning fires at
+    decoration time so authors see the nudge.
+
+    Args:
+        inputs:  typed input port map (same shape as Visualization.inputs()).
+                 Keys are port names; values are bigraph-schema type strings.
+        name:    class name override (default: derived from function name).
+        demo:    sample state dict (or callable returning one) for dashboard previews.
+        aliases: extra registration aliases for bigraph-schema discovery.
+
+    Returns the synthesized Visualization subclass, ready to be registered by
+    ``bigraph_schema.discover_packages()`` when the enclosing module is walked.
+    """
+    import warnings as _warnings
+    _warnings.warn(
+        "as_visualization is deprecated; subclass Visualization directly. "
+        "See the docstring for a migration example. The decorator continues "
+        "to work but new code should use the subclass form for clarity and "
+        "to avoid the double-name (snake_case + PascalCase) registration "
+        "the decorator emits.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+    def decorator(func):
+        if not func.__name__.startswith("update_"):
+            raise AssertionError(
+                f"as_visualization expects a function named update_<viz_name>; "
+                f"got '{func.__name__}'"
+            )
+        viz_name = name or func.__name__[len("update_"):]
+        _demo = demo
+
+        class FunctionVisualization(Visualization):
+            def inputs(self):
+                return inputs
+
+            def outputs(self):
+                return {'html': 'string'}
+
+            def update(self, state):
+                return func(state)
+
+            @classmethod
+            def demo(cls):
+                if callable(_demo):
+                    return _demo()
+                return dict(_demo or {})
+
+        FunctionVisualization.__name__ = viz_name
+        FunctionVisualization.__qualname__ = viz_name
+        FunctionVisualization.__module__ = func.__module__
+        FunctionVisualization.__doc__ = func.__doc__
+        FunctionVisualization.__pb_kind__ = "visualization"
+        FunctionVisualization.__pb_aliases__ = [viz_name] + list(aliases or [])
+        FunctionVisualization.__pb_wrapped__ = func
+        return FunctionVisualization
+    return decorator
+
+
+def render_results(composite, results=None):
+    """Gather rendered HTML from every Visualization step in ``composite``.
+
+    Returns a dict ``{step_path: {'html': '<rendered>'}}`` mirroring the shape
+    of ``process_bigraph.emitter.gather_emitter_results``.
+
+    Two modes:
+
+    - ``results=None`` — end-of-run rendering. For new-style vizes (subclass
+      did not override ``update``), call ``instance.render()`` once per viz.
+      For legacy vizes, fall back to reading the last value the runtime wrote
+      to the html output port.
+
+    - ``results=<dict>`` — replay mode. For new-style vizes, accumulate the
+      provided state then render. For legacy vizes, call ``instance.update``
+      directly. Useful for re-rendering against a saved SQLiteEmitter dump.
+    """
+    from process_bigraph.composite import find_instance_paths
+
+    viz_paths = find_instance_paths(
+        composite.state,
+        'process_bigraph.visualization.Visualization',
+    )
+    out = {}
+    for path in viz_paths:
+        node = _get_path(composite.state, path)
+        if node is None:
+            continue
+        instance = node.get('instance') if isinstance(node, dict) else None
+        if instance is None:
+            continue
+        new_style = _is_new_style(instance)
+        try:
+            if results is not None:
+                # Replay mode.
+                if new_style:
+                    instance.accumulate(results)
+                    html = instance.render()
+                else:
+                    rendered = instance.update(results) or {}
+                    html = rendered.get('html', '') if isinstance(rendered, dict) else ''
+            else:
+                # End-of-run.
+                if new_style:
+                    html = instance.render()
+                else:
+                    html = _read_last_html(composite, path) or ''
+            rendered = {'html': html}
+        except Exception as e:  # noqa: BLE001
+            rendered = {'html': f'<pre style="color:#c00">render failed: {e}</pre>'}
+        out[path] = rendered
+    return out
+
+
+def _get_path(state, path_tuple):
+    node = state
+    for p in path_tuple:
+        if not isinstance(node, dict) or p not in node:
+            return None
+        node = node[p]
+    return node
+
+
+def _read_last_html(composite, path_tuple):
+    """Best-effort: walk the composite's bigraph for the html output store
+    wired to this visualization, and return its current value (string).
+
+    bigraph wires ``outputs.html`` to a store somewhere in the composite. The
+    Visualization step's node has an ``outputs: {html: <store-path>}`` mapping
+    we can use to look up the value. If the wiring isn't found or the store
+    doesn't hold a string, returns None.
+    """
+    node = _get_path(composite.state, path_tuple)
+    if not isinstance(node, dict):
+        return None
+    outputs = node.get('outputs') or {}
+    html_target = outputs.get('html')
+    if html_target is None:
+        return None
+    if isinstance(html_target, (list, tuple)):
+        value = _get_path(composite.state, tuple(html_target))
+    else:
+        value = None
+    return value if isinstance(value, str) else None

--- a/process_bigraph/visualizations/__init__.py
+++ b/process_bigraph/visualizations/__init__.py
@@ -1,0 +1,30 @@
+"""Default Visualization classes shipped with process-bigraph.
+
+All five inherit ``process_bigraph.visualization.Visualization`` and implement
+``render_final(results, *, config) -> str``. They are auto-discovered via
+``bigraph_schema.package.discover`` so workspaces don't need to register them
+manually.
+
+Usage (from a composite or investigation spec):
+    visualizations:
+      - name: trajectory
+        address: "local:TimeSeriesPlot"
+        config: {observable: free_DnaA, sources: [baseline]}
+"""
+from process_bigraph.visualizations.time_series import TimeSeriesPlot
+from process_bigraph.visualizations.timeseries_from_observables import (
+    TimeSeriesFromObservables,
+)
+from process_bigraph.visualizations.param_vs_observable import ParamVsObservable
+from process_bigraph.visualizations.distribution import Distribution
+from process_bigraph.visualizations.phase_space import PhaseSpace
+from process_bigraph.visualizations.heatmap import Heatmap
+
+__all__ = [
+    "TimeSeriesPlot",
+    "TimeSeriesFromObservables",
+    "ParamVsObservable",
+    "Distribution",
+    "PhaseSpace",
+    "Heatmap",
+]

--- a/process_bigraph/visualizations/distribution.py
+++ b/process_bigraph/visualizations/distribution.py
@@ -1,0 +1,44 @@
+"""Distribution — histogram of a sample list.
+
+Orchestrator collects the samples (e.g., final-step values across N seed
+runs) into a flat list; this Step renders a histogram.
+"""
+from __future__ import annotations
+import html as _html
+import json
+
+from process_bigraph.visualization import Visualization
+
+
+class Distribution(Visualization):
+    """Histogram of an observable's distribution.
+
+    Inputs (declared types):
+      samples: list[float] — the values to bin
+    """
+
+    def inputs(self):
+        return {'samples': 'list[float]'}
+
+    def update(self, state):
+        samples = state.get('samples') or []
+        title = (getattr(self, 'config', None) or {}).get('title', '')
+        traces = [{
+            'x': samples, 'type': 'histogram',
+            'marker': {'color': '#6366f1'},
+            'opacity': 0.85,
+        }]
+        layout = {
+            'title': {'text': _html.escape(title), 'font': {'size': 14}},
+            'yaxis': {'title': {'text': 'count'}},
+            'margin': {'l': 55, 'r': 15, 't': 40, 'b': 40},
+            'showlegend': False,
+            'bargap': 0.05,
+        }
+        return {'html': (
+            '<div id="viz" style="height:380px"></div>'
+            '<script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>'
+            '<script>Plotly.newPlot("viz", '
+            + json.dumps(traces) + ', ' + json.dumps(layout)
+            + ', {responsive:true, displayModeBar:false});</script>'
+        )}

--- a/process_bigraph/visualizations/heatmap.py
+++ b/process_bigraph/visualizations/heatmap.py
@@ -1,0 +1,44 @@
+"""Heatmap — 2D parameter sweep, color = reduced observable."""
+from __future__ import annotations
+import html as _html
+import json
+
+from process_bigraph.visualization import Visualization
+
+
+class Heatmap(Visualization):
+    """Color matrix over a 2D parameter sweep.
+
+    Inputs (declared types):
+      x_params: list[float]
+      y_params: list[float]
+      z_values: list[list[float]]  — z[y_idx][x_idx]
+    """
+
+    def inputs(self):
+        return {
+            'x_params': 'list[float]',
+            'y_params': 'list[float]',
+            'z_values': 'list[list[float]]',
+        }
+
+    def update(self, state):
+        xs = state.get('x_params') or []
+        ys = state.get('y_params') or []
+        zs = state.get('z_values') or []
+        title = (getattr(self, 'config', None) or {}).get('title', '')
+        traces = [{
+            'z': zs, 'x': xs, 'y': ys, 'type': 'heatmap',
+            'colorscale': 'Viridis',
+        }]
+        layout = {
+            'title': {'text': _html.escape(title), 'font': {'size': 14}},
+            'margin': {'l': 55, 'r': 60, 't': 40, 'b': 40},
+        }
+        return {'html': (
+            '<div id="viz" style="height:420px"></div>'
+            '<script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>'
+            '<script>Plotly.newPlot("viz", '
+            + json.dumps(traces) + ', ' + json.dumps(layout)
+            + ', {responsive:true, displayModeBar:false});</script>'
+        )}

--- a/process_bigraph/visualizations/param_vs_observable.py
+++ b/process_bigraph/visualizations/param_vs_observable.py
@@ -1,0 +1,51 @@
+"""ParamVsObservable — sweep parameter value vs reduced observable.
+
+The orchestrator does the reduction (final/mean/max/...) before populating
+the input store; this Step just plots ``y vs x`` as a line+marker chart.
+"""
+from __future__ import annotations
+import html as _html
+import json
+
+from process_bigraph.visualization import Visualization
+
+
+class ParamVsObservable(Visualization):
+    """Plot reduced observable values across a sweep.
+
+    Inputs (declared types):
+      sweep_param_values: list[float] — x-axis (one value per run in the sweep)
+      reduced_observable: list[float] — y-axis (reduced trajectory per run)
+    """
+
+    def inputs(self):
+        return {
+            'sweep_param_values': 'list[float]',
+            'reduced_observable': 'list[float]',
+        }
+
+    def update(self, state):
+        xs = state.get('sweep_param_values') or []
+        ys = state.get('reduced_observable') or []
+        title = (getattr(self, 'config', None) or {}).get('title', '')
+        if xs and ys:
+            pairs = sorted(zip(xs, ys))
+            xs = [p[0] for p in pairs]
+            ys = [p[1] for p in pairs]
+        traces = [{
+            'x': xs, 'y': ys, 'type': 'scatter', 'mode': 'lines+markers',
+            'line': {'color': '#6366f1', 'width': 2},
+            'marker': {'color': '#6366f1', 'size': 8},
+        }]
+        layout = {
+            'title': {'text': _html.escape(title), 'font': {'size': 14}},
+            'margin': {'l': 55, 'r': 15, 't': 40, 'b': 40},
+            'showlegend': False,
+        }
+        return {'html': (
+            '<div id="viz" style="height:380px"></div>'
+            '<script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>'
+            '<script>Plotly.newPlot("viz", '
+            + json.dumps(traces) + ', ' + json.dumps(layout)
+            + ', {responsive:true, displayModeBar:false});</script>'
+        )}

--- a/process_bigraph/visualizations/phase_space.py
+++ b/process_bigraph/visualizations/phase_space.py
@@ -1,0 +1,40 @@
+"""PhaseSpace — two observables plotted against each other."""
+from __future__ import annotations
+import html as _html
+import json
+
+from process_bigraph.visualization import Visualization
+
+
+class PhaseSpace(Visualization):
+    """XY trajectory of two observables.
+
+    Inputs (declared types):
+      x: list[float]
+      y: list[float]
+    """
+
+    def inputs(self):
+        return {'x': 'list[float]', 'y': 'list[float]'}
+
+    def update(self, state):
+        xs = state.get('x') or []
+        ys = state.get('y') or []
+        title = (getattr(self, 'config', None) or {}).get('title', '')
+        traces = [{
+            'x': xs, 'y': ys, 'type': 'scatter', 'mode': 'lines+markers',
+            'line': {'color': '#6366f1', 'width': 2},
+            'marker': {'size': 5},
+        }]
+        layout = {
+            'title': {'text': _html.escape(title), 'font': {'size': 14}},
+            'margin': {'l': 55, 'r': 15, 't': 40, 'b': 40},
+            'showlegend': False,
+        }
+        return {'html': (
+            '<div id="viz" style="height:380px"></div>'
+            '<script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>'
+            '<script>Plotly.newPlot("viz", '
+            + json.dumps(traces) + ', ' + json.dumps(layout)
+            + ', {responsive:true, displayModeBar:false});</script>'
+        )}

--- a/process_bigraph/visualizations/time_series.py
+++ b/process_bigraph/visualizations/time_series.py
@@ -1,0 +1,91 @@
+"""TimeSeriesPlot — observable(s) vs time, one line per run."""
+from __future__ import annotations
+import html as _html
+import json
+
+from process_bigraph.visualization import Visualization
+
+
+_PALETTE = ['#6366f1', '#10b981', '#f43f5e', '#f59e0b',
+            '#8b5cf6', '#06b6d4', '#84cc16', '#ec4899']
+
+
+class TimeSeriesPlot(Visualization):
+    """Plot one or more observables vs time.
+
+    Inputs (declared types):
+      observable: list[float]   — trajectory values, or list-of-lists for multi-run
+      time:       list[float]   — same shape as observable
+    """
+
+    def inputs(self):
+        return {'observable': 'list[float]', 'time': 'list[float]'}
+
+    def update(self, state):
+        obs = state.get('observable')
+        ts = state.get('time')
+        if obs is None or ts is None:
+            return {'html': '<p style="color:#991b1b">missing observable or time input</p>'}
+
+        if obs and isinstance(obs[0], list):
+            runs = list(zip(ts, obs))
+        else:
+            runs = [(ts, obs)]
+        labels = state.get('_run_labels') or [''] * len(runs)
+        overlays = state.get('_overlays') or []
+
+        traces = []
+        for i, (xs, ys) in enumerate(runs):
+            traces.append({
+                'x': xs, 'y': ys, 'type': 'scatter', 'mode': 'lines',
+                'name': labels[i] if i < len(labels) else f'run {i}',
+                'line': {'color': _PALETTE[i % len(_PALETTE)], 'width': 2},
+            })
+
+        shapes = []
+        annotations = []
+        for ov in overlays:
+            kind = ov.get('kind')
+            if kind == 'reference-range':
+                y_min, y_max = ov.get('y_min'), ov.get('y_max')
+                if y_min is not None and y_max is not None:
+                    shapes.append({
+                        'type': 'rect', 'xref': 'paper', 'yref': 'y',
+                        'x0': 0, 'x1': 1, 'y0': y_min, 'y1': y_max,
+                        'fillcolor': '#fef3c7', 'opacity': 0.3,
+                        'line': {'width': 0},
+                    })
+                    annotations.append({
+                        'xref': 'paper', 'yref': 'y',
+                        'x': 0.02, 'y': y_max,
+                        'text': _html.escape(ov.get('label', 'reference range')),
+                        'showarrow': False,
+                        'font': {'size': 11, 'color': '#92400e'},
+                    })
+            elif kind == 'experimental-points':
+                pts = ov.get('points') or []
+                if pts:
+                    traces.append({
+                        'x': [p['x'] for p in pts],
+                        'y': [p['y'] for p in pts],
+                        'type': 'scatter', 'mode': 'markers',
+                        'name': ov.get('label', 'experimental'),
+                        'marker': {'color': '#000', 'size': 8, 'symbol': 'circle-open'},
+                    })
+
+        title = (getattr(self, 'config', None) or {}).get('title', '')
+        layout = {
+            'title': {'text': _html.escape(title), 'font': {'size': 14}},
+            'xaxis': {'title': {'text': 'time'}},
+            'margin': {'l': 55, 'r': 15, 't': 40, 'b': 40},
+            'legend': {'orientation': 'h', 'y': -0.2},
+            'shapes': shapes,
+            'annotations': annotations,
+        }
+        return {'html': (
+            '<div id="viz" style="height:380px"></div>'
+            '<script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>'
+            '<script>Plotly.newPlot("viz", '
+            + json.dumps(traces) + ', ' + json.dumps(layout)
+            + ', {responsive:true, displayModeBar:false});</script>'
+        )}

--- a/process_bigraph/visualizations/timeseries_from_observables.py
+++ b/process_bigraph/visualizations/timeseries_from_observables.py
@@ -43,8 +43,6 @@ import json
 import sqlite3
 from pathlib import Path
 
-import yaml
-
 from process_bigraph.visualization import Visualization
 
 
@@ -123,6 +121,10 @@ def _load_study_observable_meta(study_yaml_path: str | None) -> dict[str, dict]:
     p = Path(study_yaml_path)
     if not p.is_file():
         return {}
+    # PyYAML is not a hard process-bigraph dependency (same convention as
+    # composite_spec.py); import lazily so importing this module never
+    # requires it unless a caller actually supplies a study_yaml_path.
+    import yaml
     try:
         # study.yaml is UTF-8 (often non-ASCII prose); decode explicitly so a
         # bare-CLI render under an ASCII locale doesn't crash on read.

--- a/process_bigraph/visualizations/timeseries_from_observables.py
+++ b/process_bigraph/visualizations/timeseries_from_observables.py
@@ -1,0 +1,347 @@
+"""TimeSeriesFromObservables — self-contained multi-observable time-series.
+
+Backs Finding #26 in the v2ecoli investigation walkthrough notes:
+
+  > Critical missing piece: a generic ``TimeSeriesFromObservables``
+  > Visualization Step that consumes any list of observable specs +
+  > a runs.db and produces a time-series plot. Without this, studies
+  > that declare ``address: local:TimeSeriesPlot`` have no backing
+  > code and can't be previewed.
+
+The existing :class:`TimeSeriesPlot` is the right *renderer*, but its
+``observable: list[float]`` / ``time: list[float]`` inputs need to be
+plumbed in by an upstream Step. The dashboard's ``build_viz_composite``
+handles that plumbing for *single*-observable cases via an
+``inputs_map`` convention, but most study visualizations want to plot
+several observables together with shared time + per-run colors — and
+the wiring boilerplate has to be written per study, which the field
+notes flagged as the main reason "Visualizations tab is empty" was
+the default state.
+
+This class fixes it by being **self-contained**:
+
+  - Its only required config is ``observables: list[str]`` — the names
+    of observables (matching ``study.yaml.observables[].name``) to plot.
+  - The dashboard's renderer injects ``_runs_db_path`` and
+    ``_study_yaml_path`` (the two private config keys this class
+    reads) when it builds the composite. Both are optional; the class
+    degrades gracefully when either is missing.
+  - The class reads runs.db itself (stdlib sqlite3 — no extra deps)
+    and renders one Plotly trace per (observable × run) pair with
+    units pulled from ``study.yaml.observables[].units`` when present.
+
+The result is a single Viz address (``local:TimeSeriesFromObservables``)
+that lights up most studies' declared visualizations without any
+per-study code. The note recommends shipping this in the framework so
+every workspace gets it; that's why this lives in
+``process_bigraph.visualizations`` alongside the other defaults.
+"""
+from __future__ import annotations
+
+import html as _html
+import json
+import sqlite3
+from pathlib import Path
+
+import yaml
+
+from process_bigraph.visualization import Visualization
+
+
+_PALETTE = [
+    "#6366f1", "#10b981", "#f43f5e", "#f59e0b",
+    "#8b5cf6", "#06b6d4", "#84cc16", "#ec4899",
+    "#14b8a6", "#dc2626", "#3b82f6", "#a855f7",
+]
+
+
+class TimeSeriesFromObservables(Visualization):
+    """Multi-observable time series, self-contained.
+
+    Config keys (user-set in ``study.yaml.visualizations[].config``):
+
+      - ``observables: list[str]`` (required) — observable names to plot.
+        Matched against ``study.yaml.observables[].name`` for units
+        + against the ``observables`` map in runs.db ``history.state``
+        for data.
+      - ``title: str`` (optional) — chart title. Defaults to ``""``.
+      - ``sources: list[str]`` (optional) — restrict to runs whose
+        ``sim_name`` is in this list. Default: all runs.
+
+    Config keys injected by the renderer (private; users don't set
+    these):
+
+      - ``_runs_db_path: str`` — absolute path to the study's runs.db.
+        When absent, the chart renders an empty-data placeholder.
+      - ``_study_yaml_path: str`` — absolute path to study.yaml. Used
+        to look up per-observable ``units``. When absent, units are
+        omitted from axis labels.
+
+    Inputs: none (the class plumbs its own data). The renderer's
+    ``build_viz_composite`` skips inputs_map plumbing when a viz class
+    declares no inputs.
+    """
+
+    config_schema = {
+        # Inherits title, render_mode, sample_every from Visualization.
+        **Visualization.config_schema,
+        "observables": {"_type": "list[string]", "_default": []},
+        "sources": {"_type": "list[string]", "_default": []},
+        # Private — injected by the dashboard renderer; the schema
+        # accepts string so YAML stays clean.
+        "runs_db_path": {"_type": "string", "_default": ""},
+        "run_id": {"_type": "string", "_default": ""},
+        "study_yaml_path": {"_type": "string", "_default": ""},
+    }
+
+    def inputs(self) -> dict:
+        # Self-contained: no bigraph inputs. The renderer detects this
+        # and skips inputs_map plumbing.
+        return {}
+
+    # The class is rendered in one shot (legacy contract). Override
+    # update() directly so the baseclass orchestrator stays out of the
+    # way — we don't accumulate per-tick state; runs.db already has it.
+    def update(self, state: dict) -> dict:
+        cfg = dict(getattr(self, "config", None) or {})
+        return {"html": _render_html(cfg)}
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers (no Visualization runtime — easy to unit-test)
+# ---------------------------------------------------------------------------
+
+
+def _load_study_observable_meta(study_yaml_path: str | None) -> dict[str, dict]:
+    """Return ``{observable_name: {units, description, store_path}}``.
+
+    Tolerant of missing file, malformed YAML, or absent ``observables``
+    block — returns an empty dict in any of those cases.
+    """
+    if not study_yaml_path:
+        return {}
+    p = Path(study_yaml_path)
+    if not p.is_file():
+        return {}
+    try:
+        # study.yaml is UTF-8 (often non-ASCII prose); decode explicitly so a
+        # bare-CLI render under an ASCII locale doesn't crash on read.
+        spec = yaml.safe_load(p.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError:
+        return {}
+    out: dict[str, dict] = {}
+    for o in (spec.get("observables") or []):
+        if isinstance(o, dict) and isinstance(o.get("name"), str):
+            out[o["name"]] = {
+                "units": o.get("units") or "",
+                "description": o.get("description") or "",
+                "store_path": o.get("store_path") or "",
+            }
+    return out
+
+
+def _load_runs(runs_db_path: str | None, sources: list[str], run_id: str = "") -> list[dict]:
+    """Read runs.db and return a list of ``{run_id, sim_name, params,
+    observables, time}`` dicts.
+
+    ``observables`` is ``{name: list[number]}`` keyed by the names the
+    emitter wrote (typically the observable name as declared in
+    ``study.yaml``). ``time`` is the trajectory's time axis.
+
+    Returns ``[]`` if the db file is missing, malformed, or empty.
+    Restricts to runs in ``sources`` when provided (matching
+    ``runs_meta.sim_name``).
+    """
+    if not runs_db_path:
+        return []
+    p = Path(runs_db_path)
+    if not p.is_file():
+        return []
+
+    sources_set = set(sources or [])
+
+    try:
+        conn = sqlite3.connect(str(p))
+    except sqlite3.Error:
+        return []
+    conn.row_factory = sqlite3.Row
+    try:
+        try:
+            meta_rows = conn.execute(
+                "SELECT run_id, sim_name, params_json FROM runs_meta"
+            ).fetchall()
+        except sqlite3.OperationalError:
+            return []
+
+        has_history = conn.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='table' AND name='history'"
+        ).fetchone() is not None
+        if not has_history:
+            return []
+
+        out: list[dict] = []
+        for r in meta_rows:
+            if run_id and r["run_id"] != run_id:
+                continue
+            sim_name = r["sim_name"] or "default"
+            if sources_set and sim_name not in sources_set:
+                continue
+            try:
+                params = json.loads(r["params_json"] or "{}")
+            except (json.JSONDecodeError, TypeError):
+                params = {}
+            history_rows = conn.execute(
+                "SELECT step, global_time, state FROM history "
+                "WHERE simulation_id=? ORDER BY step ASC",
+                (r["run_id"],),
+            ).fetchall()
+            observables: dict[str, list] = {}
+            time_axis: list[float] = []
+            for hrow in history_rows:
+                try:
+                    s = json.loads(hrow["state"]) if hrow["state"] else {}
+                except (json.JSONDecodeError, TypeError):
+                    continue
+                for k, v in s.items():
+                    observables.setdefault(k, []).append(v)
+                if "time" in s:
+                    # Already captured under observables["time"]; mirror
+                    # to the dedicated axis for convenience.
+                    time_axis.append(s["time"])
+                else:
+                    time_axis.append(hrow["global_time"])
+            out.append({
+                "run_id": r["run_id"],
+                "sim_name": sim_name,
+                "params": params,
+                "observables": observables,
+                "time": time_axis,
+            })
+        return out
+    finally:
+        conn.close()
+
+
+def _label_for_run(run: dict, index: int) -> str:
+    """Compact label for a run, preferring params; falling back to
+    sim_name; finally the last 6 chars of run_id."""
+    params = run.get("params") or {}
+    if params:
+        return ", ".join(f"{k}={v}" for k, v in sorted(params.items()))
+    sim_name = run.get("sim_name") or ""
+    if sim_name and sim_name != "default":
+        return sim_name
+    rid = run.get("run_id") or f"run-{index}"
+    return rid[-6:]
+
+
+def _build_traces(
+    runs: list[dict],
+    observable_names: list[str],
+) -> list[dict]:
+    """Build Plotly traces — one line per (observable × run) pair.
+
+    Lines are colored by observable; runs of the same observable share
+    a color but get distinct dash patterns when there are multiple
+    runs, so an expert can tell apart calibration sweeps at a glance.
+    """
+    traces: list[dict] = []
+    dash_patterns = ["solid", "dash", "dot", "dashdot", "longdash"]
+    for obs_idx, name in enumerate(observable_names):
+        color = _PALETTE[obs_idx % len(_PALETTE)]
+        runs_with_obs = [
+            (i, r) for i, r in enumerate(runs)
+            if name in (r.get("observables") or {})
+        ]
+        for trace_idx, (run_idx, run) in enumerate(runs_with_obs):
+            y = run["observables"][name]
+            x = run.get("time") or list(range(len(y)))
+            dash = dash_patterns[trace_idx % len(dash_patterns)] \
+                if len(runs_with_obs) > 1 else "solid"
+            label = name
+            if len(runs_with_obs) > 1:
+                label = f"{name} — {_label_for_run(run, run_idx)}"
+            traces.append({
+                "x": x, "y": y, "type": "scatter", "mode": "lines",
+                "name": label,
+                "line": {"color": color, "width": 2, "dash": dash},
+            })
+    return traces
+
+
+def _y_axis_label(meta: dict[str, dict], names: list[str]) -> str:
+    """Compose a Y axis label from the requested observables.
+
+    - Single observable, units known: ``"<name> (<units>)"``.
+    - Multiple observables, all sharing a unit: ``"<units>"``.
+    - Multiple observables, mixed units: ``"value"`` (no label).
+    - No units known: ``""``.
+    """
+    units = [meta.get(n, {}).get("units") or "" for n in names]
+    units_set = {u for u in units if u}
+    if len(names) == 1:
+        if units[0]:
+            return f"{names[0]} ({units[0]})"
+        return names[0]
+    if len(units_set) == 1:
+        return next(iter(units_set))
+    return "value" if any(units) else ""
+
+
+def _render_html(cfg: dict) -> str:
+    """Pure renderer: build the Plotly HTML from a viz config dict.
+
+    Exposed as a free function so tests can drive it without
+    constructing a Visualization instance.
+    """
+    observable_names = list(cfg.get("observables") or [])
+    if not observable_names:
+        return (
+            '<div style="padding:12px;color:#991b1b">'
+            'TimeSeriesFromObservables: no observables declared in config. '
+            'Set <code>observables: [name1, name2]</code> in the viz config.'
+            '</div>'
+        )
+
+    runs = _load_runs(cfg.get("runs_db_path") or cfg.get("_runs_db_path"), cfg.get("sources") or [], cfg.get("run_id") or "")
+    meta = _load_study_observable_meta(cfg.get("study_yaml_path") or cfg.get("_study_yaml_path"))
+
+    if not runs:
+        return (
+            '<div style="padding:12px;color:#92400e;background:#fef3c7;'
+            'border:1px solid #fcd34d;border-radius:4px">'
+            '<strong>No run data yet.</strong><br>'
+            'Run a baseline (or wait for a Simulate-phase run to complete) '
+            'and re-render. The viz config is valid; the data side just '
+            'isn\'t populated.'
+            '</div>'
+        )
+
+    traces = _build_traces(runs, observable_names)
+    if not traces:
+        return (
+            '<div style="padding:12px;color:#991b1b">'
+            'None of the declared observables '
+            f'({", ".join(observable_names)}) were found in any run\'s '
+            'emitted state. Check that the run\'s emitter is configured '
+            'to record these names.'
+            '</div>'
+        )
+
+    title = cfg.get("title") or ""
+    y_label = _y_axis_label(meta, observable_names)
+    layout = {
+        "title": {"text": _html.escape(title), "font": {"size": 14}},
+        "xaxis": {"title": {"text": "time"}},
+        "yaxis": {"title": {"text": _html.escape(y_label)}},
+        "margin": {"l": 60, "r": 15, "t": 40, "b": 50},
+        "legend": {"orientation": "h", "y": -0.2},
+    }
+    return (
+        '<div id="viz" style="height:380px"></div>'
+        '<script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>'
+        '<script>Plotly.newPlot("viz", '
+        + json.dumps(traces) + ", " + json.dumps(layout)
+        + ", {responsive:true, displayModeBar:false});</script>"
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "process-bigraph"
-version = "1.7.1"
+version = "1.8.0"
 description = "protocol and execution for compositional systems biology"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
**Phase 1** of the viva-superpowers 3-home re-architecture: the framework **substrate** moves from the `viva_superpowers` plugin package into the `process_bigraph` engine, where it belongs. `viva_superpowers` will keep re-export shims (follow-up PR) so the ~1,829 downstream importers and the workbench keep working unchanged.

## Moved (verbatim + import repoints `viva_superpowers.X`→`process_bigraph.X`)
- `core_introspection`, `composite_generator`, `composite_discovery`, `config_helpers`, `visualization`, `visualizations/`
- Public API added to `process_bigraph/__init__.py`; `composite_spec` was already here.

## Two integration fixes (not pure moves — found by exercising the code)
1. `render_results()` had a hardcoded class-path string `viva_superpowers.visualization.Visualization` → repointed to `process_bigraph.visualization.Visualization` (else viz silently returns `{}` post-move). Regression-tested.
2. `discover_generators()`'s package-walk self-discovered process-bigraph's own **in-package** test suite (`process_bigraph/tests/`) and imported it as a side effect — a full-suite-only flake. Fixed with an exact-segment pre-descent filter (`scripts`/`tests`) + a scoped `conftest.py` collect-ignore; 2 regression tests prove the skip happens *before* import and isn't over-broad (workspace composites still discovered).

## Verification
- `uv run pytest -q` → **344 passed, 7 skipped** (baseline 243+7), deterministic across 3 runs.
- `grep -rn "viva_superpowers" process_bigraph/` → clean.
- Independent review: spec ✅, quality Approved; every moved file byte-identical to a naive find/replace except the two disclosed fixes.

## Known follow-up (deferred)
The `_SKIP_SEGMENTS` filter is PBG-local; a downstream workspace that colocates `pkg/tests/` inside its composite package could hit the same self-walk risk — tracked for the shim/follow-up phase.

Out of scope here: the viva-superpowers shims + the `spec_generators` entry-point change (next PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)