### PR TITLE
fix: composite_generator submodule shadow in __init__ (1.8.2)

### DIFF
--- a/process_bigraph/__init__.py
+++ b/process_bigraph/__init__.py
@@ -27,8 +27,12 @@ from process_bigraph.bundle import load_bundle  # noqa: F401
 from process_bigraph.emitter import Emitter, gather_emitter_results, generate_emitter_state  # noqa: F401
 from process_bigraph.types import StepLink, ProcessLink, CompositeLink  # noqa: F401
 from process_bigraph import core_introspection  # noqa: F401
+# NOTE: do NOT re-export the `composite_generator` decorator here — that name
+# is the submodule `process_bigraph.composite_generator`, and exporting the
+# same-named function shadows it (breaks `import process_bigraph.composite_generator`).
+# Get the decorator via `from process_bigraph.composite_generator import composite_generator`.
 from process_bigraph.composite_generator import (  # noqa: F401
-    composite_generator, discover_generators, build_generator,
+    discover_generators, build_generator,
     install_default_emitters, emitter_defaults,
 )
 from process_bigraph.composite_discovery import discover_all  # noqa: F401

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "process-bigraph"
-version = "1.8.1"
+version = "1.8.2"
 description = "protocol and execution for compositional systems biology"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Follow-up to #179. Its `__init__.py` re-exported the `@composite_generator` decorator at top level, shadowing the `process_bigraph.composite_generator` **submodule** — so `import process_bigraph.composite_generator as p; p.discover_generators` raised AttributeError. Drop the top-level decorator export (reachable via `from process_bigraph.composite_generator import composite_generator`). Consumer `from … import` forms were unaffected. 344 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)