### PR TITLE
fix(build): ship process_bigraph.visualizations in the wheel (1.8.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "process-bigraph"
-version = "1.8.0"
+version = "1.8.1"
 description = "protocol and execution for compositional systems biology"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -93,4 +93,5 @@ packages = [
     "process_bigraph.server",
     "process_bigraph.experiments",
     "process_bigraph.types",
+    "process_bigraph.visualizations",
 ]


### PR DESCRIPTION
1.8.0's wheel omitted the `visualizations/` subpackage — setuptools uses an explicit `packages` list and it wasn't added (source/editable installs masked it; `import process_bigraph.visualizations` fails from PyPI). Adds the entry + bumps 1.8.1. Verified: built wheel now contains `process_bigraph/visualizations/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)